### PR TITLE
GlobalContext: unwrap CameraContext

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -1480,7 +1480,7 @@ struct Camera {
     /* 0x168 */ UNK_TYPE1 pad168[0x10];
 }; // size = 0x178
 
-struct CameraContext {
+struct CameraContext { //Unused: leaving this here as reference for unk5F2.
     /* 0x000 */ Camera activeCameras[4];
     /* 0x5E0 */ Camera* activeCameraPtrs[4];
     /* 0x5F0 */ s16 activeCamera;
@@ -1599,7 +1599,10 @@ struct GlobalContext {
     /* 0x000B0 */ SceneCmd* currentSceneVram;
     /* 0x000B4 */ UNK_TYPE1 padB4[0x4];
     /* 0x000B8 */ View view;
-    /* 0x00220 */ CameraContext cameraCtx;
+    /* 0x00220 */ Camera activeCameras[4];
+    /* 0x00800 */ Camera* cameraPtrs[4];
+    /* 0x00810 */ s16 activeCamera;
+    /* 0x00812 */ s16 unk5F2; //TODO: Name this, was part of CameraContext.
     /* 0x00814 */ u8 unk814;
     /* 0x00815 */ u8 unk815;
     /* 0x00816 */ UNK_TYPE1 pad816[0x2];

--- a/include/z64.h
+++ b/include/z64.h
@@ -1025,8 +1025,6 @@ typedef struct {
     /* 0x22 */ u8 flag;
 } Arena; // size = 0x24
 
-typedef struct CameraContext CameraContext;
-
 typedef struct ActorEnBom ActorEnBom;
 
 typedef struct ActorEnFirefly ActorEnFirefly;
@@ -1480,13 +1478,6 @@ struct Camera {
     /* 0x168 */ UNK_TYPE1 pad168[0x10];
 }; // size = 0x178
 
-struct CameraContext { //Unused: leaving this here as reference for unk5F2.
-    /* 0x000 */ Camera activeCameras[4];
-    /* 0x5E0 */ Camera* activeCameraPtrs[4];
-    /* 0x5F0 */ s16 activeCamera;
-    /* 0x5F2 */ s16 unk5F2;
-}; // size = 0x5F4
-
 typedef struct {
     /* 0x00 */ z_Matrix displayMatrix;
     /* 0x40 */ Actor* actor;
@@ -1602,7 +1593,7 @@ struct GlobalContext {
     /* 0x00220 */ Camera activeCameras[4];
     /* 0x00800 */ Camera* cameraPtrs[4];
     /* 0x00810 */ s16 activeCamera;
-    /* 0x00812 */ s16 unk5F2; //TODO: Name this, was part of CameraContext.
+    /* 0x00812 */ s16 unk812;
     /* 0x00814 */ u8 unk814;
     /* 0x00815 */ u8 unk815;
     /* 0x00816 */ UNK_TYPE1 pad816[0x2];

--- a/src/code/z_snap.c
+++ b/src/code/z_snap.c
@@ -105,7 +105,7 @@ s16 func_8013A504(s16 val) {
     return (val >= 0) ? val : -val;
 }
 
-s32 func_8013A530(GlobalContext* ctxt, Actor* actor, s32 flag, Vec3f* pos, Vec3s* rot, f32 distanceMin, f32 distanceMax, s16 angleError) {
+s32 func_8013A530(GlobalContext* globalCtx, Actor* actor, s32 flag, Vec3f* pos, Vec3s* rot, f32 distanceMin, f32 distanceMax, s16 angleError) {
     Vec3f screenSpace;
     s16 x;
     s16 y;
@@ -116,7 +116,7 @@ s32 func_8013A530(GlobalContext* ctxt, Actor* actor, s32 flag, Vec3f* pos, Vec3s
     s32 ret = 0;
     UNK_TYPE unk2;
 
-    camera = ctxt->cameraCtx.activeCameraPtrs[ctxt->cameraCtx.activeCamera];
+    camera = ACTIVE_CAM;
 
     distance = CamMath_Distance(pos, &camera->eye);
     if ((distance < distanceMin) || (distanceMax < distance)) {
@@ -131,7 +131,7 @@ s32 func_8013A530(GlobalContext* ctxt, Actor* actor, s32 flag, Vec3f* pos, Vec3s
         ret |= 0x3e;
     }
 
-    func_800B4EDC(ctxt, pos, &screenSpace, &distance);
+    func_800B4EDC(globalCtx, pos, &screenSpace, &distance);
     x = (s16)(screenSpace.x * distance * 160.0f + 160.0f) - 85;
     y = (s16)(screenSpace.y * distance * -120.0f + 120.0f) - 67;
     if ((x < 0) || (0x96 < x) || (y < 0) || (0x69 < y)) {
@@ -139,14 +139,14 @@ s32 func_8013A530(GlobalContext* ctxt, Actor* actor, s32 flag, Vec3f* pos, Vec3s
         ret |= 0x3d;
     }
 
-    if (func_800C576C(&ctxt->colCtx, pos, &camera->eye, &screenSpace, &unk1, 1, 1, 1, 1, &unk2) != 0) {
+    if (func_800C576C(&globalCtx->colCtx, pos, &camera->eye, &screenSpace, &unk1, 1, 1, 1, 1, &unk2) != 0) {
         func_8013A41C(0x3c);
         ret |= 0x3c;
     }
 
     actors[0] = actor;
-    actors[1] = ctxt->actorCtx.actorList[2].first; // TODO PLAYER macro
-    if (func_800E7DCC(ctxt, &ctxt->colCheckCtx, pos, &camera->eye, actors, 2) != 0) {
+    actors[1] = globalCtx->actorCtx.actorList[2].first; // TODO PLAYER macro
+    if (func_800E7DCC(globalCtx, &globalCtx->colCheckCtx, pos, &camera->eye, actors, 2) != 0) {
         func_8013A41C(0x3b);
         ret |= 0x3b;
     }


### PR DESCRIPTION
Makes ACTIVE_CAM macro usable.
func_8013A530 in src/code/z_snap.c changes to use new GlobalContext struct.