### PR TITLE
Fix several issues with the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm -Iinclude -Isrc -Wab,-r4300_mu
 
 # ROM image
 MM_BASEROM ?= baserom.z64
-ROM_NAME := rom
-ROM := $(ROM_NAME).z64
-UNCOMPRESSED_ROM := $(ROM_NAME)_uncompressed.z64
-ELF := $(ROM_NAME).elf
+MM_ROM_NAME ?= rom
+ROM := $(MM_ROM_NAME).z64
+UNCOMPRESSED_ROM := $(MM_ROM_NAME)_uncompressed.z64
+ELF := $(MM_ROM_NAME).elf
 
 BASEROM_FILES := $(wildcard baserom/*)
 # Exclude dmadata, it will be generated right before packing the rom

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm -Iinclude -Isrc -Wab,-r4300_mu
 #### Files ####
 
 # ROM image
+MM_BASEROM ?= baserom.z64
 ROM_NAME := rom
 ROM := $(ROM_NAME).z64
 UNCOMPRESSED_ROM := $(ROM_NAME)_uncompressed.z64
@@ -104,7 +105,9 @@ CC := ./tools/preprocess.py $(CC) -- $(AS) $(ASFLAGS) --
 # disasm is not a file so we must tell make not to check it when evaluating timestamps
 .INTERMEDIATE: disasm
 
-all: $(ROM) $(UNCOMPRESSED_ROM)
+all:
+	make $(UNCOMPRESSED_ROM)
+	make $(ROM)
 
 $(ROM): $(ROM_FILES)
 	./tools/makerom.py ./tables/dmadata_table.txt $@ -c
@@ -159,6 +162,7 @@ setup:
 	git submodule update --init --recursive
 	python3 -m pip install -r requirements.txt
 	make -C tools
+	./tools/extract_rom.py $(MM_BASEROM)
 
 diff-init: all
 	rm -rf expected/
@@ -167,7 +171,10 @@ diff-init: all
 	cp $(UNCOMPRESSED_ROM) expected/$(UNCOMPRESSED_ROM)
 	cp $(ROM) expected/$(ROM)
 
-init: setup all diff-init
+init:
+	make setup
+	make all
+	make diff-init
 
 # Recipes
 


### PR DESCRIPTION
Changes:
- init now explicitly calls make on each target. This allows it to work with -j.
- setup now calls extract_rom.py, simplifying the setup process. Since extract_rom expects a path to the rom to extract, I gave a default which matches other decomp projects, with the option to override if desired.
- all now explicitly builds the uncompressed rom, then the compressed one. This fixes a problem when using -j where the compressed rom could finish building first, then fail and stop the uncompressed rom from finishing. Since the uncompressed rom was never built, you could not use first_diff.py to see what was wrong. This makes it slightly slower, but only by a few seconds in most cases.