### PR TITLE
Fixed names of global context related structs to their OoT counterpar…

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -554,11 +554,9 @@ typedef struct {
 } GameStateOverlay; // size = 0x30
 
 typedef struct {
-    /* 0x00 */ u8 unk0;
-    /* 0x01 */ u8 unk1;
-    /* 0x02 */ u16 unk2;
-    /* 0x04 */ Vec3f unk4;
-    /* 0x10 */ Vec3f unk10;
+    /* 0x00 */ u16 countdown;
+    /* 0x04 */ Vec3f originPos;
+    /* 0x10 */ Vec3f relativePos;
 } SoundSource; // size = 0x1C
 
 typedef struct {
@@ -1511,7 +1509,7 @@ struct GlobalContext {
     /* 0x01CA0 */ ActorContext actorCtx;
     /* 0x01F24 */ CutsceneContext csCtx;
     /* 0x01F74 */ CutsceneEntry* cutsceneList;
-    /* 0x01F78 */ SoundSource unk1F78[16];
+    /* 0x01F78 */ SoundSource soundSources[16];
     /* 0x02138 */ EffFootmark footmarks[100];
     /* 0x046B8 */ SramContext sram;
     /* 0x046D8 */ UNK_TYPE1 pad46D8[0x8];
@@ -1519,7 +1517,7 @@ struct GlobalContext {
     /* 0x04908 */ MessageContext msgCtx;
     /* 0x169E0 */ UNK_TYPE1 pad169E0[0x8];
     /* 0x169E8 */ InterfaceContext interfaceCtx;
-    /* 0x16D30 */ PauseContext unk16D30;
+    /* 0x16D30 */ PauseContext pauseCtx;
     /* 0x17000 */ u16 unk17000;
     /* 0x17002 */ UNK_TYPE1 pad17002[0x2];
     /* 0x17004 */ KankyoContext kankyoContext;

--- a/include/z64.h
+++ b/include/z64.h
@@ -252,7 +252,7 @@ typedef struct {
 typedef struct {
     /* 0x00 */ s32 unk0;
     /* 0x04 */ UNK_TYPE1 pad4[0x40];
-} GlobalContext17D98; // size = 0x44
+} UnusedGlobalContext17D98; // size = 0x44
 
 typedef struct GraphicsContext {
     /* 0x000 */ Gfx* polyOpaBuffer;
@@ -564,7 +564,7 @@ typedef struct {
     /* 0x02 */ u16 unk2;
     /* 0x04 */ Vec3f unk4;
     /* 0x10 */ Vec3f unk10;
-} GlobalContext1F78; // size = 0x1C
+} SoundSource; // size = 0x1C
 
 typedef struct {
     /* 0x00 */ OSContPad cur;
@@ -639,7 +639,7 @@ typedef struct {
     /* 0x21C */ f32 unk21C;
     /* 0x220 */ f32 unk220;
     /* 0x224 */ UNK_TYPE1 pad224[0xAC];
-} GlobalContext16D30; // size = 0x2D0
+} PauseContext; // size = 0x2D0
 
 typedef struct {
     /* 0x000 */ View view;
@@ -1516,7 +1516,7 @@ struct GlobalContext {
     /* 0x01CA0 */ ActorContext actorCtx;
     /* 0x01F24 */ CutsceneContext csCtx;
     /* 0x01F74 */ CutsceneEntry* cutsceneList;
-    /* 0x01F78 */ GlobalContext1F78 unk1F78[16];
+    /* 0x01F78 */ SoundSource unk1F78[16];
     /* 0x02138 */ EffFootmark footmarks[100];
     /* 0x046B8 */ SramContext sram;
     /* 0x046D8 */ UNK_TYPE1 pad46D8[0x8];
@@ -1524,7 +1524,7 @@ struct GlobalContext {
     /* 0x04908 */ MessageContext msgCtx;
     /* 0x169E0 */ UNK_TYPE1 pad169E0[0x8];
     /* 0x169E8 */ InterfaceContext interfaceCtx;
-    /* 0x16D30 */ GlobalContext16D30 unk16D30;
+    /* 0x16D30 */ PauseContext unk16D30;
     /* 0x17000 */ u16 unk17000;
     /* 0x17002 */ UNK_TYPE1 pad17002[0x2];
     /* 0x17004 */ KankyoContext kankyoContext;

--- a/include/z64.h
+++ b/include/z64.h
@@ -249,11 +249,6 @@ typedef struct {
     /* 0x20308 */ u16 tailMagic; // 5678
 } GfxPool; // size = 0x20310
 
-typedef struct {
-    /* 0x00 */ s32 unk0;
-    /* 0x04 */ UNK_TYPE1 pad4[0x40];
-} UnusedGlobalContext17D98; // size = 0x44
-
 typedef struct GraphicsContext {
     /* 0x000 */ Gfx* polyOpaBuffer;
     /* 0x004 */ Gfx* polyXluBuffer;

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -51,7 +51,7 @@ void func_8096B104(EnOkarinaEffect* this, GlobalContext* globalCtx) {
 
 void func_8096B174(EnOkarinaEffect* this, GlobalContext* globalCtx) {
     DECR(this->unk144);
-    if (!globalCtx->unk16D30.unk1EC && !globalCtx->unk17000 && !globalCtx->msgCtx.unk11F10 &&
+    if (!globalCtx->pauseCtx.unk1EC && !globalCtx->unk17000 && !globalCtx->msgCtx.unk11F10 &&
         !FrameAdvance_IsEnabled(globalCtx) && this->unk144 == 0) {
         EnOkarinaEffect_SetupAction(this, func_8096B1FC);
     }


### PR DESCRIPTION
…ts + to avoid auto-complete code issues

Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Fixed names of global context related structs to their OoT counterparts + to avoid auto-complete code issues