### PR TITLE
Add `CutsceneData` struct

### DIFF
--- a/include/z64cutscene.h
+++ b/include/z64cutscene.h
@@ -77,4 +77,11 @@ typedef struct {
     /* 0x9 */ UNK_TYPE1 pad9[0x3];
 } CsCmdUnk9B; // size = 0xC
 
+typedef union CutsceneData {
+    s32 i;
+    f32 f;
+    s16 s[2];
+    s8  b[4];
+} CutsceneData;
+
 #endif


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

ZAPD will start extracting cutscenes as `CutsceneData[]` instead of `s32[]` when [ZAPD PR 151](https://github.com/zeldaret/ZAPD/pull/151) is merged.
Since MM doesn't have this type yet, that PR is failing and can't be merged yet.
