### PR TITLE
Remove header dependencies checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,13 +171,13 @@ build/uncompressed_dmadata: $(UNCOMPRESSED_ROM_FILES:build/uncompressed_dmadata=
 	./tools/dmadata.py ./tables/dmadata_table.txt $@ -u
 
 build/binary/boot build/binary/code: build/code.elf
-	@$(OBJCOPY) --dump-section $(notdir $@)=$@ $< /dev/null
+	$(OBJCOPY) --dump-section $(notdir $@)=$@ $< /dev/null
 
 build/binary/assets/scenes/%: build/code.elf
-	@$(OBJCOPY) --dump-section $*=$@ $< /dev/null
+	$(OBJCOPY) --dump-section $*=$@ $< /dev/null
 
 build/binary/overlays/%: build/code.elf
-	@$(OBJCOPY) --dump-section $*=$@ $< /dev/null
+	$(OBJCOPY) --dump-section $*=$@ $< /dev/null
 
 
 #### ASM rules ####
@@ -249,8 +249,8 @@ build/asm/%.o: asm/%.asm | $(C_O_FILES)
 
 build/src/overlays/%.o: src/overlays/%.c
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
-	@./tools/overlay.py $@ build/src/overlays/$*_overlay.s
-	@$(AS) $(ASFLAGS) build/src/overlays/$*_overlay.s -o build/src/overlays/$*_overlay.o
+	./tools/overlay.py $@ build/src/overlays/$*_overlay.s
+	$(AS) $(ASFLAGS) build/src/overlays/$*_overlay.s -o build/src/overlays/$*_overlay.o
 
 build/%.o: %.c
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
@@ -282,17 +282,16 @@ build/comp/assets/textures/%.yaz0: build/baserom/assets/textures/%
 	./tools/yaz0 $< $@
 
 build/%.d: %.c
-	@./tools/depend.py $< $@
-	@$(GCC) $< -Iinclude -Isrc -I./ -MM -MT 'build/$*.o' >> $@
+	./tools/depend.py $< $@
 
 build/dmadata_script.ld: build/dmadata_script.txt
-	@$(GCC) -E -CC -x c -Iinclude $< | grep -v '^#' > $@
+	$(GCC) -E -CC -x c -Iinclude $< | grep -v '^#' > $@
 
 build/linker_scripts/%.ld: linker_scripts/%.txt
-	@$(GCC) -E -CC -x c -Iinclude $< | grep -v '^#' > $@
+	$(GCC) -E -CC -x c -Iinclude $< | grep -v '^#' > $@
 
 build/assets/%.d: assets/%.c
-	@$(GCC) $< -Iinclude -I./ -MM -MT 'build/assets/$*.o' > $@
+	$(GCC) $< -Iinclude -I./ -MM -MT 'build/assets/$*.o' > $@
 
 ## Build C files from assets
 
@@ -306,8 +305,8 @@ build/assets/%.jpg.inc.c: assets/%.jpg
 	$(ZAPD) bren -eh -i $< -o $@
 
 # Checks headers dependencies of each C file
-# ifneq ($(MAKECMDGOALS), clean)
-# ifneq ($(MAKECMDGOALS), distclean)
-# -include $(C_FILES:%.c=build/%.d)
-# endif
-# endif
+ifneq ($(MAKECMDGOALS), clean)
+ifneq ($(MAKECMDGOALS), distclean)
+-include $(C_FILES:%.c=build/%.d)
+endif
+endif

--- a/Makefile
+++ b/Makefile
@@ -305,8 +305,9 @@ build/assets/%.bin.inc.c: assets/%.bin
 build/assets/%.jpg.inc.c: assets/%.jpg
 	$(ZAPD) bren -eh -i $< -o $@
 
-ifneq ($(MAKECMDGOALS), clean)
-ifneq ($(MAKECMDGOALS), distclean)
--include $(C_FILES:%.c=build/%.d)
-endif
-endif
+# Checks headers dependencies of each C file
+# ifneq ($(MAKECMDGOALS), clean)
+# ifneq ($(MAKECMDGOALS), distclean)
+# -include $(C_FILES:%.c=build/%.d)
+# endif
+# endif


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

As we discussed in the discord server, it isn't a good idea to constantly check which C files should be recompiled when a header is  changed at this stage of this project since every header is included everywhere, so that check is now removed.

I also decided to remove most of the `@` at each command so we can see what's actually going in each step of the build process (instead of simply waiting of something that seems to be stuck...)
