### PR TITLE
Fix ordering of relocations in overlay

### DIFF
--- a/tools/overlay.py
+++ b/tools/overlay.py
@@ -28,8 +28,9 @@ if __name__ == '__main__':
         out.write('.section .ovl\n');
 
         relocs = []
-        for section in elffile.iter_sections():
-            if isinstance(section, RelocationSection):
+        for section_name in ['.rel.text', '.rel.data', '.rel.rodata']:
+            section = elffile.get_section_by_name(section_name)
+            if section is not None:
                 symtab = elffile.get_section(section['sh_link'])
                 for reloc in section.iter_relocations():
                     symbol = symtab.get_symbol(reloc['r_info_sym'])


### PR DESCRIPTION
Fixing an issue that has been on my TODO list for awhile. Relocations are always in the order of .text, .data, then .rodata. Sometimes objects don't order the relocation sections that way, which causes our script to produce non-matching overlays. Fix it by just iterating over those sections in the expected order.