### PR TITLE
Small env fixes: git submodules & python3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,7 @@
 [submodule "tools/decomp-permuter"]
 	path = tools/decomp-permuter
 	url = https://github.com/simonlindholm/decomp-permuter
+	branch = main
 [submodule "ZAPD"]
 	path = tools/ZAPD
 	url = https://github.com/zeldaret/ZAPD.git

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,10 @@ distclean: clean
 	rm -rf assets/src baserom/
 
 setup:
-	git submodule update --init --recursive --remote
+	# Initialize submodules, fetching commit in case it is not on the default branch
+	-git submodule update --init --recursive
+	git submodule foreach --recursive 'git fetch origin $$sha1'
+	git submodule update --recursive
 	python3 -m pip install -r requirements.txt
 	$(MAKE) -C tools
 	./tools/extract_rom.py $(MM_BASEROM)

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ distclean: clean
 	rm -rf assets/src baserom/
 
 setup:
-	git submodule update --init --recursive
+	git submodule update --init --recursive --remote
 	python3 -m pip install -r requirements.txt
 	$(MAKE) -C tools
 	./tools/extract_rom.py $(MM_BASEROM)

--- a/tools/gen_mips_to_c_context.py
+++ b/tools/gen_mips_to_c_context.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tools/overlayhelpers/ichaindis.py
+++ b/tools/overlayhelpers/ichaindis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Using `/usr/bin/env python3` is preferred over `/usr/bin/python3` because it is compatible with virtualenvs, etc. It picks the version of `python3` currently on the `PATH`, rather than the system-wide default.

For the git submodules, I had two issues (at least on git 2.7.4 from Ubuntu 16.04, which is admittedly pretty old!)

- The ZAPD repo is currently pointing at a commit not on the master branch, which has to be specifically fetched. Adding `--remote` to the update command fixes this.
- The decomp-permuter has primary branch `main` not `master` like this repo, so this has to be specified in `.gitmodules` when using `--remote`.

