### PR TITLE
Update actor symbols

### DIFF
--- a/tools/overlayhelpers/actor_symbols.py
+++ b/tools/overlayhelpers/actor_symbols.py
@@ -710,7 +710,7 @@ def null_or_ptr(w):
 # (name, vrom_st, vrom_end, vram_st, vram_end)
 def read_actor_ovl_tbl():
     actortbl = []
-    with open(repo + "decomp/code","rb") as codefile:
+    with open(repo + "build/baserom/code","rb") as codefile:
         codefile.seek(0x109510) # actor overlay table offset into code
         entry = as_word_list(codefile.read(0x20))
         i = 0
@@ -730,10 +730,10 @@ def resolve_symbol(address):
     for entry in actor_tbl:
         if address >= 0x80000000:
             if entry[3] <= address < entry[4]:
-                return repo + "decomp" + os.sep + entry[0], address - entry[3]
+                return repo + "build/baserom/overlays" + os.sep + entry[0], address - entry[3]
         else:
             if entry[1] <= address < entry[2]:
-                return repo + "decomp" + os.sep + entry[0], address - entry[1]
+                return repo + "build/baserom/overlays" + os.sep + entry[0], address - entry[1]
     else:
         return None, None
 

--- a/tools/overlayhelpers/actor_symbols.py
+++ b/tools/overlayhelpers/actor_symbols.py
@@ -710,7 +710,7 @@ def null_or_ptr(w):
 # (name, vrom_st, vrom_end, vram_st, vram_end)
 def read_actor_ovl_tbl():
     actortbl = []
-    with open(repo + "build/baserom/code","rb") as codefile:
+    with open(repo + "baserom/code","rb") as codefile:
         codefile.seek(0x109510) # actor overlay table offset into code
         entry = as_word_list(codefile.read(0x20))
         i = 0
@@ -730,10 +730,10 @@ def resolve_symbol(address):
     for entry in actor_tbl:
         if address >= 0x80000000:
             if entry[3] <= address < entry[4]:
-                return repo + "build/baserom/overlays" + os.sep + entry[0], address - entry[3]
+                return repo + "baserom/overlays" + os.sep + entry[0], address - entry[3]
         else:
             if entry[1] <= address < entry[2]:
-                return repo + "build/baserom/overlays" + os.sep + entry[0], address - entry[1]
+                return repo + "baserom/overlays" + os.sep + entry[0], address - entry[1]
     else:
         return None, None
 


### PR DESCRIPTION
The `decomp/` directory is no longer generated as of this recent PR  https://github.com/zeldaret/mm/pull/117. This breaks the `tools/overlayhelper` scripts via the actor_symbols.py, so a quick fix is made. 

I would expect `baserom/` would be fine as well as `build/baserom/`, but I arbitrarily went with the latter. Let me know if you prefer the former.

This may also be affected (and break again) by https://github.com/zeldaret/mm/pull/121