### PR TITLE
Hotfix: Fix running `make init` without `-jN`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ distclean: assetclean clean
 	$(RM) -rf baserom/ asm 
 
 ## Extraction step
-# The `cp -r baserom/ build/baserom/` is a temporary solution to the race condition/dependency bug we currently have.
+# TODO: The `cp -r baserom/ build/baserom/` is a temporary solution to the race condition/dependency bug we currently have.
 # It should properly fixed in the future.
 setup:
 	git submodule update --init --recursive

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ build/src/libultra/voice/%: CC := ./tools/preprocess.py $(CC_OLD) -- $(AS) $(ASF
 
 CC := ./tools/preprocess.py $(CC) -- $(AS) $(ASFLAGS) --
 
-.PHONY: all clean setup diff-init init assetclean distclean
+.PHONY: all clean setup diff-init init assetclean distclean assembly
 # make will delete any generated assembly files that are not a prerequisite for anything, so keep it from doing so
 .PRECIOUS: asm/%.asm
 .DEFAULT_GOAL := $(UNCOMPRESSED_ROM)


### PR DESCRIPTION
- Add `cp -r baserom/ build/baserom/` at the end of the `setup` target.
  - This is just a hacky way to fix the dependency bug we currently have. Hopefully somebody will figure out a proper way to fix this soon.
- Add an `assembly` target.
  - This should allow to not regenerate every assembly every time `make` is run, making possible to edit assembly files locally to do your own tests.
  - To regenerate the assemblies before compiling, just run `make assembly` before running `make`.
- Small cleaning of the `Makefile`.