### PR TITLE
Remove argument names from action funcs

### DIFF
--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.h
@@ -5,7 +5,7 @@
 
 struct ArrowFire;
 
-typedef void (*ArrowFireActionFunc)(struct ArrowFire* this, GlobalContext* globalCtx);
+typedef void (*ArrowFireActionFunc)(struct ArrowFire*, GlobalContext*);
 
 typedef struct ArrowFire {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.h
@@ -5,7 +5,7 @@
 
 struct ArrowIce;
 
-typedef void (*ArrowIceActionFunc)(struct ArrowIce* this, GlobalContext* globalCtx);
+typedef void (*ArrowIceActionFunc)(struct ArrowIce*, GlobalContext*);
 
 typedef struct ArrowIce {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.h
@@ -5,7 +5,7 @@
 
 struct ArrowLight;
 
-typedef void (*ArrowLightActionFunc)(struct ArrowLight* this, GlobalContext* globalCtx);
+typedef void (*ArrowLightActionFunc)(struct ArrowLight*, GlobalContext*);
 
 typedef struct ArrowLight {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Astr_Bombwall/z_bg_astr_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Astr_Bombwall/z_bg_astr_bombwall.h
@@ -5,7 +5,7 @@
 
 struct BgAstrBombwall;
 
-typedef void (*BgAstrBombwallActionFunc)(struct BgAstrBombwall* this, GlobalContext* globalCtx);
+typedef void (*BgAstrBombwallActionFunc)(struct BgAstrBombwall*, GlobalContext*);
 
 typedef struct BgAstrBombwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Botihasira/z_bg_botihasira.h
+++ b/src/overlays/actors/ovl_Bg_Botihasira/z_bg_botihasira.h
@@ -5,7 +5,7 @@
 
 struct BgBotihasira;
 
-typedef void (*BgBotihasiraActionFunc)(struct BgBotihasira* this, GlobalContext* globalCtx);
+typedef void (*BgBotihasiraActionFunc)(struct BgBotihasira*, GlobalContext*);
 
 typedef struct BgBotihasira {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.h
@@ -5,7 +5,7 @@
 
 struct BgBreakwall;
 
-typedef void (*BgBreakwallActionFunc)(struct BgBreakwall* this, GlobalContext* globalCtx);
+typedef void (*BgBreakwallActionFunc)(struct BgBreakwall*, GlobalContext*);
 
 typedef struct BgBreakwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Crace_Movebg/z_bg_crace_movebg.h
+++ b/src/overlays/actors/ovl_Bg_Crace_Movebg/z_bg_crace_movebg.h
@@ -5,7 +5,7 @@
 
 struct BgCraceMovebg;
 
-typedef void (*BgCraceMovebgActionFunc)(struct BgCraceMovebg* this, GlobalContext* globalCtx);
+typedef void (*BgCraceMovebgActionFunc)(struct BgCraceMovebg*, GlobalContext*);
 
 typedef struct BgCraceMovebg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Danpei_Movebg/z_bg_danpei_movebg.h
+++ b/src/overlays/actors/ovl_Bg_Danpei_Movebg/z_bg_danpei_movebg.h
@@ -5,7 +5,7 @@
 
 struct BgDanpeiMovebg;
 
-typedef void (*BgDanpeiMovebgActionFunc)(struct BgDanpeiMovebg* this, GlobalContext* globalCtx);
+typedef void (*BgDanpeiMovebgActionFunc)(struct BgDanpeiMovebg*, GlobalContext*);
 
 typedef struct BgDanpeiMovebg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dblue_Balance/z_bg_dblue_balance.h
+++ b/src/overlays/actors/ovl_Bg_Dblue_Balance/z_bg_dblue_balance.h
@@ -5,7 +5,7 @@
 
 struct BgDblueBalance;
 
-typedef void (*BgDblueBalanceActionFunc)(struct BgDblueBalance* this, GlobalContext* globalCtx);
+typedef void (*BgDblueBalanceActionFunc)(struct BgDblueBalance*, GlobalContext*);
 
 typedef struct BgDblueBalance {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dblue_Elevator/z_bg_dblue_elevator.h
+++ b/src/overlays/actors/ovl_Bg_Dblue_Elevator/z_bg_dblue_elevator.h
@@ -5,7 +5,7 @@
 
 struct BgDblueElevator;
 
-typedef void (*BgDblueElevatorActionFunc)(struct BgDblueElevator* this, GlobalContext* globalCtx);
+typedef void (*BgDblueElevatorActionFunc)(struct BgDblueElevator*, GlobalContext*);
 
 typedef struct BgDblueElevator {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.h
+++ b/src/overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.h
@@ -5,7 +5,7 @@
 
 struct BgDblueMovebg;
 
-typedef void (*BgDblueMovebgActionFunc)(struct BgDblueMovebg* this, GlobalContext* globalCtx);
+typedef void (*BgDblueMovebgActionFunc)(struct BgDblueMovebg*, GlobalContext*);
 
 typedef struct BgDblueMovebg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dblue_Waterfall/z_bg_dblue_waterfall.h
+++ b/src/overlays/actors/ovl_Bg_Dblue_Waterfall/z_bg_dblue_waterfall.h
@@ -5,7 +5,7 @@
 
 struct BgDblueWaterfall;
 
-typedef void (*BgDblueWaterfallActionFunc)(struct BgDblueWaterfall* this, GlobalContext* globalCtx);
+typedef void (*BgDblueWaterfallActionFunc)(struct BgDblueWaterfall*, GlobalContext*);
 
 typedef struct BgDblueWaterfall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.h
+++ b/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.h
@@ -5,7 +5,7 @@
 
 struct BgDkjailIvy;
 
-typedef void (*BgDkjailIvyActionFunc)(struct BgDkjailIvy* this, GlobalContext* globalCtx);
+typedef void (*BgDkjailIvyActionFunc)(struct BgDkjailIvy*, GlobalContext*);
 
 typedef struct BgDkjailIvy {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.h
@@ -5,7 +5,7 @@
 
 struct BgDyYoseizo;
 
-typedef void (*BgDyYoseizoActionFunc)(struct BgDyYoseizo* this, GlobalContext* globalCtx);
+typedef void (*BgDyYoseizoActionFunc)(struct BgDyYoseizo*, GlobalContext*);
 
 typedef struct BgDyYoseizo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_F40_Block/z_bg_f40_block.h
+++ b/src/overlays/actors/ovl_Bg_F40_Block/z_bg_f40_block.h
@@ -5,7 +5,7 @@
 
 struct BgF40Block;
 
-typedef void (*BgF40BlockActionFunc)(struct BgF40Block* this, GlobalContext* globalCtx);
+typedef void (*BgF40BlockActionFunc)(struct BgF40Block*, GlobalContext*);
 
 typedef struct BgF40Block {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_F40_Flift/z_bg_f40_flift.h
+++ b/src/overlays/actors/ovl_Bg_F40_Flift/z_bg_f40_flift.h
@@ -5,7 +5,7 @@
 
 struct BgF40Flift;
 
-typedef void (*BgF40FliftActionFunc)(struct BgF40Flift* this, GlobalContext* globalCtx);
+typedef void (*BgF40FliftActionFunc)(struct BgF40Flift*, GlobalContext*);
 
 typedef struct BgF40Flift {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.h
+++ b/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.h
@@ -5,7 +5,7 @@
 
 struct BgF40Switch;
 
-typedef void (*BgF40SwitchActionFunc)(struct BgF40Switch* this, GlobalContext* globalCtx);
+typedef void (*BgF40SwitchActionFunc)(struct BgF40Switch*, GlobalContext*);
 
 typedef struct BgF40Switch {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Fire_Wall/z_bg_fire_wall.h
+++ b/src/overlays/actors/ovl_Bg_Fire_Wall/z_bg_fire_wall.h
@@ -5,7 +5,7 @@
 
 struct BgFireWall;
 
-typedef void (*BgFireWallActionFunc)(struct BgFireWall* this, GlobalContext* globalCtx);
+typedef void (*BgFireWallActionFunc)(struct BgFireWall*, GlobalContext*);
 
 typedef struct BgFireWall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Goron_Oyu/z_bg_goron_oyu.h
+++ b/src/overlays/actors/ovl_Bg_Goron_Oyu/z_bg_goron_oyu.h
@@ -5,7 +5,7 @@
 
 struct BgGoronOyu;
 
-typedef void (*BgGoronOyuActionFunc)(struct BgGoronOyu* this, GlobalContext* globalCtx);
+typedef void (*BgGoronOyuActionFunc)(struct BgGoronOyu*, GlobalContext*);
 
 typedef struct BgGoronOyu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Haka_Bombwall/z_bg_haka_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Haka_Bombwall/z_bg_haka_bombwall.h
@@ -5,7 +5,7 @@
 
 struct BgHakaBombwall;
 
-typedef void (*BgHakaBombwallActionFunc)(struct BgHakaBombwall* this, GlobalContext* globalCtx);
+typedef void (*BgHakaBombwallActionFunc)(struct BgHakaBombwall*, GlobalContext*);
 
 typedef struct BgHakaBombwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.h
@@ -5,7 +5,7 @@
 
 struct BgHakuginBombwall;
 
-typedef void (*BgHakuginBombwallActionFunc)(struct BgHakuginBombwall* this, GlobalContext* globalCtx);
+typedef void (*BgHakuginBombwallActionFunc)(struct BgHakuginBombwall*, GlobalContext*);
 
 typedef struct BgHakuginBombwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Hakugin_Elvpole/z_bg_hakugin_elvpole.h
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Elvpole/z_bg_hakugin_elvpole.h
@@ -5,7 +5,7 @@
 
 struct BgHakuginElvpole;
 
-typedef void (*BgHakuginElvpoleActionFunc)(struct BgHakuginElvpole* this, GlobalContext* globalCtx);
+typedef void (*BgHakuginElvpoleActionFunc)(struct BgHakuginElvpole*, GlobalContext*);
 
 typedef struct BgHakuginElvpole {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.h
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.h
@@ -5,7 +5,7 @@
 
 struct BgHakuginPost;
 
-typedef void (*BgHakuginPostActionFunc)(struct BgHakuginPost* this, GlobalContext* globalCtx);
+typedef void (*BgHakuginPostActionFunc)(struct BgHakuginPost*, GlobalContext*);
 
 typedef struct BgHakuginPost {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Hakugin_Switch/z_bg_hakugin_switch.h
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Switch/z_bg_hakugin_switch.h
@@ -5,7 +5,7 @@
 
 struct BgHakuginSwitch;
 
-typedef void (*BgHakuginSwitchActionFunc)(struct BgHakuginSwitch* this, GlobalContext* globalCtx);
+typedef void (*BgHakuginSwitchActionFunc)(struct BgHakuginSwitch*, GlobalContext*);
 
 typedef struct BgHakuginSwitch {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Icefloe/z_bg_icefloe.h
+++ b/src/overlays/actors/ovl_Bg_Icefloe/z_bg_icefloe.h
@@ -5,7 +5,7 @@
 
 struct BgIcefloe;
 
-typedef void (*BgIcefloeActionFunc)(struct BgIcefloe* this, GlobalContext* globalCtx);
+typedef void (*BgIcefloeActionFunc)(struct BgIcefloe*, GlobalContext*);
 
 typedef struct BgIcefloe {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.h
+++ b/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.h
@@ -5,7 +5,7 @@
 
 struct BgIkanaBlock;
 
-typedef void (*BgIkanaBlockActionFunc)(struct BgIkanaBlock* this, GlobalContext* globalCtx);
+typedef void (*BgIkanaBlockActionFunc)(struct BgIkanaBlock*, GlobalContext*);
 
 typedef struct BgIkanaBlock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikana_Bombwall/z_bg_ikana_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Ikana_Bombwall/z_bg_ikana_bombwall.h
@@ -5,7 +5,7 @@
 
 struct BgIkanaBombwall;
 
-typedef void (*BgIkanaBombwallActionFunc)(struct BgIkanaBombwall* this, GlobalContext* globalCtx);
+typedef void (*BgIkanaBombwallActionFunc)(struct BgIkanaBombwall*, GlobalContext*);
 
 typedef struct BgIkanaBombwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.h
+++ b/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.h
@@ -5,7 +5,7 @@
 
 struct BgIkanaDharma;
 
-typedef void (*BgIkanaDharmaActionFunc)(struct BgIkanaDharma* this, GlobalContext* globalCtx);
+typedef void (*BgIkanaDharmaActionFunc)(struct BgIkanaDharma*, GlobalContext*);
 
 typedef struct BgIkanaDharma {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikana_Mirror/z_bg_ikana_mirror.h
+++ b/src/overlays/actors/ovl_Bg_Ikana_Mirror/z_bg_ikana_mirror.h
@@ -5,7 +5,7 @@
 
 struct BgIkanaMirror;
 
-typedef void (*BgIkanaMirrorActionFunc)(struct BgIkanaMirror* this, GlobalContext* globalCtx);
+typedef void (*BgIkanaMirrorActionFunc)(struct BgIkanaMirror*, GlobalContext*);
 
 typedef struct BgIkanaMirror {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikana_Rotaryroom/z_bg_ikana_rotaryroom.h
+++ b/src/overlays/actors/ovl_Bg_Ikana_Rotaryroom/z_bg_ikana_rotaryroom.h
@@ -5,7 +5,7 @@
 
 struct BgIkanaRotaryroom;
 
-typedef void (*BgIkanaRotaryroomActionFunc)(struct BgIkanaRotaryroom* this, GlobalContext* globalCtx);
+typedef void (*BgIkanaRotaryroomActionFunc)(struct BgIkanaRotaryroom*, GlobalContext*);
 
 typedef struct BgIkanaRotaryroom {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ikninside/z_bg_ikninside.h
+++ b/src/overlays/actors/ovl_Bg_Ikninside/z_bg_ikninside.h
@@ -5,7 +5,7 @@
 
 struct BgIkninside;
 
-typedef void (*BgIkninsideActionFunc)(struct BgIkninside* this, GlobalContext* globalCtx);
+typedef void (*BgIkninsideActionFunc)(struct BgIkninside*, GlobalContext*);
 
 typedef struct BgIkninside {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Iknv_Doukutu/z_bg_iknv_doukutu.h
+++ b/src/overlays/actors/ovl_Bg_Iknv_Doukutu/z_bg_iknv_doukutu.h
@@ -5,7 +5,7 @@
 
 struct BgIknvDoukutu;
 
-typedef void (*BgIknvDoukutuActionFunc)(struct BgIknvDoukutu* this, GlobalContext* globalCtx);
+typedef void (*BgIknvDoukutuActionFunc)(struct BgIknvDoukutu*, GlobalContext*);
 
 typedef struct BgIknvDoukutu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.h
@@ -5,7 +5,7 @@
 
 struct BgIngate;
 
-typedef void (*BgIngateActionFunc)(struct BgIngate* this, GlobalContext* globalCtx);
+typedef void (*BgIngateActionFunc)(struct BgIngate*, GlobalContext*);
 
 typedef struct BgIngate {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Keikoku_Saku/z_bg_keikoku_saku.h
+++ b/src/overlays/actors/ovl_Bg_Keikoku_Saku/z_bg_keikoku_saku.h
@@ -5,7 +5,7 @@
 
 struct BgKeikokuSaku;
 
-typedef void (*BgKeikokuSakuActionFunc)(struct BgKeikokuSaku* this, GlobalContext* globalCtx);
+typedef void (*BgKeikokuSakuActionFunc)(struct BgKeikokuSaku*, GlobalContext*);
 
 typedef struct BgKeikokuSaku {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Kin2_Bombwall/z_bg_kin2_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Kin2_Bombwall/z_bg_kin2_bombwall.h
@@ -5,7 +5,7 @@
 
 struct BgKin2Bombwall;
 
-typedef void (*BgKin2BombwallActionFunc)(struct BgKin2Bombwall* this, GlobalContext* globalCtx);
+typedef void (*BgKin2BombwallActionFunc)(struct BgKin2Bombwall*, GlobalContext*);
 
 typedef struct BgKin2Bombwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.h
+++ b/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.h
@@ -5,7 +5,7 @@
 
 struct BgKin2Picture;
 
-typedef void (*BgKin2PictureActionFunc)(struct BgKin2Picture* this, GlobalContext* globalCtx);
+typedef void (*BgKin2PictureActionFunc)(struct BgKin2Picture*, GlobalContext*);
 
 typedef struct BgKin2Picture {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Kin2_Shelf/z_bg_kin2_shelf.h
+++ b/src/overlays/actors/ovl_Bg_Kin2_Shelf/z_bg_kin2_shelf.h
@@ -5,7 +5,7 @@
 
 struct BgKin2Shelf;
 
-typedef void (*BgKin2ShelfActionFunc)(struct BgKin2Shelf* this, GlobalContext* globalCtx);
+typedef void (*BgKin2ShelfActionFunc)(struct BgKin2Shelf*, GlobalContext*);
 
 typedef struct BgKin2Shelf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Last_Bwall/z_bg_last_bwall.h
+++ b/src/overlays/actors/ovl_Bg_Last_Bwall/z_bg_last_bwall.h
@@ -5,7 +5,7 @@
 
 struct BgLastBwall;
 
-typedef void (*BgLastBwallActionFunc)(struct BgLastBwall* this, GlobalContext* globalCtx);
+typedef void (*BgLastBwallActionFunc)(struct BgLastBwall*, GlobalContext*);
 
 typedef struct BgLastBwall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.h
+++ b/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.h
@@ -5,7 +5,7 @@
 
 struct BgNumaHana;
 
-typedef void (*BgNumaHanaActionFunc)(struct BgNumaHana* this, GlobalContext* globalCtx);
+typedef void (*BgNumaHanaActionFunc)(struct BgNumaHana*, GlobalContext*);
 
 typedef struct BgNumaHana {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.h
+++ b/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.h
@@ -5,7 +5,7 @@
 
 struct BgOpenShutter;
 
-typedef void (*BgOpenShutterActionFunc)(struct BgOpenShutter* this, GlobalContext* globalCtx);
+typedef void (*BgOpenShutterActionFunc)(struct BgOpenShutter*, GlobalContext*);
 
 typedef struct BgOpenShutter {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Sinkai_Kabe/z_bg_sinkai_kabe.h
+++ b/src/overlays/actors/ovl_Bg_Sinkai_Kabe/z_bg_sinkai_kabe.h
@@ -5,7 +5,7 @@
 
 struct BgSinkaiKabe;
 
-typedef void (*BgSinkaiKabeActionFunc)(struct BgSinkaiKabe* this, GlobalContext* globalCtx);
+typedef void (*BgSinkaiKabeActionFunc)(struct BgSinkaiKabe*, GlobalContext*);
 
 typedef struct BgSinkaiKabe {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Spdweb/z_bg_spdweb.h
+++ b/src/overlays/actors/ovl_Bg_Spdweb/z_bg_spdweb.h
@@ -5,7 +5,7 @@
 
 struct BgSpdweb;
 
-typedef void (*BgSpdwebActionFunc)(struct BgSpdweb* this, GlobalContext* globalCtx);
+typedef void (*BgSpdwebActionFunc)(struct BgSpdweb*, GlobalContext*);
 
 typedef struct BgSpdweb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Bg_Spout_Fire/z_bg_spout_fire.h
+++ b/src/overlays/actors/ovl_Bg_Spout_Fire/z_bg_spout_fire.h
@@ -5,7 +5,7 @@
 
 struct BgSpoutFire;
 
-typedef void (*BgSpoutFireActionFunc)(struct BgSpoutFire* this, GlobalContext* globalCtx);
+typedef void (*BgSpoutFireActionFunc)(struct BgSpoutFire*, GlobalContext*);
 
 typedef struct BgSpoutFire {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_01/z_boss_01.h
+++ b/src/overlays/actors/ovl_Boss_01/z_boss_01.h
@@ -5,7 +5,7 @@
 
 struct Boss01;
 
-typedef void (*Boss01ActionFunc)(struct Boss01* this, GlobalContext* globalCtx);
+typedef void (*Boss01ActionFunc)(struct Boss01*, GlobalContext*);
 
 typedef struct Boss01 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_02/z_boss_02.h
+++ b/src/overlays/actors/ovl_Boss_02/z_boss_02.h
@@ -5,7 +5,7 @@
 
 struct Boss02;
 
-typedef void (*Boss02ActionFunc)(struct Boss02* this, GlobalContext* globalCtx);
+typedef void (*Boss02ActionFunc)(struct Boss02*, GlobalContext*);
 
 typedef struct Boss02 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_03/z_boss_03.h
+++ b/src/overlays/actors/ovl_Boss_03/z_boss_03.h
@@ -5,7 +5,7 @@
 
 struct Boss03;
 
-typedef void (*Boss03ActionFunc)(struct Boss03* this, GlobalContext* globalCtx);
+typedef void (*Boss03ActionFunc)(struct Boss03*, GlobalContext*);
 
 typedef struct Boss03 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_04/z_boss_04.h
+++ b/src/overlays/actors/ovl_Boss_04/z_boss_04.h
@@ -5,7 +5,7 @@
 
 struct Boss04;
 
-typedef void (*Boss04ActionFunc)(struct Boss04* this, GlobalContext* globalCtx);
+typedef void (*Boss04ActionFunc)(struct Boss04*, GlobalContext*);
 
 typedef struct Boss04 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_05/z_boss_05.h
+++ b/src/overlays/actors/ovl_Boss_05/z_boss_05.h
@@ -5,7 +5,7 @@
 
 struct Boss05;
 
-typedef void (*Boss05ActionFunc)(struct Boss05* this, GlobalContext* globalCtx);
+typedef void (*Boss05ActionFunc)(struct Boss05*, GlobalContext*);
 
 typedef struct Boss05 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_06/z_boss_06.h
+++ b/src/overlays/actors/ovl_Boss_06/z_boss_06.h
@@ -5,7 +5,7 @@
 
 struct Boss06;
 
-typedef void (*Boss06ActionFunc)(struct Boss06* this, GlobalContext* globalCtx);
+typedef void (*Boss06ActionFunc)(struct Boss06*, GlobalContext*);
 
 typedef struct Boss06 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_07/z_boss_07.h
+++ b/src/overlays/actors/ovl_Boss_07/z_boss_07.h
@@ -5,7 +5,7 @@
 
 struct Boss07;
 
-typedef void (*Boss07ActionFunc)(struct Boss07* this, GlobalContext* globalCtx);
+typedef void (*Boss07ActionFunc)(struct Boss07*, GlobalContext*);
 
 typedef struct Boss07 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.h
+++ b/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.h
@@ -5,7 +5,7 @@
 
 struct BossHakugin;
 
-typedef void (*BossHakuginActionFunc)(struct BossHakugin* this, GlobalContext* globalCtx);
+typedef void (*BossHakuginActionFunc)(struct BossHakugin*, GlobalContext*);
 
 typedef struct BossHakugin {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.h
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.h
@@ -5,7 +5,7 @@
 
 struct DemoEffect;
 
-typedef void (*DemoEffectActionFunc)(struct DemoEffect* this, GlobalContext* globalCtx);
+typedef void (*DemoEffectActionFunc)(struct DemoEffect*, GlobalContext*);
 
 typedef struct DemoEffect {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.h
+++ b/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.h
@@ -5,7 +5,7 @@
 
 struct DemoGetitem;
 
-typedef void (*DemoGetitemActionFunc)(struct DemoGetitem* this, GlobalContext* globalCtx);
+typedef void (*DemoGetitemActionFunc)(struct DemoGetitem*, GlobalContext*);
 
 typedef struct DemoGetitem {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.h
@@ -5,7 +5,7 @@
 
 struct DemoKankyo;
 
-typedef void (*DemoKankyoActionFunc)(struct DemoKankyo* this, GlobalContext* globalCtx);
+typedef void (*DemoKankyoActionFunc)(struct DemoKankyo*, GlobalContext*);
 
 typedef struct DemoKankyo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Demo_Moonend/z_demo_moonend.h
+++ b/src/overlays/actors/ovl_Demo_Moonend/z_demo_moonend.h
@@ -5,7 +5,7 @@
 
 struct DemoMoonend;
 
-typedef void (*DemoMoonendActionFunc)(struct DemoMoonend* this, GlobalContext* globalCtx);
+typedef void (*DemoMoonendActionFunc)(struct DemoMoonend*, GlobalContext*);
 
 typedef struct DemoMoonend {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.h
+++ b/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.h
@@ -5,7 +5,7 @@
 
 struct DemoSyoten;
 
-typedef void (*DemoSyotenActionFunc)(struct DemoSyoten* this, GlobalContext* globalCtx);
+typedef void (*DemoSyotenActionFunc)(struct DemoSyoten*, GlobalContext*);
 
 typedef struct DemoSyoten {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Ah/z_dm_ah.h
+++ b/src/overlays/actors/ovl_Dm_Ah/z_dm_ah.h
@@ -5,7 +5,7 @@
 
 struct DmAh;
 
-typedef void (*DmAhActionFunc)(struct DmAh* this, GlobalContext* globalCtx);
+typedef void (*DmAhActionFunc)(struct DmAh*, GlobalContext*);
 
 typedef struct DmAh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Al/z_dm_al.h
+++ b/src/overlays/actors/ovl_Dm_Al/z_dm_al.h
@@ -5,7 +5,7 @@
 
 struct DmAl;
 
-typedef void (*DmAlActionFunc)(struct DmAl* this, GlobalContext* globalCtx);
+typedef void (*DmAlActionFunc)(struct DmAl*, GlobalContext*);
 
 typedef struct DmAl {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_An/z_dm_an.h
+++ b/src/overlays/actors/ovl_Dm_An/z_dm_an.h
@@ -5,7 +5,7 @@
 
 struct DmAn;
 
-typedef void (*DmAnActionFunc)(struct DmAn* this, GlobalContext* globalCtx);
+typedef void (*DmAnActionFunc)(struct DmAn*, GlobalContext*);
 
 typedef struct DmAn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Bal/z_dm_bal.h
+++ b/src/overlays/actors/ovl_Dm_Bal/z_dm_bal.h
@@ -5,7 +5,7 @@
 
 struct DmBal;
 
-typedef void (*DmBalActionFunc)(struct DmBal* this, GlobalContext* globalCtx);
+typedef void (*DmBalActionFunc)(struct DmBal*, GlobalContext*);
 
 typedef struct DmBal {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.h
+++ b/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.h
@@ -5,7 +5,7 @@
 
 struct DmChar00;
 
-typedef void (*DmChar00ActionFunc)(struct DmChar00* this, GlobalContext* globalCtx);
+typedef void (*DmChar00ActionFunc)(struct DmChar00*, GlobalContext*);
 
 typedef struct DmChar00 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.h
+++ b/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.h
@@ -5,7 +5,7 @@
 
 struct DmChar01;
 
-typedef void (*DmChar01ActionFunc)(struct DmChar01* this, GlobalContext* globalCtx);
+typedef void (*DmChar01ActionFunc)(struct DmChar01*, GlobalContext*);
 
 typedef struct DmChar01 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.h
+++ b/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.h
@@ -5,7 +5,7 @@
 
 struct DmChar02;
 
-typedef void (*DmChar02ActionFunc)(struct DmChar02* this, GlobalContext* globalCtx);
+typedef void (*DmChar02ActionFunc)(struct DmChar02*, GlobalContext*);
 
 typedef struct DmChar02 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char03/z_dm_char03.h
+++ b/src/overlays/actors/ovl_Dm_Char03/z_dm_char03.h
@@ -5,7 +5,7 @@
 
 struct DmChar03;
 
-typedef void (*DmChar03ActionFunc)(struct DmChar03* this, GlobalContext* globalCtx);
+typedef void (*DmChar03ActionFunc)(struct DmChar03*, GlobalContext*);
 
 typedef struct DmChar03 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.h
+++ b/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.h
@@ -5,7 +5,7 @@
 
 struct DmChar04;
 
-typedef void (*DmChar04ActionFunc)(struct DmChar04* this, GlobalContext* globalCtx);
+typedef void (*DmChar04ActionFunc)(struct DmChar04*, GlobalContext*);
 
 typedef struct DmChar04 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.h
+++ b/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.h
@@ -5,7 +5,7 @@
 
 struct DmChar05;
 
-typedef void (*DmChar05ActionFunc)(struct DmChar05* this, GlobalContext* globalCtx);
+typedef void (*DmChar05ActionFunc)(struct DmChar05*, GlobalContext*);
 
 typedef struct DmChar05 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.h
+++ b/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.h
@@ -5,7 +5,7 @@
 
 struct DmChar06;
 
-typedef void (*DmChar06ActionFunc)(struct DmChar06* this, GlobalContext* globalCtx);
+typedef void (*DmChar06ActionFunc)(struct DmChar06*, GlobalContext*);
 
 typedef struct DmChar06 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.h
+++ b/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.h
@@ -5,7 +5,7 @@
 
 struct DmChar08;
 
-typedef void (*DmChar08ActionFunc)(struct DmChar08* this, GlobalContext* globalCtx);
+typedef void (*DmChar08ActionFunc)(struct DmChar08*, GlobalContext*);
 
 typedef struct DmChar08 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Char09/z_dm_char09.h
+++ b/src/overlays/actors/ovl_Dm_Char09/z_dm_char09.h
@@ -5,7 +5,7 @@
 
 struct DmChar09;
 
-typedef void (*DmChar09ActionFunc)(struct DmChar09* this, GlobalContext* globalCtx);
+typedef void (*DmChar09ActionFunc)(struct DmChar09*, GlobalContext*);
 
 typedef struct DmChar09 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Gm/z_dm_gm.h
+++ b/src/overlays/actors/ovl_Dm_Gm/z_dm_gm.h
@@ -5,7 +5,7 @@
 
 struct DmGm;
 
-typedef void (*DmGmActionFunc)(struct DmGm* this, GlobalContext* globalCtx);
+typedef void (*DmGmActionFunc)(struct DmGm*, GlobalContext*);
 
 typedef struct DmGm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Hina/z_dm_hina.h
+++ b/src/overlays/actors/ovl_Dm_Hina/z_dm_hina.h
@@ -5,7 +5,7 @@
 
 struct DmHina;
 
-typedef void (*DmHinaActionFunc)(struct DmHina* this, GlobalContext* globalCtx);
+typedef void (*DmHinaActionFunc)(struct DmHina*, GlobalContext*);
 
 typedef struct DmHina {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.h
+++ b/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.h
@@ -5,7 +5,7 @@
 
 struct DmOpstage;
 
-typedef void (*DmOpstageActionFunc)(struct DmOpstage* this, GlobalContext* globalCtx);
+typedef void (*DmOpstageActionFunc)(struct DmOpstage*, GlobalContext*);
 
 typedef struct DmOpstage {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Stk/z_dm_stk.h
+++ b/src/overlays/actors/ovl_Dm_Stk/z_dm_stk.h
@@ -5,7 +5,7 @@
 
 struct DmStk;
 
-typedef void (*DmStkActionFunc)(struct DmStk* this, GlobalContext* globalCtx);
+typedef void (*DmStkActionFunc)(struct DmStk*, GlobalContext*);
 
 typedef struct DmStk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.h
+++ b/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.h
@@ -5,7 +5,7 @@
 
 struct DmTag;
 
-typedef void (*DmTagActionFunc)(struct DmTag* this, GlobalContext* globalCtx);
+typedef void (*DmTagActionFunc)(struct DmTag*, GlobalContext*);
 
 typedef struct DmTag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.h
+++ b/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.h
@@ -5,7 +5,7 @@
 
 struct DmZl;
 
-typedef void (*DmZlActionFunc)(struct DmZl* this, GlobalContext* globalCtx);
+typedef void (*DmZlActionFunc)(struct DmZl*, GlobalContext*);
 
 typedef struct DmZl {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.h
@@ -5,7 +5,7 @@
 
 struct DoorShutter;
 
-typedef void (*DoorShutterActionFunc)(struct DoorShutter* this, GlobalContext* globalCtx);
+typedef void (*DoorShutterActionFunc)(struct DoorShutter*, GlobalContext*);
 
 typedef struct DoorShutter {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.h
@@ -5,7 +5,7 @@
 
 struct DoorWarp1;
 
-typedef void (*DoorWarp1ActionFunc)(struct DoorWarp1* this, GlobalContext* globalCtx);
+typedef void (*DoorWarp1ActionFunc)(struct DoorWarp1*, GlobalContext*);
 
 typedef struct DoorWarp1 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Eff_Change/z_eff_change.h
+++ b/src/overlays/actors/ovl_Eff_Change/z_eff_change.h
@@ -5,7 +5,7 @@
 
 struct EffChange;
 
-typedef void (*EffChangeActionFunc)(struct EffChange* this, GlobalContext* globalCtx);
+typedef void (*EffChangeActionFunc)(struct EffChange*, GlobalContext*);
 
 typedef struct EffChange {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.h
+++ b/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.h
@@ -5,7 +5,7 @@
 
 struct EffKamejimaWave;
 
-typedef void (*EffKamejimaWaveActionFunc)(struct EffKamejimaWave* this, GlobalContext* globalCtx);
+typedef void (*EffKamejimaWaveActionFunc)(struct EffKamejimaWave*, GlobalContext*);
 
 typedef struct EffKamejimaWave {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.h
+++ b/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.h
@@ -5,7 +5,7 @@
 
 struct EffLastday;
 
-typedef void (*EffLastdayActionFunc)(struct EffLastday* this, GlobalContext* globalCtx);
+typedef void (*EffLastdayActionFunc)(struct EffLastday*, GlobalContext*);
 
 typedef struct EffLastday {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.h
+++ b/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.h
@@ -5,7 +5,7 @@
 
 struct EffStk;
 
-typedef void (*EffStkActionFunc)(struct EffStk* this, GlobalContext* globalCtx);
+typedef void (*EffStkActionFunc)(struct EffStk*, GlobalContext*);
 
 typedef struct EffStk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.h
+++ b/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.h
@@ -5,7 +5,7 @@
 
 struct EffZoraband;
 
-typedef void (*EffZorabandActionFunc)(struct EffZoraband* this, GlobalContext* globalCtx);
+typedef void (*EffZorabandActionFunc)(struct EffZoraband*, GlobalContext*);
 
 typedef struct EffZoraband {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg;
 
-typedef void (*ElfMsgActionFunc)(struct ElfMsg* this, GlobalContext* globalCtx);
+typedef void (*ElfMsgActionFunc)(struct ElfMsg*, GlobalContext*);
 
 typedef struct ElfMsg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg2;
 
-typedef void (*ElfMsg2ActionFunc)(struct ElfMsg2* this, GlobalContext* globalCtx);
+typedef void (*ElfMsg2ActionFunc)(struct ElfMsg2*, GlobalContext*);
 
 typedef struct ElfMsg2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.h
+++ b/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg3;
 
-typedef void (*ElfMsg3ActionFunc)(struct ElfMsg3* this, GlobalContext* globalCtx);
+typedef void (*ElfMsg3ActionFunc)(struct ElfMsg3*, GlobalContext*);
 
 typedef struct ElfMsg3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.h
+++ b/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg4;
 
-typedef void (*ElfMsg4ActionFunc)(struct ElfMsg4* this, GlobalContext* globalCtx);
+typedef void (*ElfMsg4ActionFunc)(struct ElfMsg4*, GlobalContext*);
 
 typedef struct ElfMsg4 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.h
+++ b/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg5;
 
-typedef void (*ElfMsg5ActionFunc)(struct ElfMsg5* this, GlobalContext* globalCtx);
+typedef void (*ElfMsg5ActionFunc)(struct ElfMsg5*, GlobalContext*);
 
 typedef struct ElfMsg5 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.h
+++ b/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.h
@@ -5,7 +5,7 @@
 
 struct ElfMsg6;
 
-typedef void (*ElfMsg6ActionFunc)(struct ElfMsg6* this, GlobalContext* globalCtx);
+typedef void (*ElfMsg6ActionFunc)(struct ElfMsg6*, GlobalContext*);
 
 typedef struct ElfMsg6 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ah/z_en_ah.h
+++ b/src/overlays/actors/ovl_En_Ah/z_en_ah.h
@@ -5,7 +5,7 @@
 
 struct EnAh;
 
-typedef void (*EnAhActionFunc)(struct EnAh* this, GlobalContext* globalCtx);
+typedef void (*EnAhActionFunc)(struct EnAh*, GlobalContext*);
 
 typedef struct EnAh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.h
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.h
@@ -5,7 +5,7 @@
 
 struct EnAkindonuts;
 
-typedef void (*EnAkindonutsActionFunc)(struct EnAkindonuts* this, GlobalContext* globalCtx);
+typedef void (*EnAkindonutsActionFunc)(struct EnAkindonuts*, GlobalContext*);
 
 typedef struct EnAkindonuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Al/z_en_al.h
+++ b/src/overlays/actors/ovl_En_Al/z_en_al.h
@@ -5,7 +5,7 @@
 
 struct EnAl;
 
-typedef void (*EnAlActionFunc)(struct EnAl* this, GlobalContext* globalCtx);
+typedef void (*EnAlActionFunc)(struct EnAl*, GlobalContext*);
 
 typedef struct EnAl {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Am/z_en_am.h
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.h
@@ -5,7 +5,7 @@
 
 struct EnAm;
 
-typedef void (*EnAmActionFunc)(struct EnAm* this, GlobalContext* globalCtx);
+typedef void (*EnAmActionFunc)(struct EnAm*, GlobalContext*);
 
 typedef struct EnAm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_An/z_en_an.h
+++ b/src/overlays/actors/ovl_En_An/z_en_an.h
@@ -5,7 +5,7 @@
 
 struct EnAn;
 
-typedef void (*EnAnActionFunc)(struct EnAn* this, GlobalContext* globalCtx);
+typedef void (*EnAnActionFunc)(struct EnAn*, GlobalContext*);
 
 typedef struct EnAn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_And/z_en_and.h
+++ b/src/overlays/actors/ovl_En_And/z_en_and.h
@@ -5,7 +5,7 @@
 
 struct EnAnd;
 
-typedef void (*EnAndActionFunc)(struct EnAnd* this, GlobalContext* globalCtx);
+typedef void (*EnAndActionFunc)(struct EnAnd*, GlobalContext*);
 
 typedef struct EnAnd {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.h
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.h
@@ -5,7 +5,7 @@
 
 struct EnAni;
 
-typedef void (*EnAniActionFunc)(struct EnAni* this, GlobalContext* globalCtx);
+typedef void (*EnAniActionFunc)(struct EnAni*, GlobalContext*);
 
 typedef struct EnAni {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.h
+++ b/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.h
@@ -5,7 +5,7 @@
 
 struct EnAob01;
 
-typedef void (*EnAob01ActionFunc)(struct EnAob01* this, GlobalContext* globalCtx);
+typedef void (*EnAob01ActionFunc)(struct EnAob01*, GlobalContext*);
 
 typedef struct EnAob01 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.h
@@ -5,7 +5,7 @@
 
 struct EnArrow;
 
-typedef void (*EnArrowActionFunc)(struct EnArrow* this, GlobalContext* globalCtx);
+typedef void (*EnArrowActionFunc)(struct EnArrow*, GlobalContext*);
 
 typedef struct EnArrow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.h
@@ -5,7 +5,7 @@
 
 struct EnAttackNiw;
 
-typedef void (*EnAttackNiwActionFunc)(struct EnAttackNiw* this, GlobalContext* globalCtx);
+typedef void (*EnAttackNiwActionFunc)(struct EnAttackNiw*, GlobalContext*);
 
 typedef struct EnAttackNiw {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Az/z_en_az.h
+++ b/src/overlays/actors/ovl_En_Az/z_en_az.h
@@ -5,7 +5,7 @@
 
 struct EnAz;
 
-typedef void (*EnAzActionFunc)(struct EnAz* this, GlobalContext* globalCtx);
+typedef void (*EnAzActionFunc)(struct EnAz*, GlobalContext*);
 
 typedef struct EnAz {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Baba/z_en_baba.h
+++ b/src/overlays/actors/ovl_En_Baba/z_en_baba.h
@@ -5,7 +5,7 @@
 
 struct EnBaba;
 
-typedef void (*EnBabaActionFunc)(struct EnBaba* this, GlobalContext* globalCtx);
+typedef void (*EnBabaActionFunc)(struct EnBaba*, GlobalContext*);
 
 typedef struct EnBaba {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Baguo/z_en_baguo.h
+++ b/src/overlays/actors/ovl_En_Baguo/z_en_baguo.h
@@ -5,7 +5,7 @@
 
 struct EnBaguo;
 
-typedef void (*EnBaguoActionFunc)(struct EnBaguo* this, GlobalContext* globalCtx);
+typedef void (*EnBaguoActionFunc)(struct EnBaguo*, GlobalContext*);
 
 typedef struct EnBaguo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bal/z_en_bal.h
+++ b/src/overlays/actors/ovl_En_Bal/z_en_bal.h
@@ -5,7 +5,7 @@
 
 struct EnBal;
 
-typedef void (*EnBalActionFunc)(struct EnBal* this, GlobalContext* globalCtx);
+typedef void (*EnBalActionFunc)(struct EnBal*, GlobalContext*);
 
 typedef struct EnBal {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bat/z_en_bat.h
+++ b/src/overlays/actors/ovl_En_Bat/z_en_bat.h
@@ -5,7 +5,7 @@
 
 struct EnBat;
 
-typedef void (*EnBatActionFunc)(struct EnBat* this, GlobalContext* globalCtx);
+typedef void (*EnBatActionFunc)(struct EnBat*, GlobalContext*);
 
 typedef struct EnBat {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.h
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.h
@@ -5,7 +5,7 @@
 
 struct EnBb;
 
-typedef void (*EnBbActionFunc)(struct EnBb* this, GlobalContext* globalCtx);
+typedef void (*EnBbActionFunc)(struct EnBb*, GlobalContext*);
 
 typedef struct EnBb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.h
+++ b/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.h
@@ -5,7 +5,7 @@
 
 struct EnBba01;
 
-typedef void (*EnBba01ActionFunc)(struct EnBba01* this, GlobalContext* globalCtx);
+typedef void (*EnBba01ActionFunc)(struct EnBba01*, GlobalContext*);
 
 typedef struct EnBba01 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.h
+++ b/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.h
@@ -5,7 +5,7 @@
 
 struct EnBbfall;
 
-typedef void (*EnBbfallActionFunc)(struct EnBbfall* this, GlobalContext* globalCtx);
+typedef void (*EnBbfallActionFunc)(struct EnBbfall*, GlobalContext*);
 
 typedef struct EnBbfall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bee/z_en_bee.h
+++ b/src/overlays/actors/ovl_En_Bee/z_en_bee.h
@@ -5,7 +5,7 @@
 
 struct EnBee;
 
-typedef void (*EnBeeActionFunc)(struct EnBee* this, GlobalContext* globalCtx);
+typedef void (*EnBeeActionFunc)(struct EnBee*, GlobalContext*);
 
 typedef struct EnBee {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bh/z_en_bh.h
+++ b/src/overlays/actors/ovl_En_Bh/z_en_bh.h
@@ -5,7 +5,7 @@
 
 struct EnBh;
 
-typedef void (*EnBhActionFunc)(struct EnBh* this, GlobalContext* globalCtx);
+typedef void (*EnBhActionFunc)(struct EnBh*, GlobalContext*);
 
 typedef struct EnBh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.h
@@ -5,7 +5,7 @@
 
 struct EnBigokuta;
 
-typedef void (*EnBigokutaActionFunc)(struct EnBigokuta* this, GlobalContext* globalCtx);
+typedef void (*EnBigokutaActionFunc)(struct EnBigokuta*, GlobalContext*);
 
 typedef struct EnBigokuta {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.h
+++ b/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.h
@@ -5,7 +5,7 @@
 
 struct EnBigpamet;
 
-typedef void (*EnBigpametActionFunc)(struct EnBigpamet* this, GlobalContext* globalCtx);
+typedef void (*EnBigpametActionFunc)(struct EnBigpamet*, GlobalContext*);
 
 typedef struct EnBigpamet {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.h
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.h
@@ -5,7 +5,7 @@
 
 struct EnBigpo;
 
-typedef void (*EnBigpoActionFunc)(struct EnBigpo* this, GlobalContext* globalCtx);
+typedef void (*EnBigpoActionFunc)(struct EnBigpo*, GlobalContext*);
 
 typedef struct EnBigpo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bjt/z_en_bjt.h
+++ b/src/overlays/actors/ovl_En_Bjt/z_en_bjt.h
@@ -5,7 +5,7 @@
 
 struct EnBjt;
 
-typedef void (*EnBjtActionFunc)(struct EnBjt* this, GlobalContext* globalCtx);
+typedef void (*EnBjtActionFunc)(struct EnBjt*, GlobalContext*);
 
 typedef struct EnBjt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.h
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.h
@@ -5,7 +5,7 @@
 
 struct EnBom;
 
-typedef void (*EnBomActionFunc)(struct EnBom* this, GlobalContext* globalCtx);
+typedef void (*EnBomActionFunc)(struct EnBom*, GlobalContext*);
 
 typedef struct EnBom {
     /* 0x000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.h
@@ -5,7 +5,7 @@
 
 struct EnBomBowlMan;
 
-typedef void (*EnBomBowlManActionFunc)(struct EnBomBowlMan* this, GlobalContext* globalCtx);
+typedef void (*EnBomBowlManActionFunc)(struct EnBomBowlMan*, GlobalContext*);
 
 typedef struct EnBomBowlMan {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.h
@@ -5,7 +5,7 @@
 
 struct EnBomChu;
 
-typedef void (*EnBomChuActionFunc)(struct EnBomChu* this, GlobalContext* globalCtx);
+typedef void (*EnBomChuActionFunc)(struct EnBomChu*, GlobalContext*);
 
 typedef struct EnBomChu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bombal/z_en_bombal.h
+++ b/src/overlays/actors/ovl_En_Bombal/z_en_bombal.h
@@ -5,7 +5,7 @@
 
 struct EnBombal;
 
-typedef void (*EnBombalActionFunc)(struct EnBombal* this, GlobalContext* globalCtx);
+typedef void (*EnBombalActionFunc)(struct EnBombal*, GlobalContext*);
 
 typedef struct EnBombal {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bombers/z_en_bombers.h
+++ b/src/overlays/actors/ovl_En_Bombers/z_en_bombers.h
@@ -5,7 +5,7 @@
 
 struct EnBombers;
 
-typedef void (*EnBombersActionFunc)(struct EnBombers* this, GlobalContext* globalCtx);
+typedef void (*EnBombersActionFunc)(struct EnBombers*, GlobalContext*);
 
 typedef struct EnBombers {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.h
+++ b/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.h
@@ -5,7 +5,7 @@
 
 struct EnBombers2;
 
-typedef void (*EnBombers2ActionFunc)(struct EnBombers2* this, GlobalContext* globalCtx);
+typedef void (*EnBombers2ActionFunc)(struct EnBombers2*, GlobalContext*);
 
 typedef struct EnBombers2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.h
@@ -5,7 +5,7 @@
 
 struct EnBombf;
 
-typedef void (*EnBombfActionFunc)(struct EnBombf* this, GlobalContext* globalCtx);
+typedef void (*EnBombfActionFunc)(struct EnBombf*, GlobalContext*);
 
 typedef struct EnBombf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
+++ b/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.h
@@ -5,7 +5,7 @@
 
 struct EnBomjima;
 
-typedef void (*EnBomjimaActionFunc)(struct EnBomjima* this, GlobalContext* globalCtx);
+typedef void (*EnBomjimaActionFunc)(struct EnBomjima*, GlobalContext*);
 
 typedef struct EnBomjima {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.h
+++ b/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.h
@@ -5,7 +5,7 @@
 
 struct EnBomjimb;
 
-typedef void (*EnBomjimbActionFunc)(struct EnBomjimb* this, GlobalContext* globalCtx);
+typedef void (*EnBomjimbActionFunc)(struct EnBomjimb*, GlobalContext*);
 
 typedef struct EnBomjimb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.h
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.h
@@ -5,7 +5,7 @@
 
 struct EnBoom;
 
-typedef void (*EnBoomActionFunc)(struct EnBoom* this, GlobalContext* globalCtx);
+typedef void (*EnBoomActionFunc)(struct EnBoom*, GlobalContext*);
 
 typedef struct EnBoom {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Box/z_en_box.h
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.h
@@ -5,7 +5,7 @@
 
 struct EnBox;
 
-typedef void (*EnBoxActionFunc)(struct EnBox* this, GlobalContext* globalCtx);
+typedef void (*EnBoxActionFunc)(struct EnBox*, GlobalContext*);
 
 typedef struct EnBox {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bsb/z_en_bsb.h
+++ b/src/overlays/actors/ovl_En_Bsb/z_en_bsb.h
@@ -5,7 +5,7 @@
 
 struct EnBsb;
 
-typedef void (*EnBsbActionFunc)(struct EnBsb* this, GlobalContext* globalCtx);
+typedef void (*EnBsbActionFunc)(struct EnBsb*, GlobalContext*);
 
 typedef struct EnBsb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.h
@@ -5,7 +5,7 @@
 
 struct EnBubble;
 
-typedef void (*EnBubbleActionFunc)(struct EnBubble* this, GlobalContext* globalCtx);
+typedef void (*EnBubbleActionFunc)(struct EnBubble*, GlobalContext*);
 
 typedef struct EnBubble {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.h
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.h
@@ -5,7 +5,7 @@
 
 struct EnButte;
 
-typedef void (*EnButteActionFunc)(struct EnButte* this, GlobalContext* globalCtx);
+typedef void (*EnButteActionFunc)(struct EnButte*, GlobalContext*);
 
 typedef struct EnButte {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.h
+++ b/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.h
@@ -5,7 +5,7 @@
 
 struct EnCne01;
 
-typedef void (*EnCne01ActionFunc)(struct EnCne01* this, GlobalContext* globalCtx);
+typedef void (*EnCne01ActionFunc)(struct EnCne01*, GlobalContext*);
 
 typedef struct EnCne01 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.h
+++ b/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.h
@@ -5,7 +5,7 @@
 
 struct EnColMan;
 
-typedef void (*EnColManActionFunc)(struct EnColMan* this, GlobalContext* globalCtx);
+typedef void (*EnColManActionFunc)(struct EnColMan*, GlobalContext*);
 
 typedef struct EnColMan {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.h
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.h
@@ -5,7 +5,7 @@
 
 struct EnCow;
 
-typedef void (*EnCowActionFunc)(struct EnCow* this, GlobalContext* globalCtx);
+typedef void (*EnCowActionFunc)(struct EnCow*, GlobalContext*);
 
 typedef struct EnCow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.h
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.h
@@ -5,7 +5,7 @@
 
 struct EnCrow;
 
-typedef void (*EnCrowActionFunc)(struct EnCrow* this, GlobalContext* globalCtx);
+typedef void (*EnCrowActionFunc)(struct EnCrow*, GlobalContext*);
 
 typedef struct EnCrow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dai/z_en_dai.h
+++ b/src/overlays/actors/ovl_En_Dai/z_en_dai.h
@@ -5,7 +5,7 @@
 
 struct EnDai;
 
-typedef void (*EnDaiActionFunc)(struct EnDai* this, GlobalContext* globalCtx);
+typedef void (*EnDaiActionFunc)(struct EnDai*, GlobalContext*);
 
 typedef struct EnDaiParticle {
     /* 0x00 */ u8 isEnabled;

--- a/src/overlays/actors/ovl_En_Death/z_en_death.h
+++ b/src/overlays/actors/ovl_En_Death/z_en_death.h
@@ -5,7 +5,7 @@
 
 struct EnDeath;
 
-typedef void (*EnDeathActionFunc)(struct EnDeath* this, GlobalContext* globalCtx);
+typedef void (*EnDeathActionFunc)(struct EnDeath*, GlobalContext*);
 
 typedef struct EnDeath {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.h
@@ -5,7 +5,7 @@
 
 struct EnDekubaba;
 
-typedef void (*EnDekubabaActionFunc)(struct EnDekubaba* this, GlobalContext* globalCtx);
+typedef void (*EnDekubabaActionFunc)(struct EnDekubaba*, GlobalContext*);
 
 typedef struct EnDekubaba {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.h
+++ b/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.h
@@ -5,7 +5,7 @@
 
 struct EnDemoheishi;
 
-typedef void (*EnDemoheishiActionFunc)(struct EnDemoheishi* this, GlobalContext* globalCtx);
+typedef void (*EnDemoheishiActionFunc)(struct EnDemoheishi*, GlobalContext*);
 
 typedef struct EnDemoheishi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dnh/z_en_dnh.h
+++ b/src/overlays/actors/ovl_En_Dnh/z_en_dnh.h
@@ -5,7 +5,7 @@
 
 struct EnDnh;
 
-typedef void (*EnDnhActionFunc)(struct EnDnh* this, GlobalContext* globalCtx);
+typedef void (*EnDnhActionFunc)(struct EnDnh*, GlobalContext*);
 
 typedef struct EnDnh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dnk/z_en_dnk.h
+++ b/src/overlays/actors/ovl_En_Dnk/z_en_dnk.h
@@ -5,7 +5,7 @@
 
 struct EnDnk;
 
-typedef void (*EnDnkActionFunc)(struct EnDnk* this, GlobalContext* globalCtx);
+typedef void (*EnDnkActionFunc)(struct EnDnk*, GlobalContext*);
 
 typedef struct EnDnk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dnq/z_en_dnq.h
+++ b/src/overlays/actors/ovl_En_Dnq/z_en_dnq.h
@@ -5,7 +5,7 @@
 
 struct EnDnq;
 
-typedef void (*EnDnqActionFunc)(struct EnDnq* this, GlobalContext* globalCtx);
+typedef void (*EnDnqActionFunc)(struct EnDnq*, GlobalContext*);
 
 typedef struct EnDnq {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.h
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.h
@@ -5,7 +5,7 @@
 
 struct EnDns;
 
-typedef void (*EnDnsActionFunc)(struct EnDns* this, GlobalContext* globalCtx);
+typedef void (*EnDnsActionFunc)(struct EnDns*, GlobalContext*);
 
 typedef struct EnDns {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.h
@@ -5,7 +5,7 @@
 
 struct EnDodongo;
 
-typedef void (*EnDodongoActionFunc)(struct EnDodongo* this, GlobalContext* globalCtx);
+typedef void (*EnDodongoActionFunc)(struct EnDodongo*, GlobalContext*);
 
 typedef struct EnDodongo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Door/z_en_door.h
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.h
@@ -5,7 +5,7 @@
 
 struct EnDoor;
 
-typedef void (*EnDoorActionFunc)(struct EnDoor* this, GlobalContext* globalCtx);
+typedef void (*EnDoorActionFunc)(struct EnDoor*, GlobalContext*);
 
 typedef struct EnDoor {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Door_Etc/z_en_door_etc.h
+++ b/src/overlays/actors/ovl_En_Door_Etc/z_en_door_etc.h
@@ -5,7 +5,7 @@
 
 struct EnDoorEtc;
 
-typedef void (*EnDoorEtcActionFunc)(struct EnDoorEtc* this, GlobalContext* globalCtx);
+typedef void (*EnDoorEtcActionFunc)(struct EnDoorEtc*, GlobalContext*);
 
 typedef struct EnDoorEtc {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dragon/z_en_dragon.h
+++ b/src/overlays/actors/ovl_En_Dragon/z_en_dragon.h
@@ -5,7 +5,7 @@
 
 struct EnDragon;
 
-typedef void (*EnDragonActionFunc)(struct EnDragon* this, GlobalContext* globalCtx);
+typedef void (*EnDragonActionFunc)(struct EnDragon*, GlobalContext*);
 
 typedef struct EnDragon {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Drs/z_en_drs.h
+++ b/src/overlays/actors/ovl_En_Drs/z_en_drs.h
@@ -5,7 +5,7 @@
 
 struct EnDrs;
 
-typedef void (*EnDrsActionFunc)(struct EnDrs* this, GlobalContext* globalCtx);
+typedef void (*EnDrsActionFunc)(struct EnDrs*, GlobalContext*);
 
 typedef struct EnDrs {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.h
+++ b/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.h
@@ -5,7 +5,7 @@
 
 struct EnDs2n;
 
-typedef void (*EnDs2nActionFunc)(struct EnDs2n* this, GlobalContext* globalCtx);
+typedef void (*EnDs2nActionFunc)(struct EnDs2n*, GlobalContext*);
 
 typedef struct EnDs2n {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Dt/z_en_dt.h
+++ b/src/overlays/actors/ovl_En_Dt/z_en_dt.h
@@ -5,7 +5,7 @@
 
 struct EnDt;
 
-typedef void (*EnDtActionFunc)(struct EnDt* this, GlobalContext* globalCtx);
+typedef void (*EnDtActionFunc)(struct EnDt*, GlobalContext*);
 
 typedef struct EnDt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Egblock/z_en_egblock.h
+++ b/src/overlays/actors/ovl_En_Egblock/z_en_egblock.h
@@ -5,7 +5,7 @@
 
 struct EnEgblock;
 
-typedef void (*EnEgblockActionFunc)(struct EnEgblock* this, GlobalContext* globalCtx);
+typedef void (*EnEgblockActionFunc)(struct EnEgblock*, GlobalContext*);
 
 typedef struct EnEgblock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Egol/z_en_egol.h
+++ b/src/overlays/actors/ovl_En_Egol/z_en_egol.h
@@ -5,7 +5,7 @@
 
 struct EnEgol;
 
-typedef void (*EnEgolActionFunc)(struct EnEgol* this, GlobalContext* globalCtx);
+typedef void (*EnEgolActionFunc)(struct EnEgol*, GlobalContext*);
 
 typedef struct EnEgol {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.h
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.h
@@ -5,7 +5,7 @@
 
 struct EnElf;
 
-typedef void (*EnElfActionFunc)(struct EnElf* this, GlobalContext* globalCtx);
+typedef void (*EnElfActionFunc)(struct EnElf*, GlobalContext*);
 
 typedef struct EnElf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Elfbub/z_en_elfbub.h
+++ b/src/overlays/actors/ovl_En_Elfbub/z_en_elfbub.h
@@ -5,7 +5,7 @@
 
 struct EnElfbub;
 
-typedef void (*EnElfbubActionFunc)(struct EnElfbub* this, GlobalContext* globalCtx);
+typedef void (*EnElfbubActionFunc)(struct EnElfbub*, GlobalContext*);
 
 typedef struct EnElfbub {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.h
+++ b/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.h
@@ -5,7 +5,7 @@
 
 struct EnElfgrp;
 
-typedef void (*EnElfgrpActionFunc)(struct EnElfgrp* this, GlobalContext* globalCtx);
+typedef void (*EnElfgrpActionFunc)(struct EnElfgrp*, GlobalContext*);
 
 typedef struct EnElfgrp {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Elforg/z_en_elforg.h
+++ b/src/overlays/actors/ovl_En_Elforg/z_en_elforg.h
@@ -5,7 +5,7 @@
 
 struct EnElforg;
 
-typedef void (*EnElforgActionFunc)(struct EnElforg* this, GlobalContext* globalCtx);
+typedef void (*EnElforgActionFunc)(struct EnElforg*, GlobalContext*);
 
 typedef struct EnElforg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
@@ -5,7 +5,7 @@
 
 struct EnEncount1;
 
-typedef void (*EnEncount1ActionFunc)(struct EnEncount1* this, GlobalContext* globalCtx);
+typedef void (*EnEncount1ActionFunc)(struct EnEncount1*, GlobalContext*);
 
 typedef struct EnEncount1 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Encount3/z_en_encount3.h
+++ b/src/overlays/actors/ovl_En_Encount3/z_en_encount3.h
@@ -5,7 +5,7 @@
 
 struct EnEncount3;
 
-typedef void (*EnEncount3ActionFunc)(struct EnEncount3* this, GlobalContext* globalCtx);
+typedef void (*EnEncount3ActionFunc)(struct EnEncount3*, GlobalContext*);
 
 typedef struct EnEncount3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Encount4/z_en_encount4.h
+++ b/src/overlays/actors/ovl_En_Encount4/z_en_encount4.h
@@ -5,7 +5,7 @@
 
 struct EnEncount4;
 
-typedef void (*EnEncount4ActionFunc)(struct EnEncount4* this, GlobalContext* globalCtx);
+typedef void (*EnEncount4ActionFunc)(struct EnEncount4*, GlobalContext*);
 
 typedef struct EnEncount4 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ending_Hero6/z_en_ending_hero6.h
+++ b/src/overlays/actors/ovl_En_Ending_Hero6/z_en_ending_hero6.h
@@ -5,7 +5,7 @@
 
 struct EnEndingHero6;
 
-typedef void (*EnEndingHero6ActionFunc)(struct EnEndingHero6* this, GlobalContext* globalCtx);
+typedef void (*EnEndingHero6ActionFunc)(struct EnEndingHero6*, GlobalContext*);
 
 typedef struct EnEndingHero6 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Estone/z_en_estone.h
+++ b/src/overlays/actors/ovl_En_Estone/z_en_estone.h
@@ -5,7 +5,7 @@
 
 struct EnEstone;
 
-typedef void (*EnEstoneActionFunc)(struct EnEstone* this, GlobalContext* globalCtx);
+typedef void (*EnEstoneActionFunc)(struct EnEstone*, GlobalContext*);
 
 typedef struct EnEstone {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fall/z_en_fall.h
+++ b/src/overlays/actors/ovl_En_Fall/z_en_fall.h
@@ -5,7 +5,7 @@
 
 struct EnFall;
 
-typedef void (*EnFallActionFunc)(struct EnFall* this, GlobalContext* globalCtx);
+typedef void (*EnFallActionFunc)(struct EnFall*, GlobalContext*);
 
 typedef struct EnFall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fall2/z_en_fall2.h
+++ b/src/overlays/actors/ovl_En_Fall2/z_en_fall2.h
@@ -5,7 +5,7 @@
 
 struct EnFall2;
 
-typedef void (*EnFall2ActionFunc)(struct EnFall2* this, GlobalContext* globalCtx);
+typedef void (*EnFall2ActionFunc)(struct EnFall2*, GlobalContext*);
 
 typedef struct EnFall2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Famos/z_en_famos.h
+++ b/src/overlays/actors/ovl_En_Famos/z_en_famos.h
@@ -5,7 +5,7 @@
 
 struct EnFamos;
 
-typedef void (*EnFamosActionFunc)(struct EnFamos* this, GlobalContext* globalCtx);
+typedef void (*EnFamosActionFunc)(struct EnFamos*, GlobalContext*);
 
 typedef struct EnFamos {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fish2/z_en_fish2.h
+++ b/src/overlays/actors/ovl_En_Fish2/z_en_fish2.h
@@ -5,7 +5,7 @@
 
 struct EnFish2;
 
-typedef void (*EnFish2ActionFunc)(struct EnFish2* this, GlobalContext* globalCtx);
+typedef void (*EnFish2ActionFunc)(struct EnFish2*, GlobalContext*);
 
 typedef struct EnFish2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.h
@@ -5,7 +5,7 @@
 
 struct EnFloormas;
 
-typedef void (*EnFloormasActionFunc)(struct EnFloormas* this, GlobalContext* globalCtx);
+typedef void (*EnFloormasActionFunc)(struct EnFloormas*, GlobalContext*);
 
 typedef struct EnFloormas {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.h
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.h
@@ -5,7 +5,7 @@
 
 struct EnFu;
 
-typedef void (*EnFuActionFunc)(struct EnFu* this, GlobalContext* globalCtx);
+typedef void (*EnFuActionFunc)(struct EnFu*, GlobalContext*);
 
 typedef struct EnFu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fu_Kago/z_en_fu_kago.h
+++ b/src/overlays/actors/ovl_En_Fu_Kago/z_en_fu_kago.h
@@ -5,7 +5,7 @@
 
 struct EnFuKago;
 
-typedef void (*EnFuKagoActionFunc)(struct EnFuKago* this, GlobalContext* globalCtx);
+typedef void (*EnFuKagoActionFunc)(struct EnFuKago*, GlobalContext*);
 
 typedef struct EnFuKago {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Fu_Mato/z_en_fu_mato.h
+++ b/src/overlays/actors/ovl_En_Fu_Mato/z_en_fu_mato.h
@@ -5,7 +5,7 @@
 
 struct EnFuMato;
 
-typedef void (*EnFuMatoActionFunc)(struct EnFuMato* this, GlobalContext* globalCtx);
+typedef void (*EnFuMatoActionFunc)(struct EnFuMato*, GlobalContext*);
 
 typedef struct EnFuMato {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.h
+++ b/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.h
@@ -5,7 +5,7 @@
 
 struct EnGakufu;
 
-typedef void (*EnGakufuActionFunc)(struct EnGakufu* this, GlobalContext* globalCtx);
+typedef void (*EnGakufuActionFunc)(struct EnGakufu*, GlobalContext*);
 
 typedef struct EnGakufu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.h
+++ b/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.h
@@ -5,7 +5,7 @@
 
 struct EnGamelupy;
 
-typedef void (*EnGamelupyActionFunc)(struct EnGamelupy* this, GlobalContext* globalCtx);
+typedef void (*EnGamelupyActionFunc)(struct EnGamelupy*, GlobalContext*);
 
 typedef struct EnGamelupy {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gb2/z_en_gb2.h
+++ b/src/overlays/actors/ovl_En_Gb2/z_en_gb2.h
@@ -5,7 +5,7 @@
 
 struct EnGb2;
 
-typedef void (*EnGb2ActionFunc)(struct EnGb2* this, GlobalContext* globalCtx);
+typedef void (*EnGb2ActionFunc)(struct EnGb2*, GlobalContext*);
 
 typedef struct EnGb2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.h
@@ -5,7 +5,7 @@
 
 struct EnGe1;
 
-typedef void (*EnGe1ActionFunc)(struct EnGe1* this, GlobalContext* globalCtx);
+typedef void (*EnGe1ActionFunc)(struct EnGe1*, GlobalContext*);
 
 typedef struct EnGe1 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.h
@@ -5,7 +5,7 @@
 
 struct EnGe2;
 
-typedef void (*EnGe2ActionFunc)(struct EnGe2* this, GlobalContext* globalCtx);
+typedef void (*EnGe2ActionFunc)(struct EnGe2*, GlobalContext*);
 
 typedef struct EnGe2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.h
@@ -5,7 +5,7 @@
 
 struct EnGe3;
 
-typedef void (*EnGe3ActionFunc)(struct EnGe3* this, GlobalContext* globalCtx);
+typedef void (*EnGe3ActionFunc)(struct EnGe3*, GlobalContext*);
 
 typedef struct EnGe3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Geg/z_en_geg.h
+++ b/src/overlays/actors/ovl_En_Geg/z_en_geg.h
@@ -5,7 +5,7 @@
 
 struct EnGeg;
 
-typedef void (*EnGegActionFunc)(struct EnGeg* this, GlobalContext* globalCtx);
+typedef void (*EnGegActionFunc)(struct EnGeg*, GlobalContext*);
 
 typedef struct EnGeg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gg/z_en_gg.h
+++ b/src/overlays/actors/ovl_En_Gg/z_en_gg.h
@@ -5,7 +5,7 @@
 
 struct EnGg;
 
-typedef void (*EnGgActionFunc)(struct EnGg* this, GlobalContext* globalCtx);
+typedef void (*EnGgActionFunc)(struct EnGg*, GlobalContext*);
 
 typedef struct EnGg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gg2/z_en_gg2.h
+++ b/src/overlays/actors/ovl_En_Gg2/z_en_gg2.h
@@ -5,7 +5,7 @@
 
 struct EnGg2;
 
-typedef void (*EnGg2ActionFunc)(struct EnGg2* this, GlobalContext* globalCtx);
+typedef void (*EnGg2ActionFunc)(struct EnGg2*, GlobalContext*);
 
 typedef struct EnGg2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Giant/z_en_giant.h
+++ b/src/overlays/actors/ovl_En_Giant/z_en_giant.h
@@ -5,7 +5,7 @@
 
 struct EnGiant;
 
-typedef void (*EnGiantActionFunc)(struct EnGiant* this, GlobalContext* globalCtx);
+typedef void (*EnGiantActionFunc)(struct EnGiant*, GlobalContext*);
 
 typedef struct EnGiant {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gk/z_en_gk.h
+++ b/src/overlays/actors/ovl_En_Gk/z_en_gk.h
@@ -5,7 +5,7 @@
 
 struct EnGk;
 
-typedef void (*EnGkActionFunc)(struct EnGk* this, GlobalContext* globalCtx);
+typedef void (*EnGkActionFunc)(struct EnGk*, GlobalContext*);
 
 typedef struct EnGk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.h
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.h
@@ -5,7 +5,7 @@
 
 struct EnGm;
 
-typedef void (*EnGmActionFunc)(struct EnGm* this, GlobalContext* globalCtx);
+typedef void (*EnGmActionFunc)(struct EnGm*, GlobalContext*);
 
 typedef struct EnGm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.h
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.h
@@ -5,7 +5,7 @@
 
 struct EnGo;
 
-typedef void (*EnGoActionFunc)(struct EnGo* this, GlobalContext* globalCtx);
+typedef void (*EnGoActionFunc)(struct EnGo*, GlobalContext*);
 
 typedef struct EnGo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.h
@@ -5,7 +5,7 @@
 
 struct EnGoroiwa;
 
-typedef void (*EnGoroiwaActionFunc)(struct EnGoroiwa* this, GlobalContext* globalCtx);
+typedef void (*EnGoroiwaActionFunc)(struct EnGoroiwa*, GlobalContext*);
 
 typedef struct EnGoroiwa {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.h
+++ b/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.h
@@ -5,7 +5,7 @@
 
 struct EnGrasshopper;
 
-typedef void (*EnGrasshopperActionFunc)(struct EnGrasshopper* this, GlobalContext* globalCtx);
+typedef void (*EnGrasshopperActionFunc)(struct EnGrasshopper*, GlobalContext*);
 
 typedef struct EnGrasshopper {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.h
+++ b/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.h
@@ -5,7 +5,7 @@
 
 struct EnGuardNuts;
 
-typedef void (*EnGuardNutsActionFunc)(struct EnGuardNuts* this, GlobalContext* globalCtx);
+typedef void (*EnGuardNutsActionFunc)(struct EnGuardNuts*, GlobalContext*);
 
 typedef struct EnGuardNuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.h
+++ b/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.h
@@ -5,7 +5,7 @@
 
 struct EnHakurock;
 
-typedef void (*EnHakurockActionFunc)(struct EnHakurock* this, GlobalContext* globalCtx);
+typedef void (*EnHakurockActionFunc)(struct EnHakurock*, GlobalContext*);
 
 typedef struct EnHakurock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hanabi/z_en_hanabi.h
+++ b/src/overlays/actors/ovl_En_Hanabi/z_en_hanabi.h
@@ -5,7 +5,7 @@
 
 struct EnHanabi;
 
-typedef void (*EnHanabiActionFunc)(struct EnHanabi* this, GlobalContext* globalCtx);
+typedef void (*EnHanabiActionFunc)(struct EnHanabi*, GlobalContext*);
 
 typedef struct EnHanabi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Heishi/z_en_heishi.h
+++ b/src/overlays/actors/ovl_En_Heishi/z_en_heishi.h
@@ -5,7 +5,7 @@
 
 struct EnHeishi;
 
-typedef void (*EnHeishiActionFunc)(struct EnHeishi* this, GlobalContext* globalCtx);
+typedef void (*EnHeishiActionFunc)(struct EnHeishi*, GlobalContext*);
 
 typedef struct EnHeishi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hgo/z_en_hgo.h
+++ b/src/overlays/actors/ovl_En_Hgo/z_en_hgo.h
@@ -5,7 +5,7 @@
 
 struct EnHgo;
 
-typedef void (*EnHgoActionFunc)(struct EnHgo* this, GlobalContext* globalCtx);
+typedef void (*EnHgoActionFunc)(struct EnHgo*, GlobalContext*);
 
 typedef struct EnHgo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.h
+++ b/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.h
@@ -5,7 +5,7 @@
 
 struct EnHiddenNuts;
 
-typedef void (*EnHiddenNutsActionFunc)(struct EnHiddenNuts* this, GlobalContext* globalCtx);
+typedef void (*EnHiddenNutsActionFunc)(struct EnHiddenNuts*, GlobalContext*);
 
 typedef struct EnHiddenNuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.h
+++ b/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.h
@@ -5,7 +5,7 @@
 
 struct EnHintSkb;
 
-typedef void (*EnHintSkbActionFunc)(struct EnHintSkb* this, GlobalContext* globalCtx);
+typedef void (*EnHintSkbActionFunc)(struct EnHintSkb*, GlobalContext*);
 
 typedef struct EnHintSkb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hit_Tag/z_en_hit_tag.h
+++ b/src/overlays/actors/ovl_En_Hit_Tag/z_en_hit_tag.h
@@ -5,7 +5,7 @@
 
 struct EnHitTag;
 
-typedef void (*EnHitTagActionFunc)(struct EnHitTag* this, GlobalContext* globalCtx);
+typedef void (*EnHitTagActionFunc)(struct EnHitTag*, GlobalContext*);
 
 typedef struct EnHitTag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.h
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.h
@@ -5,7 +5,7 @@
 
 struct EnHoll;
 
-typedef void (*EnHollActionFunc)(struct EnHoll* this, GlobalContext* globalCtx);
+typedef void (*EnHollActionFunc)(struct EnHoll*, GlobalContext*);
 
 typedef struct EnHoll {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.h
@@ -5,7 +5,7 @@
 
 struct EnHonotrap;
 
-typedef void (*EnHonotrapActionFunc)(struct EnHonotrap* this, GlobalContext* globalCtx);
+typedef void (*EnHonotrapActionFunc)(struct EnHonotrap*, GlobalContext*);
 
 typedef struct EnHonotrap {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.h
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.h
@@ -5,7 +5,7 @@
 
 struct EnHs;
 
-typedef void (*EnHsActionFunc)(struct EnHs* this, GlobalContext* globalCtx);
+typedef void (*EnHsActionFunc)(struct EnHs*, GlobalContext*);
 
 typedef struct EnHs {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ig/z_en_ig.h
+++ b/src/overlays/actors/ovl_En_Ig/z_en_ig.h
@@ -5,7 +5,7 @@
 
 struct EnIg;
 
-typedef void (*EnIgActionFunc)(struct EnIg* this, GlobalContext* globalCtx);
+typedef void (*EnIgActionFunc)(struct EnIg*, GlobalContext*);
 
 typedef struct EnIg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.h
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.h
@@ -5,7 +5,7 @@
 
 struct EnIk;
 
-typedef void (*EnIkActionFunc)(struct EnIk* this, GlobalContext* globalCtx);
+typedef void (*EnIkActionFunc)(struct EnIk*, GlobalContext*);
 
 typedef struct EnIk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.h
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.h
@@ -5,7 +5,7 @@
 
 struct EnInsect;
 
-typedef void (*EnInsectActionFunc)(struct EnInsect* this, GlobalContext* globalCtx);
+typedef void (*EnInsectActionFunc)(struct EnInsect*, GlobalContext*);
 
 typedef struct EnInsect {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Invadepoh_Demo/z_en_invadepoh_demo.h
+++ b/src/overlays/actors/ovl_En_Invadepoh_Demo/z_en_invadepoh_demo.h
@@ -5,7 +5,7 @@
 
 struct EnInvadepohDemo;
 
-typedef void (*EnInvadepohDemoActionFunc)(struct EnInvadepohDemo* this, GlobalContext* globalCtx);
+typedef void (*EnInvadepohDemoActionFunc)(struct EnInvadepohDemo*, GlobalContext*);
 
 typedef struct EnInvadepohDemo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Invisible_Ruppe/z_en_invisible_ruppe.h
+++ b/src/overlays/actors/ovl_En_Invisible_Ruppe/z_en_invisible_ruppe.h
@@ -5,7 +5,7 @@
 
 struct EnInvisibleRuppe;
 
-typedef void (*EnInvisibleRuppeActionFunc)(struct EnInvisibleRuppe* this, GlobalContext* globalCtx);
+typedef void (*EnInvisibleRuppeActionFunc)(struct EnInvisibleRuppe*, GlobalContext*);
 
 typedef struct EnInvisibleRuppe {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.h
@@ -5,7 +5,7 @@
 
 struct EnIshi;
 
-typedef void (*EnIshiActionFunc)(struct EnIshi* this, GlobalContext* globalCtx);
+typedef void (*EnIshiActionFunc)(struct EnIshi*, GlobalContext*);
 
 typedef struct EnIshi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ja/z_en_ja.h
+++ b/src/overlays/actors/ovl_En_Ja/z_en_ja.h
@@ -5,7 +5,7 @@
 
 struct EnJa;
 
-typedef void (*EnJaActionFunc)(struct EnJa* this, GlobalContext* globalCtx);
+typedef void (*EnJaActionFunc)(struct EnJa*, GlobalContext*);
 
 typedef struct EnJa {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Jg/z_en_jg.h
+++ b/src/overlays/actors/ovl_En_Jg/z_en_jg.h
@@ -5,7 +5,7 @@
 
 struct EnJg;
 
-typedef void (*EnJgActionFunc)(struct EnJg* this, GlobalContext* globalCtx);
+typedef void (*EnJgActionFunc)(struct EnJg*, GlobalContext*);
 
 typedef struct EnJg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.h
+++ b/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.h
@@ -5,7 +5,7 @@
 
 struct EnJgameTsn;
 
-typedef void (*EnJgameTsnActionFunc)(struct EnJgameTsn* this, GlobalContext* globalCtx);
+typedef void (*EnJgameTsnActionFunc)(struct EnJgameTsn*, GlobalContext*);
 
 typedef struct EnJgameTsn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Js/z_en_js.h
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.h
@@ -5,7 +5,7 @@
 
 struct EnJs;
 
-typedef void (*EnJsActionFunc)(struct EnJs* this, GlobalContext* globalCtx);
+typedef void (*EnJsActionFunc)(struct EnJs*, GlobalContext*);
 
 typedef struct EnJs {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Jso/z_en_jso.h
+++ b/src/overlays/actors/ovl_En_Jso/z_en_jso.h
@@ -5,7 +5,7 @@
 
 struct EnJso;
 
-typedef void (*EnJsoActionFunc)(struct EnJso* this, GlobalContext* globalCtx);
+typedef void (*EnJsoActionFunc)(struct EnJso*, GlobalContext*);
 
 typedef struct EnJso {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Jso2/z_en_jso2.h
+++ b/src/overlays/actors/ovl_En_Jso2/z_en_jso2.h
@@ -5,7 +5,7 @@
 
 struct EnJso2;
 
-typedef void (*EnJso2ActionFunc)(struct EnJso2* this, GlobalContext* globalCtx);
+typedef void (*EnJso2ActionFunc)(struct EnJso2*, GlobalContext*);
 
 typedef struct EnJso2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kaizoku/z_en_kaizoku.h
+++ b/src/overlays/actors/ovl_En_Kaizoku/z_en_kaizoku.h
@@ -5,7 +5,7 @@
 
 struct EnKaizoku;
 
-typedef void (*EnKaizokuActionFunc)(struct EnKaizoku* this, GlobalContext* globalCtx);
+typedef void (*EnKaizokuActionFunc)(struct EnKaizoku*, GlobalContext*);
 
 typedef struct EnKaizoku {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.h
@@ -5,7 +5,7 @@
 
 struct EnKakasi;
 
-typedef void (*EnKakasiActionFunc)(struct EnKakasi* this, GlobalContext* globalCtx);
+typedef void (*EnKakasiActionFunc)(struct EnKakasi*, GlobalContext*);
 
 typedef struct EnKakasi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kame/z_en_kame.h
+++ b/src/overlays/actors/ovl_En_Kame/z_en_kame.h
@@ -5,7 +5,7 @@
 
 struct EnKame;
 
-typedef void (*EnKameActionFunc)(struct EnKame* this, GlobalContext* globalCtx);
+typedef void (*EnKameActionFunc)(struct EnKame*, GlobalContext*);
 
 typedef struct EnKame {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.h
@@ -5,7 +5,7 @@
 
 struct EnKarebaba;
 
-typedef void (*EnKarebabaActionFunc)(struct EnKarebaba* this, GlobalContext* globalCtx);
+typedef void (*EnKarebabaActionFunc)(struct EnKarebaba*, GlobalContext*);
 
 typedef struct EnKarebaba {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kbt/z_en_kbt.h
+++ b/src/overlays/actors/ovl_En_Kbt/z_en_kbt.h
@@ -5,7 +5,7 @@
 
 struct EnKbt;
 
-typedef void (*EnKbtActionFunc)(struct EnKbt* this, GlobalContext* globalCtx);
+typedef void (*EnKbtActionFunc)(struct EnKbt*, GlobalContext*);
 
 typedef struct EnKbt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.h
+++ b/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.h
@@ -5,7 +5,7 @@
 
 struct EnKendoJs;
 
-typedef void (*EnKendoJsActionFunc)(struct EnKendoJs* this, GlobalContext* globalCtx);
+typedef void (*EnKendoJsActionFunc)(struct EnKendoJs*, GlobalContext*);
 
 typedef struct EnKendoJs {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kgy/z_en_kgy.h
+++ b/src/overlays/actors/ovl_En_Kgy/z_en_kgy.h
@@ -5,7 +5,7 @@
 
 struct EnKgy;
 
-typedef void (*EnKgyActionFunc)(struct EnKgy* this, GlobalContext* globalCtx);
+typedef void (*EnKgyActionFunc)(struct EnKgy*, GlobalContext*);
 
 typedef struct EnKgy {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kitan/z_en_kitan.h
+++ b/src/overlays/actors/ovl_En_Kitan/z_en_kitan.h
@@ -5,7 +5,7 @@
 
 struct EnKitan;
 
-typedef void (*EnKitanActionFunc)(struct EnKitan* this, GlobalContext* globalCtx);
+typedef void (*EnKitanActionFunc)(struct EnKitan*, GlobalContext*);
 
 typedef struct EnKitan {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Knight/z_en_knight.h
+++ b/src/overlays/actors/ovl_En_Knight/z_en_knight.h
@@ -5,7 +5,7 @@
 
 struct EnKnight;
 
-typedef void (*EnKnightActionFunc)(struct EnKnight* this, GlobalContext* globalCtx);
+typedef void (*EnKnightActionFunc)(struct EnKnight*, GlobalContext*);
 
 typedef struct EnKnight {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.h
+++ b/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.h
@@ -5,7 +5,7 @@
 
 struct EnKujiya;
 
-typedef void (*EnKujiyaActionFunc)(struct EnKujiya* this, GlobalContext* globalCtx);
+typedef void (*EnKujiyaActionFunc)(struct EnKujiya*, GlobalContext*);
 
 typedef struct EnKujiya {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.h
@@ -5,7 +5,7 @@
 
 struct EnKusa;
 
-typedef void (*EnKusaActionFunc)(struct EnKusa* this, GlobalContext* globalCtx);
+typedef void (*EnKusaActionFunc)(struct EnKusa*, GlobalContext*);
 
 typedef struct EnKusa {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.h
+++ b/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.h
@@ -5,7 +5,7 @@
 
 struct EnKusa2;
 
-typedef void (*EnKusa2ActionFunc)(struct EnKusa2* this, GlobalContext* globalCtx);
+typedef void (*EnKusa2ActionFunc)(struct EnKusa2*, GlobalContext*);
 
 typedef struct EnKusa2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.h
+++ b/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.h
@@ -5,7 +5,7 @@
 
 struct EnLiftNuts;
 
-typedef void (*EnLiftNutsActionFunc)(struct EnLiftNuts* this, GlobalContext* globalCtx);
+typedef void (*EnLiftNutsActionFunc)(struct EnLiftNuts*, GlobalContext*);
 
 typedef struct EnLiftNuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Look_Nuts/z_en_look_nuts.h
+++ b/src/overlays/actors/ovl_En_Look_Nuts/z_en_look_nuts.h
@@ -5,7 +5,7 @@
 
 struct EnLookNuts;
 
-typedef void (*EnLookNutsActionFunc)(struct EnLookNuts* this, GlobalContext* globalCtx);
+typedef void (*EnLookNutsActionFunc)(struct EnLookNuts*, GlobalContext*);
 
 typedef struct EnLookNuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.h
@@ -5,7 +5,7 @@
 
 struct EnMThunder;
 
-typedef void (*EnMThunderActionFunc)(struct EnMThunder* this, GlobalContext* globalCtx);
+typedef void (*EnMThunderActionFunc)(struct EnMThunder*, GlobalContext*);
 
 typedef struct EnMThunder {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Maruta/z_en_maruta.h
+++ b/src/overlays/actors/ovl_En_Maruta/z_en_maruta.h
@@ -5,7 +5,7 @@
 
 struct EnMaruta;
 
-typedef void (*EnMarutaActionFunc)(struct EnMaruta* this, GlobalContext* globalCtx);
+typedef void (*EnMarutaActionFunc)(struct EnMaruta*, GlobalContext*);
 
 typedef struct EnMaruta {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Minideath/z_en_minideath.h
+++ b/src/overlays/actors/ovl_En_Minideath/z_en_minideath.h
@@ -5,7 +5,7 @@
 
 struct EnMinideath;
 
-typedef void (*EnMinideathActionFunc)(struct EnMinideath* this, GlobalContext* globalCtx);
+typedef void (*EnMinideathActionFunc)(struct EnMinideath*, GlobalContext*);
 
 typedef struct EnMinideath {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.h
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.h
@@ -5,7 +5,7 @@
 
 struct EnMk;
 
-typedef void (*EnMkActionFunc)(struct EnMk* this, GlobalContext* globalCtx);
+typedef void (*EnMkActionFunc)(struct EnMk*, GlobalContext*);
 
 typedef struct EnMk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mkk/z_en_mkk.h
+++ b/src/overlays/actors/ovl_En_Mkk/z_en_mkk.h
@@ -5,7 +5,7 @@
 
 struct EnMkk;
 
-typedef void (*EnMkkActionFunc)(struct EnMkk* this, GlobalContext* globalCtx);
+typedef void (*EnMkkActionFunc)(struct EnMkk*, GlobalContext*);
 
 typedef struct EnMkk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.h
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.h
@@ -5,7 +5,7 @@
 
 struct EnMm;
 
-typedef void (*EnMmActionFunc)(struct EnMm* this, GlobalContext* globalCtx);
+typedef void (*EnMmActionFunc)(struct EnMm*, GlobalContext*);
 
 typedef struct EnMm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.h
@@ -5,7 +5,7 @@
 
 struct EnMm2;
 
-typedef void (*EnMm2ActionFunc)(struct EnMm2* this, GlobalContext* globalCtx);
+typedef void (*EnMm2ActionFunc)(struct EnMm2*, GlobalContext*);
 
 typedef struct EnMm2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mm3/z_en_mm3.h
+++ b/src/overlays/actors/ovl_En_Mm3/z_en_mm3.h
@@ -5,7 +5,7 @@
 
 struct EnMm3;
 
-typedef void (*EnMm3ActionFunc)(struct EnMm3* this, GlobalContext* globalCtx);
+typedef void (*EnMm3ActionFunc)(struct EnMm3*, GlobalContext*);
 
 typedef struct EnMm3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mnk/z_en_mnk.h
+++ b/src/overlays/actors/ovl_En_Mnk/z_en_mnk.h
@@ -5,7 +5,7 @@
 
 struct EnMnk;
 
-typedef void (*EnMnkActionFunc)(struct EnMnk* this, GlobalContext* globalCtx);
+typedef void (*EnMnkActionFunc)(struct EnMnk*, GlobalContext*);
 
 typedef struct EnMnk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.h
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.h
@@ -5,7 +5,7 @@
 
 struct EnMs;
 
-typedef void (*EnMsActionFunc)(struct EnMs* this, GlobalContext* globalCtx);
+typedef void (*EnMsActionFunc)(struct EnMs*, GlobalContext*);
 
 typedef struct EnMs {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.h
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.h
@@ -5,7 +5,7 @@
 
 struct EnMttag;
 
-typedef void (*EnMttagActionFunc)(struct EnMttag* this, GlobalContext* globalCtx);
+typedef void (*EnMttagActionFunc)(struct EnMttag*, GlobalContext*);
 
 typedef struct EnMttag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.h
+++ b/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.h
@@ -5,7 +5,7 @@
 
 struct EnMushi2;
 
-typedef void (*EnMushi2ActionFunc)(struct EnMushi2* this, GlobalContext* globalCtx);
+typedef void (*EnMushi2ActionFunc)(struct EnMushi2*, GlobalContext*);
 
 typedef struct EnMushi2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Muto/z_en_muto.h
+++ b/src/overlays/actors/ovl_En_Muto/z_en_muto.h
@@ -5,7 +5,7 @@
 
 struct EnMuto;
 
-typedef void (*EnMutoActionFunc)(struct EnMuto* this, GlobalContext* globalCtx);
+typedef void (*EnMutoActionFunc)(struct EnMuto*, GlobalContext*);
 
 typedef struct EnMuto {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.h
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.h
@@ -5,7 +5,7 @@
 
 struct EnNb;
 
-typedef void (*EnNbActionFunc)(struct EnNb* this, GlobalContext* globalCtx);
+typedef void (*EnNbActionFunc)(struct EnNb*, GlobalContext*);
 
 typedef struct EnNb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.h
+++ b/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.h
@@ -5,7 +5,7 @@
 
 struct EnNeoReeba;
 
-typedef void (*EnNeoReebaActionFunc)(struct EnNeoReeba* this, GlobalContext* globalCtx);
+typedef void (*EnNeoReebaActionFunc)(struct EnNeoReeba*, GlobalContext*);
 
 typedef struct EnNeoReeba {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.h
@@ -5,7 +5,7 @@
 
 struct EnNwc;
 
-typedef void (*EnNwcActionFunc)(struct EnNwc* this, GlobalContext* globalCtx);
+typedef void (*EnNwcActionFunc)(struct EnNwc*, GlobalContext*);
 
 typedef struct EnNwc {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.h
@@ -5,7 +5,7 @@
 
 struct EnOkarinaTag;
 
-typedef void (*EnOkarinaTagActionFunc)(struct EnOkarinaTag* this, GlobalContext* globalCtx);
+typedef void (*EnOkarinaTagActionFunc)(struct EnOkarinaTag*, GlobalContext*);
 
 typedef struct EnOkarinaTag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.h
@@ -5,7 +5,7 @@
 
 struct EnOkuta;
 
-typedef void (*EnOkutaActionFunc)(struct EnOkuta* this, GlobalContext* globalCtx);
+typedef void (*EnOkutaActionFunc)(struct EnOkuta*, GlobalContext*);
 
 typedef struct EnOkuta {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.h
+++ b/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.h
@@ -5,7 +5,7 @@
 
 struct EnOnpuman;
 
-typedef void (*EnOnpumanActionFunc)(struct EnOnpuman* this, GlobalContext* globalCtx);
+typedef void (*EnOnpumanActionFunc)(struct EnOnpuman*, GlobalContext*);
 
 typedef struct EnOnpuman {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Osk/z_en_osk.h
+++ b/src/overlays/actors/ovl_En_Osk/z_en_osk.h
@@ -5,7 +5,7 @@
 
 struct EnOsk;
 
-typedef void (*EnOskActionFunc)(struct EnOsk* this, GlobalContext* globalCtx);
+typedef void (*EnOskActionFunc)(struct EnOsk*, GlobalContext*);
 
 typedef struct EnOsk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Osn/z_en_osn.h
+++ b/src/overlays/actors/ovl_En_Osn/z_en_osn.h
@@ -5,7 +5,7 @@
 
 struct EnOsn;
 
-typedef void (*EnOsnActionFunc)(struct EnOsn* this, GlobalContext* globalCtx);
+typedef void (*EnOsnActionFunc)(struct EnOsn*, GlobalContext*);
 
 typedef struct EnOsn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ot/z_en_ot.h
+++ b/src/overlays/actors/ovl_En_Ot/z_en_ot.h
@@ -5,7 +5,7 @@
 
 struct EnOt;
 
-typedef void (*EnOtActionFunc)(struct EnOt* this, GlobalContext* globalCtx);
+typedef void (*EnOtActionFunc)(struct EnOt*, GlobalContext*);
 
 typedef struct EnOt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.h
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.h
@@ -5,7 +5,7 @@
 
 struct EnOwl;
 
-typedef void (*EnOwlActionFunc)(struct EnOwl* this, GlobalContext* globalCtx);
+typedef void (*EnOwlActionFunc)(struct EnOwl*, GlobalContext*);
 
 typedef struct EnOwl {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Paper/z_en_paper.h
+++ b/src/overlays/actors/ovl_En_Paper/z_en_paper.h
@@ -5,7 +5,7 @@
 
 struct EnPaper;
 
-typedef void (*EnPaperActionFunc)(struct EnPaper* this, GlobalContext* globalCtx);
+typedef void (*EnPaperActionFunc)(struct EnPaper*, GlobalContext*);
 
 typedef struct EnPaper {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.h
@@ -5,7 +5,7 @@
 
 struct EnPeehat;
 
-typedef void (*EnPeehatActionFunc)(struct EnPeehat* this, GlobalContext* globalCtx);
+typedef void (*EnPeehatActionFunc)(struct EnPeehat*, GlobalContext*);
 
 typedef struct EnPeehat {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Pm/z_en_pm.h
+++ b/src/overlays/actors/ovl_En_Pm/z_en_pm.h
@@ -5,7 +5,7 @@
 
 struct EnPm;
 
-typedef void (*EnPmActionFunc)(struct EnPm* this, GlobalContext* globalCtx);
+typedef void (*EnPmActionFunc)(struct EnPm*, GlobalContext*);
 
 typedef struct EnPm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Po_Composer/z_en_po_composer.h
+++ b/src/overlays/actors/ovl_En_Po_Composer/z_en_po_composer.h
@@ -5,7 +5,7 @@
 
 struct EnPoComposer;
 
-typedef void (*EnPoComposerActionFunc)(struct EnPoComposer* this, GlobalContext* globalCtx);
+typedef void (*EnPoComposerActionFunc)(struct EnPoComposer*, GlobalContext*);
 
 typedef struct EnPoComposer {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
+++ b/src/overlays/actors/ovl_En_Po_Sisters/z_en_po_sisters.h
@@ -5,7 +5,7 @@
 
 struct EnPoSisters;
 
-typedef void (*EnPoSistersActionFunc)(struct EnPoSisters* this, GlobalContext* globalCtx);
+typedef void (*EnPoSistersActionFunc)(struct EnPoSisters*, GlobalContext*);
 
 typedef struct EnPoSisters {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.h
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.h
@@ -5,7 +5,7 @@
 
 struct EnPoh;
 
-typedef void (*EnPohActionFunc)(struct EnPoh* this, GlobalContext* globalCtx);
+typedef void (*EnPohActionFunc)(struct EnPoh*, GlobalContext*);
 
 typedef struct EnPoh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.h
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.h
@@ -5,7 +5,7 @@
 
 struct EnPp;
 
-typedef void (*EnPpActionFunc)(struct EnPp* this, GlobalContext* globalCtx);
+typedef void (*EnPpActionFunc)(struct EnPp*, GlobalContext*);
 
 typedef struct EnPp {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Pr/z_en_pr.h
+++ b/src/overlays/actors/ovl_En_Pr/z_en_pr.h
@@ -5,7 +5,7 @@
 
 struct EnPr;
 
-typedef void (*EnPrActionFunc)(struct EnPr* this, GlobalContext* globalCtx);
+typedef void (*EnPrActionFunc)(struct EnPr*, GlobalContext*);
 
 typedef struct EnPr {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Pr2/z_en_pr2.h
+++ b/src/overlays/actors/ovl_En_Pr2/z_en_pr2.h
@@ -5,7 +5,7 @@
 
 struct EnPr2;
 
-typedef void (*EnPr2ActionFunc)(struct EnPr2* this, GlobalContext* globalCtx);
+typedef void (*EnPr2ActionFunc)(struct EnPr2*, GlobalContext*);
 
 typedef struct EnPr2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Prz/z_en_prz.h
+++ b/src/overlays/actors/ovl_En_Prz/z_en_prz.h
@@ -5,7 +5,7 @@
 
 struct EnPrz;
 
-typedef void (*EnPrzActionFunc)(struct EnPrz* this, GlobalContext* globalCtx);
+typedef void (*EnPrzActionFunc)(struct EnPrz*, GlobalContext*);
 
 typedef struct EnPrz {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Pst/z_en_pst.h
+++ b/src/overlays/actors/ovl_En_Pst/z_en_pst.h
@@ -5,7 +5,7 @@
 
 struct EnPst;
 
-typedef void (*EnPstActionFunc)(struct EnPst* this, GlobalContext* globalCtx);
+typedef void (*EnPstActionFunc)(struct EnPst*, GlobalContext*);
 
 typedef struct EnPst {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Racedog/z_en_racedog.h
+++ b/src/overlays/actors/ovl_En_Racedog/z_en_racedog.h
@@ -5,7 +5,7 @@
 
 struct EnRacedog;
 
-typedef void (*EnRacedogActionFunc)(struct EnRacedog* this, GlobalContext* globalCtx);
+typedef void (*EnRacedogActionFunc)(struct EnRacedog*, GlobalContext*);
 
 typedef struct EnRacedog {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Raf/z_en_raf.h
+++ b/src/overlays/actors/ovl_En_Raf/z_en_raf.h
@@ -5,7 +5,7 @@
 
 struct EnRaf;
 
-typedef void (*EnRafActionFunc)(struct EnRaf* this, GlobalContext* globalCtx);
+typedef void (*EnRafActionFunc)(struct EnRaf*, GlobalContext*);
 
 typedef struct EnRaf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.h
+++ b/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.h
@@ -5,7 +5,7 @@
 
 struct EnRailSkb;
 
-typedef void (*EnRailSkbActionFunc)(struct EnRailSkb* this, GlobalContext* globalCtx);
+typedef void (*EnRailSkbActionFunc)(struct EnRailSkb*, GlobalContext*);
 
 typedef struct EnRailSkb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.h
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.h
@@ -5,7 +5,7 @@
 
 struct EnRailgibud;
 
-typedef void (*EnRailgibudActionFunc)(struct EnRailgibud* this, GlobalContext* globalCtx);
+typedef void (*EnRailgibudActionFunc)(struct EnRailgibud*, GlobalContext*);
 
 typedef struct EnRailgibud {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.h
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.h
@@ -5,7 +5,7 @@
 
 struct EnRd;
 
-typedef void (*EnRdActionFunc)(struct EnRd* this, GlobalContext* globalCtx);
+typedef void (*EnRdActionFunc)(struct EnRd*, GlobalContext*);
 
 typedef struct EnRd {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.h
+++ b/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.h
@@ -5,7 +5,7 @@
 
 struct EnRecepgirl;
 
-typedef void (*EnRecepgirlActionFunc)(struct EnRecepgirl* this, GlobalContext* globalCtx);
+typedef void (*EnRecepgirlActionFunc)(struct EnRecepgirl*, GlobalContext*);
 
 typedef struct EnRecepgirl {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Rg/z_en_rg.h
+++ b/src/overlays/actors/ovl_En_Rg/z_en_rg.h
@@ -5,7 +5,7 @@
 
 struct EnRg;
 
-typedef void (*EnRgActionFunc)(struct EnRg* this, GlobalContext* globalCtx);
+typedef void (*EnRgActionFunc)(struct EnRg*, GlobalContext*);
 
 typedef struct EnRg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.h
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.h
@@ -5,7 +5,7 @@
 
 struct EnRr;
 
-typedef void (*EnRrActionFunc)(struct EnRr* this, GlobalContext* globalCtx);
+typedef void (*EnRrActionFunc)(struct EnRr*, GlobalContext*);
 
 typedef struct EnRr {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ru/z_en_ru.h
+++ b/src/overlays/actors/ovl_En_Ru/z_en_ru.h
@@ -5,7 +5,7 @@
 
 struct EnRu;
 
-typedef void (*EnRuActionFunc)(struct EnRu* this, GlobalContext* globalCtx);
+typedef void (*EnRuActionFunc)(struct EnRu*, GlobalContext*);
 
 typedef struct EnRu {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.h
+++ b/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.h
@@ -5,7 +5,7 @@
 
 struct EnRuppecrow;
 
-typedef void (*EnRuppecrowActionFunc)(struct EnRuppecrow* this, GlobalContext* globalCtx);
+typedef void (*EnRuppecrowActionFunc)(struct EnRuppecrow*, GlobalContext*);
 
 typedef struct EnRuppecrow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Rz/z_en_rz.h
+++ b/src/overlays/actors/ovl_En_Rz/z_en_rz.h
@@ -5,7 +5,7 @@
 
 struct EnRz;
 
-typedef void (*EnRzActionFunc)(struct EnRz* this, GlobalContext* globalCtx);
+typedef void (*EnRzActionFunc)(struct EnRz*, GlobalContext*);
 
 typedef struct EnRz {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.h
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.h
@@ -5,7 +5,7 @@
 
 struct EnSGoro;
 
-typedef void (*EnSGoroActionFunc)(struct EnSGoro* this, GlobalContext* globalCtx);
+typedef void (*EnSGoroActionFunc)(struct EnSGoro*, GlobalContext*);
 
 typedef struct EnSGoro {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Sc_Ruppe/z_en_sc_ruppe.h
+++ b/src/overlays/actors/ovl_En_Sc_Ruppe/z_en_sc_ruppe.h
@@ -5,7 +5,7 @@
 
 struct EnScRuppe;
 
-typedef void (*EnScRuppeActionFunc)(struct EnScRuppe* this, GlobalContext* globalCtx);
+typedef void (*EnScRuppeActionFunc)(struct EnScRuppe*, GlobalContext*);
 
 typedef struct EnScRuppe {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Scopecrow/z_en_scopecrow.h
+++ b/src/overlays/actors/ovl_En_Scopecrow/z_en_scopecrow.h
@@ -5,7 +5,7 @@
 
 struct EnScopecrow;
 
-typedef void (*EnScopecrowActionFunc)(struct EnScopecrow* this, GlobalContext* globalCtx);
+typedef void (*EnScopecrowActionFunc)(struct EnScopecrow*, GlobalContext*);
 
 typedef struct EnScopecrow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.h
+++ b/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.h
@@ -5,7 +5,7 @@
 
 struct EnScopenuts;
 
-typedef void (*EnScopenutsActionFunc)(struct EnScopenuts* this, GlobalContext* globalCtx);
+typedef void (*EnScopenutsActionFunc)(struct EnScopenuts*, GlobalContext*);
 
 typedef struct EnScopenuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.h
+++ b/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.h
@@ -5,7 +5,7 @@
 
 struct EnSekihi;
 
-typedef void (*EnSekihiActionFunc)(struct EnSekihi* this, GlobalContext* globalCtx);
+typedef void (*EnSekihiActionFunc)(struct EnSekihi*, GlobalContext*);
 
 typedef struct EnSekihi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Sellnuts/z_en_sellnuts.h
+++ b/src/overlays/actors/ovl_En_Sellnuts/z_en_sellnuts.h
@@ -5,7 +5,7 @@
 
 struct EnSellnuts;
 
-typedef void (*EnSellnutsActionFunc)(struct EnSellnuts* this, GlobalContext* globalCtx);
+typedef void (*EnSellnutsActionFunc)(struct EnSellnuts*, GlobalContext*);
 
 typedef struct EnSellnuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Shn/z_en_shn.h
+++ b/src/overlays/actors/ovl_En_Shn/z_en_shn.h
@@ -5,7 +5,7 @@
 
 struct EnShn;
 
-typedef void (*EnShnActionFunc)(struct EnShn* this, GlobalContext* globalCtx);
+typedef void (*EnShnActionFunc)(struct EnShn*, GlobalContext*);
 
 typedef struct EnShn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Si/z_en_si.h
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.h
@@ -5,7 +5,7 @@
 
 struct EnSi;
 
-typedef void (*EnSiActionFunc)(struct EnSi* this, GlobalContext* globalCtx);
+typedef void (*EnSiActionFunc)(struct EnSi*, GlobalContext*);
 
 typedef struct EnSi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.h
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.h
@@ -5,7 +5,7 @@
 
 struct EnSkb;
 
-typedef void (*EnSkbActionFunc)(struct EnSkb* this, GlobalContext* globalCtx);
+typedef void (*EnSkbActionFunc)(struct EnSkb*, GlobalContext*);
 
 typedef struct EnSkb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Slime/z_en_slime.h
+++ b/src/overlays/actors/ovl_En_Slime/z_en_slime.h
@@ -5,7 +5,7 @@
 
 struct EnSlime;
 
-typedef void (*EnSlimeActionFunc)(struct EnSlime* this, GlobalContext* globalCtx);
+typedef void (*EnSlimeActionFunc)(struct EnSlime*, GlobalContext*);
 
 typedef struct EnSlime {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Snowman/z_en_snowman.h
+++ b/src/overlays/actors/ovl_En_Snowman/z_en_snowman.h
@@ -5,7 +5,7 @@
 
 struct EnSnowman;
 
-typedef void (*EnSnowmanActionFunc)(struct EnSnowman* this, GlobalContext* globalCtx);
+typedef void (*EnSnowmanActionFunc)(struct EnSnowman*, GlobalContext*);
 
 typedef struct EnSnowman {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Snowwd/z_en_snowwd.h
+++ b/src/overlays/actors/ovl_En_Snowwd/z_en_snowwd.h
@@ -5,7 +5,7 @@
 
 struct EnSnowwd;
 
-typedef void (*EnSnowwdActionFunc)(struct EnSnowwd* this, GlobalContext* globalCtx);
+typedef void (*EnSnowwdActionFunc)(struct EnSnowwd*, GlobalContext*);
 
 typedef struct EnSnowwd {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.h
@@ -5,7 +5,7 @@
 
 struct EnSsh;
 
-typedef void (*EnSshActionFunc)(struct EnSsh* this, GlobalContext* globalCtx);
+typedef void (*EnSshActionFunc)(struct EnSsh*, GlobalContext*);
 
 typedef struct EnSsh {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_St/z_en_st.h
+++ b/src/overlays/actors/ovl_En_St/z_en_st.h
@@ -5,7 +5,7 @@
 
 struct EnSt;
 
-typedef void (*EnStActionFunc)(struct EnSt* this, GlobalContext* globalCtx);
+typedef void (*EnStActionFunc)(struct EnSt*, GlobalContext*);
 
 typedef struct EnSt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.h
+++ b/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.h
@@ -5,7 +5,7 @@
 
 struct EnStoneheishi;
 
-typedef void (*EnStoneheishiActionFunc)(struct EnStoneheishi* this, GlobalContext* globalCtx);
+typedef void (*EnStoneheishiActionFunc)(struct EnStoneheishi*, GlobalContext*);
 
 typedef struct EnStoneheishi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.h
+++ b/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.h
@@ -5,7 +5,7 @@
 
 struct EnStopheishi;
 
-typedef void (*EnStopheishiActionFunc)(struct EnStopheishi* this, GlobalContext* globalCtx);
+typedef void (*EnStopheishiActionFunc)(struct EnStopheishi*, GlobalContext*);
 
 typedef struct EnStopheishi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.h
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.h
@@ -5,7 +5,7 @@
 
 struct EnStream;
 
-typedef void (*EnStreamActionFunc)(struct EnStream* this, GlobalContext* globalCtx);
+typedef void (*EnStreamActionFunc)(struct EnStream*, GlobalContext*);
 
 typedef struct EnStream {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.h
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.h
@@ -5,7 +5,7 @@
 
 struct EnSw;
 
-typedef void (*EnSwActionFunc)(struct EnSw* this, GlobalContext* globalCtx);
+typedef void (*EnSwActionFunc)(struct EnSw*, GlobalContext*);
 
 typedef struct EnSw {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Syateki_Crow/z_en_syateki_crow.h
+++ b/src/overlays/actors/ovl_En_Syateki_Crow/z_en_syateki_crow.h
@@ -5,7 +5,7 @@
 
 struct EnSyatekiCrow;
 
-typedef void (*EnSyatekiCrowActionFunc)(struct EnSyatekiCrow* this, GlobalContext* globalCtx);
+typedef void (*EnSyatekiCrowActionFunc)(struct EnSyatekiCrow*, GlobalContext*);
 
 typedef struct EnSyatekiCrow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.h
+++ b/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.h
@@ -5,7 +5,7 @@
 
 struct EnSyatekiDekunuts;
 
-typedef void (*EnSyatekiDekunutsActionFunc)(struct EnSyatekiDekunuts* this, GlobalContext* globalCtx);
+typedef void (*EnSyatekiDekunutsActionFunc)(struct EnSyatekiDekunuts*, GlobalContext*);
 
 typedef struct EnSyatekiDekunuts {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.h
@@ -5,7 +5,7 @@
 
 struct EnSyatekiMan;
 
-typedef void (*EnSyatekiManActionFunc)(struct EnSyatekiMan* this, GlobalContext* globalCtx);
+typedef void (*EnSyatekiManActionFunc)(struct EnSyatekiMan*, GlobalContext*);
 
 typedef struct EnSyatekiMan {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.h
+++ b/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.h
@@ -5,7 +5,7 @@
 
 struct EnSyatekiOkuta;
 
-typedef void (*EnSyatekiOkutaActionFunc)(struct EnSyatekiOkuta* this, GlobalContext* globalCtx);
+typedef void (*EnSyatekiOkutaActionFunc)(struct EnSyatekiOkuta*, GlobalContext*);
 
 typedef struct EnSyatekiOkuta {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Syateki_Wf/z_en_syateki_wf.h
+++ b/src/overlays/actors/ovl_En_Syateki_Wf/z_en_syateki_wf.h
@@ -5,7 +5,7 @@
 
 struct EnSyatekiWf;
 
-typedef void (*EnSyatekiWfActionFunc)(struct EnSyatekiWf* this, GlobalContext* globalCtx);
+typedef void (*EnSyatekiWfActionFunc)(struct EnSyatekiWf*, GlobalContext*);
 
 typedef struct EnSyatekiWf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tab/z_en_tab.h
+++ b/src/overlays/actors/ovl_En_Tab/z_en_tab.h
@@ -5,7 +5,7 @@
 
 struct EnTab;
 
-typedef void (*EnTabActionFunc)(struct EnTab* this, GlobalContext* globalCtx);
+typedef void (*EnTabActionFunc)(struct EnTab*, GlobalContext*);
 
 typedef struct EnTab {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.h
+++ b/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.h
@@ -5,7 +5,7 @@
 
 struct EnTakaraya;
 
-typedef void (*EnTakarayaActionFunc)(struct EnTakaraya* this, GlobalContext* globalCtx);
+typedef void (*EnTakarayaActionFunc)(struct EnTakaraya*, GlobalContext*);
 
 typedef struct EnTakaraya {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.h
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.h
@@ -5,7 +5,7 @@
 
 struct EnTalk;
 
-typedef void (*EnTalkActionFunc)(struct EnTalk* this, GlobalContext* globalCtx);
+typedef void (*EnTalkActionFunc)(struct EnTalk*, GlobalContext*);
 
 typedef struct EnTalk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.h
+++ b/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.h
@@ -5,7 +5,7 @@
 
 struct EnTalkGibud;
 
-typedef void (*EnTalkGibudActionFunc)(struct EnTalkGibud* this, GlobalContext* globalCtx);
+typedef void (*EnTalkGibudActionFunc)(struct EnTalkGibud*, GlobalContext*);
 
 typedef struct EnTalkGibud {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tanron2/z_en_tanron2.h
+++ b/src/overlays/actors/ovl_En_Tanron2/z_en_tanron2.h
@@ -5,7 +5,7 @@
 
 struct EnTanron2;
 
-typedef void (*EnTanron2ActionFunc)(struct EnTanron2* this, GlobalContext* globalCtx);
+typedef void (*EnTanron2ActionFunc)(struct EnTanron2*, GlobalContext*);
 
 typedef struct EnTanron2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tanron3/z_en_tanron3.h
+++ b/src/overlays/actors/ovl_En_Tanron3/z_en_tanron3.h
@@ -5,7 +5,7 @@
 
 struct EnTanron3;
 
-typedef void (*EnTanron3ActionFunc)(struct EnTanron3* this, GlobalContext* globalCtx);
+typedef void (*EnTanron3ActionFunc)(struct EnTanron3*, GlobalContext*);
 
 typedef struct EnTanron3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tanron4/z_en_tanron4.h
+++ b/src/overlays/actors/ovl_En_Tanron4/z_en_tanron4.h
@@ -5,7 +5,7 @@
 
 struct EnTanron4;
 
-typedef void (*EnTanron4ActionFunc)(struct EnTanron4* this, GlobalContext* globalCtx);
+typedef void (*EnTanron4ActionFunc)(struct EnTanron4*, GlobalContext*);
 
 typedef struct EnTanron4 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Test3/z_en_test3.h
+++ b/src/overlays/actors/ovl_En_Test3/z_en_test3.h
@@ -5,7 +5,7 @@
 
 struct EnTest3;
 
-typedef void (*EnTest3ActionFunc)(struct EnTest3* this, GlobalContext* globalCtx);
+typedef void (*EnTest3ActionFunc)(struct EnTest3*, GlobalContext*);
 
 typedef struct EnTest3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Test4/z_en_test4.h
+++ b/src/overlays/actors/ovl_En_Test4/z_en_test4.h
@@ -5,7 +5,7 @@
 
 struct EnTest4;
 
-typedef void (*EnTest4ActionFunc)(struct EnTest4* this, GlobalContext* globalCtx);
+typedef void (*EnTest4ActionFunc)(struct EnTest4*, GlobalContext*);
 
 typedef struct EnTest4 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Test5/z_en_test5.h
+++ b/src/overlays/actors/ovl_En_Test5/z_en_test5.h
@@ -5,7 +5,7 @@
 
 struct EnTest5;
 
-typedef void (*EnTest5ActionFunc)(struct EnTest5* this, GlobalContext* globalCtx);
+typedef void (*EnTest5ActionFunc)(struct EnTest5*, GlobalContext*);
 
 typedef struct EnTest5 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Test6/z_en_test6.h
+++ b/src/overlays/actors/ovl_En_Test6/z_en_test6.h
@@ -5,7 +5,7 @@
 
 struct EnTest6;
 
-typedef void (*EnTest6ActionFunc)(struct EnTest6* this, GlobalContext* globalCtx);
+typedef void (*EnTest6ActionFunc)(struct EnTest6*, GlobalContext*);
 
 typedef struct EnTest6 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Test7/z_en_test7.h
+++ b/src/overlays/actors/ovl_En_Test7/z_en_test7.h
@@ -5,7 +5,7 @@
 
 struct EnTest7;
 
-typedef void (*EnTest7ActionFunc)(struct EnTest7* this, GlobalContext* globalCtx);
+typedef void (*EnTest7ActionFunc)(struct EnTest7*, GlobalContext*);
 
 typedef struct EnTest7 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.h
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.h
@@ -5,7 +5,7 @@
 
 struct EnTg;
 
-typedef void (*EnTgActionFunc)(struct EnTg* this, GlobalContext* globalCtx);
+typedef void (*EnTgActionFunc)(struct EnTg*, GlobalContext*);
 
 typedef struct EnTg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.h
+++ b/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.h
@@ -5,7 +5,7 @@
 
 struct EnThiefbird;
 
-typedef void (*EnThiefbirdActionFunc)(struct EnThiefbird* this, GlobalContext* globalCtx);
+typedef void (*EnThiefbirdActionFunc)(struct EnThiefbird*, GlobalContext*);
 
 typedef struct EnThiefbird {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.h
+++ b/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.h
@@ -5,7 +5,7 @@
 
 struct EnTimeTag;
 
-typedef void (*EnTimeTagActionFunc)(struct EnTimeTag* this, GlobalContext* globalCtx);
+typedef void (*EnTimeTagActionFunc)(struct EnTimeTag*, GlobalContext*);
 
 typedef struct EnTimeTag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.h
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.h
@@ -5,7 +5,7 @@
 
 struct EnTite;
 
-typedef void (*EnTiteActionFunc)(struct EnTite* this, GlobalContext* globalCtx);
+typedef void (*EnTiteActionFunc)(struct EnTite*, GlobalContext*);
 
 typedef struct EnTite {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.h
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.h
@@ -5,7 +5,7 @@
 
 struct EnTk;
 
-typedef void (*EnTkActionFunc)(struct EnTk* this, GlobalContext* globalCtx);
+typedef void (*EnTkActionFunc)(struct EnTk*, GlobalContext*);
 
 typedef struct EnTk {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Trt2/z_en_trt2.h
+++ b/src/overlays/actors/ovl_En_Trt2/z_en_trt2.h
@@ -5,7 +5,7 @@
 
 struct EnTrt2;
 
-typedef void (*EnTrt2ActionFunc)(struct EnTrt2* this, GlobalContext* globalCtx);
+typedef void (*EnTrt2ActionFunc)(struct EnTrt2*, GlobalContext*);
 
 typedef struct EnTrt2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tru/z_en_tru.h
+++ b/src/overlays/actors/ovl_En_Tru/z_en_tru.h
@@ -5,7 +5,7 @@
 
 struct EnTru;
 
-typedef void (*EnTruActionFunc)(struct EnTru* this, GlobalContext* globalCtx);
+typedef void (*EnTruActionFunc)(struct EnTru*, GlobalContext*);
 
 typedef struct EnTru {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tru_Mt/z_en_tru_mt.h
+++ b/src/overlays/actors/ovl_En_Tru_Mt/z_en_tru_mt.h
@@ -5,7 +5,7 @@
 
 struct EnTruMt;
 
-typedef void (*EnTruMtActionFunc)(struct EnTruMt* this, GlobalContext* globalCtx);
+typedef void (*EnTruMtActionFunc)(struct EnTruMt*, GlobalContext*);
 
 typedef struct EnTruMt {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Tsn/z_en_tsn.h
+++ b/src/overlays/actors/ovl_En_Tsn/z_en_tsn.h
@@ -5,7 +5,7 @@
 
 struct EnTsn;
 
-typedef void (*EnTsnActionFunc)(struct EnTsn* this, GlobalContext* globalCtx);
+typedef void (*EnTsnActionFunc)(struct EnTsn*, GlobalContext*);
 
 typedef struct EnTsn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Twig/z_en_twig.h
+++ b/src/overlays/actors/ovl_En_Twig/z_en_twig.h
@@ -5,7 +5,7 @@
 
 struct EnTwig;
 
-typedef void (*EnTwigActionFunc)(struct EnTwig* this, GlobalContext* globalCtx);
+typedef void (*EnTwigActionFunc)(struct EnTwig*, GlobalContext*);
 
 typedef struct EnTwig {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.h
@@ -5,7 +5,7 @@
 
 struct EnViewer;
 
-typedef void (*EnViewerActionFunc)(struct EnViewer* this, GlobalContext* globalCtx);
+typedef void (*EnViewerActionFunc)(struct EnViewer*, GlobalContext*);
 
 typedef struct EnViewer {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.h
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.h
@@ -5,7 +5,7 @@
 
 struct EnVm;
 
-typedef void (*EnVmActionFunc)(struct EnVm* this, GlobalContext* globalCtx);
+typedef void (*EnVmActionFunc)(struct EnVm*, GlobalContext*);
 
 typedef struct EnVm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.h
@@ -5,7 +5,7 @@
 
 struct EnWallmas;
 
-typedef void (*EnWallmasActionFunc)(struct EnWallmas* this, GlobalContext* globalCtx);
+typedef void (*EnWallmasActionFunc)(struct EnWallmas*, GlobalContext*);
 
 typedef struct EnWallmas {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Warp_tag/z_en_warp_tag.h
+++ b/src/overlays/actors/ovl_En_Warp_tag/z_en_warp_tag.h
@@ -5,7 +5,7 @@
 
 struct EnWarptag;
 
-typedef void (*EnWarptagActionFunc)(struct EnWarptag* this, GlobalContext* globalCtx);
+typedef void (*EnWarptagActionFunc)(struct EnWarptag*, GlobalContext*);
 
 typedef struct EnWarptag {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wdhand/z_en_wdhand.h
+++ b/src/overlays/actors/ovl_En_Wdhand/z_en_wdhand.h
@@ -5,7 +5,7 @@
 
 struct EnWdhand;
 
-typedef void (*EnWdhandActionFunc)(struct EnWdhand* this, GlobalContext* globalCtx);
+typedef void (*EnWdhandActionFunc)(struct EnWdhand*, GlobalContext*);
 
 typedef struct EnWdhand {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.h
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.h
@@ -5,7 +5,7 @@
 
 struct EnWf;
 
-typedef void (*EnWfActionFunc)(struct EnWf* this, GlobalContext* globalCtx);
+typedef void (*EnWfActionFunc)(struct EnWf*, GlobalContext*);
 
 typedef struct EnWf {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wiz/z_en_wiz.h
+++ b/src/overlays/actors/ovl_En_Wiz/z_en_wiz.h
@@ -5,7 +5,7 @@
 
 struct EnWiz;
 
-typedef void (*EnWizActionFunc)(struct EnWiz* this, GlobalContext* globalCtx);
+typedef void (*EnWizActionFunc)(struct EnWiz*, GlobalContext*);
 
 typedef struct EnWiz {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wiz_Brock/z_en_wiz_brock.h
+++ b/src/overlays/actors/ovl_En_Wiz_Brock/z_en_wiz_brock.h
@@ -5,7 +5,7 @@
 
 struct EnWizBrock;
 
-typedef void (*EnWizBrockActionFunc)(struct EnWizBrock* this, GlobalContext* globalCtx);
+typedef void (*EnWizBrockActionFunc)(struct EnWizBrock*, GlobalContext*);
 
 typedef struct EnWizBrock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.h
+++ b/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.h
@@ -5,7 +5,7 @@
 
 struct EnWizFire;
 
-typedef void (*EnWizFireActionFunc)(struct EnWizFire* this, GlobalContext* globalCtx);
+typedef void (*EnWizFireActionFunc)(struct EnWizFire*, GlobalContext*);
 
 typedef struct EnWizFire {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Yb/z_en_yb.h
+++ b/src/overlays/actors/ovl_En_Yb/z_en_yb.h
@@ -5,7 +5,7 @@
 
 struct EnYb;
 
-typedef void (*EnYbActionFunc)(struct EnYb* this, GlobalContext* globalCtx);
+typedef void (*EnYbActionFunc)(struct EnYb*, GlobalContext*);
 
 typedef struct EnYb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.h
@@ -5,7 +5,7 @@
 
 struct EnZl4;
 
-typedef void (*EnZl4ActionFunc)(struct EnZl4* this, GlobalContext* globalCtx);
+typedef void (*EnZl4ActionFunc)(struct EnZl4*, GlobalContext*);
 
 typedef struct EnZl4 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.h
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.h
@@ -5,7 +5,7 @@
 
 struct EnZo;
 
-typedef void (*EnZoActionFunc)(struct EnZo* this, GlobalContext* globalCtx);
+typedef void (*EnZoActionFunc)(struct EnZo*, GlobalContext*);
 
 typedef struct EnZo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zob/z_en_zob.h
+++ b/src/overlays/actors/ovl_En_Zob/z_en_zob.h
@@ -5,7 +5,7 @@
 
 struct EnZob;
 
-typedef void (*EnZobActionFunc)(struct EnZob* this, GlobalContext* globalCtx);
+typedef void (*EnZobActionFunc)(struct EnZob*, GlobalContext*);
 
 typedef struct EnZob {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zod/z_en_zod.h
+++ b/src/overlays/actors/ovl_En_Zod/z_en_zod.h
@@ -5,7 +5,7 @@
 
 struct EnZod;
 
-typedef void (*EnZodActionFunc)(struct EnZod* this, GlobalContext* globalCtx);
+typedef void (*EnZodActionFunc)(struct EnZod*, GlobalContext*);
 
 typedef struct EnZod {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zog/z_en_zog.h
+++ b/src/overlays/actors/ovl_En_Zog/z_en_zog.h
@@ -5,7 +5,7 @@
 
 struct EnZog;
 
-typedef void (*EnZogActionFunc)(struct EnZog* this, GlobalContext* globalCtx);
+typedef void (*EnZogActionFunc)(struct EnZog*, GlobalContext*);
 
 typedef struct EnZog {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.h
+++ b/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.h
@@ -5,7 +5,7 @@
 
 struct EnZoraegg;
 
-typedef void (*EnZoraeggActionFunc)(struct EnZoraegg* this, GlobalContext* globalCtx);
+typedef void (*EnZoraeggActionFunc)(struct EnZoraegg*, GlobalContext*);
 
 typedef struct EnZoraegg {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.h
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.h
@@ -5,7 +5,7 @@
 
 struct EnZos;
 
-typedef void (*EnZosActionFunc)(struct EnZos* this, GlobalContext* globalCtx);
+typedef void (*EnZosActionFunc)(struct EnZos*, GlobalContext*);
 
 typedef struct EnZos {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zot/z_en_zot.h
+++ b/src/overlays/actors/ovl_En_Zot/z_en_zot.h
@@ -5,7 +5,7 @@
 
 struct EnZot;
 
-typedef void (*EnZotActionFunc)(struct EnZot* this, GlobalContext* globalCtx);
+typedef void (*EnZotActionFunc)(struct EnZot*, GlobalContext*);
 
 typedef struct EnZot {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zov/z_en_zov.h
+++ b/src/overlays/actors/ovl_En_Zov/z_en_zov.h
@@ -5,7 +5,7 @@
 
 struct EnZov;
 
-typedef void (*EnZovActionFunc)(struct EnZov* this, GlobalContext* globalCtx);
+typedef void (*EnZovActionFunc)(struct EnZov*, GlobalContext*);
 
 typedef struct EnZov {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_En_Zow/z_en_zow.h
+++ b/src/overlays/actors/ovl_En_Zow/z_en_zow.h
@@ -5,7 +5,7 @@
 
 struct EnZow;
 
-typedef void (*EnZowActionFunc)(struct EnZow* this, GlobalContext* globalCtx);
+typedef void (*EnZowActionFunc)(struct EnZow*, GlobalContext*);
 
 typedef struct EnZow {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.h
@@ -5,7 +5,7 @@
 
 struct ItemEtcetera;
 
-typedef void (*ItemEtceteraActionFunc)(struct ItemEtcetera* this, GlobalContext* globalCtx);
+typedef void (*ItemEtceteraActionFunc)(struct ItemEtcetera*, GlobalContext*);
 
 typedef struct ItemEtcetera {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
@@ -5,7 +5,7 @@
 
 struct ObjAqua;
 
-typedef void (*ObjAquaActionFunc)(struct ObjAqua* this, GlobalContext* globalCtx);
+typedef void (*ObjAquaActionFunc)(struct ObjAqua*, GlobalContext*);
 
 typedef struct ObjAqua {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Armos/z_obj_armos.h
+++ b/src/overlays/actors/ovl_Obj_Armos/z_obj_armos.h
@@ -5,7 +5,7 @@
 
 struct ObjArmos;
 
-typedef void (*ObjArmosActionFunc)(struct ObjArmos* this, GlobalContext* globalCtx);
+typedef void (*ObjArmosActionFunc)(struct ObjArmos*, GlobalContext*);
 
 typedef struct ObjArmos {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.h
@@ -5,7 +5,7 @@
 
 struct ObjBean;
 
-typedef void (*ObjBeanActionFunc)(struct ObjBean* this, GlobalContext* globalCtx);
+typedef void (*ObjBeanActionFunc)(struct ObjBean*, GlobalContext*);
 
 typedef struct ObjBean {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Bigicicle/z_obj_bigicicle.h
+++ b/src/overlays/actors/ovl_Obj_Bigicicle/z_obj_bigicicle.h
@@ -5,7 +5,7 @@
 
 struct ObjBigicicle;
 
-typedef void (*ObjBigicicleActionFunc)(struct ObjBigicicle* this, GlobalContext* globalCtx);
+typedef void (*ObjBigicicleActionFunc)(struct ObjBigicicle*, GlobalContext*);
 
 typedef struct ObjBigicicle {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.h
@@ -5,7 +5,7 @@
 
 struct ObjBlockstop;
 
-typedef void (*ObjBlockstopActionFunc)(struct ObjBlockstop* this, GlobalContext* globalCtx);
+typedef void (*ObjBlockstopActionFunc)(struct ObjBlockstop*, GlobalContext*);
 
 typedef struct ObjBlockstop {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.h
@@ -5,7 +5,7 @@
 
 struct ObjBombiwa;
 
-typedef void (*ObjBombiwaActionFunc)(struct ObjBombiwa* this, GlobalContext* globalCtx);
+typedef void (*ObjBombiwaActionFunc)(struct ObjBombiwa*, GlobalContext*);
 
 typedef struct ObjBombiwa {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.h
+++ b/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.h
@@ -5,7 +5,7 @@
 
 struct ObjChan;
 
-typedef void (*ObjChanActionFunc)(struct ObjChan* this, GlobalContext* globalCtx);
+typedef void (*ObjChanActionFunc)(struct ObjChan*, GlobalContext*);
 
 typedef struct ObjChan {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.h
@@ -5,7 +5,7 @@
 
 struct ObjComb;
 
-typedef void (*ObjCombActionFunc)(struct ObjComb* this, GlobalContext* globalCtx);
+typedef void (*ObjCombActionFunc)(struct ObjComb*, GlobalContext*);
 
 typedef struct ObjComb {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.h
+++ b/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.h
@@ -5,7 +5,7 @@
 
 struct ObjDanpeilift;
 
-typedef void (*ObjDanpeiliftActionFunc)(struct ObjDanpeilift* this, GlobalContext* globalCtx);
+typedef void (*ObjDanpeiliftActionFunc)(struct ObjDanpeilift*, GlobalContext*);
 
 typedef struct ObjDanpeilift {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Demo/z_obj_demo.h
+++ b/src/overlays/actors/ovl_Obj_Demo/z_obj_demo.h
@@ -5,7 +5,7 @@
 
 struct ObjDemo;
 
-typedef void (*ObjDemoActionFunc)(struct ObjDemo* this, GlobalContext* globalCtx);
+typedef void (*ObjDemoActionFunc)(struct ObjDemo*, GlobalContext*);
 
 typedef struct ObjDemo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.h
+++ b/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.h
@@ -5,7 +5,7 @@
 
 struct ObjDhouse;
 
-typedef void (*ObjDhouseActionFunc)(struct ObjDhouse* this, GlobalContext* globalCtx);
+typedef void (*ObjDhouseActionFunc)(struct ObjDhouse*, GlobalContext*);
 
 typedef struct ObjDhouse {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Dora/z_obj_dora.h
+++ b/src/overlays/actors/ovl_Obj_Dora/z_obj_dora.h
@@ -5,7 +5,7 @@
 
 struct ObjDora;
 
-typedef void (*ObjDoraActionFunc)(struct ObjDora* this, GlobalContext* globalCtx);
+typedef void (*ObjDoraActionFunc)(struct ObjDora*, GlobalContext*);
 
 typedef struct ObjDora {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.h
+++ b/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.h
@@ -5,7 +5,7 @@
 
 struct ObjDriftice;
 
-typedef void (*ObjDrifticeActionFunc)(struct ObjDriftice* this, GlobalContext* globalCtx);
+typedef void (*ObjDrifticeActionFunc)(struct ObjDriftice*, GlobalContext*);
 
 typedef struct ObjDriftice {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Etcetera/z_obj_etcetera.h
+++ b/src/overlays/actors/ovl_Obj_Etcetera/z_obj_etcetera.h
@@ -5,7 +5,7 @@
 
 struct ObjEtcetera;
 
-typedef void (*ObjEtceteraActionFunc)(struct ObjEtcetera* this, GlobalContext* globalCtx);
+typedef void (*ObjEtceteraActionFunc)(struct ObjEtcetera*, GlobalContext*);
 
 typedef struct ObjEtcetera {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.h
+++ b/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.h
@@ -5,7 +5,7 @@
 
 struct ObjFireshield;
 
-typedef void (*ObjFireshieldActionFunc)(struct ObjFireshield* this, GlobalContext* globalCtx);
+typedef void (*ObjFireshieldActionFunc)(struct ObjFireshield*, GlobalContext*);
 
 typedef struct ObjFireshield {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.h
+++ b/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.h
@@ -5,7 +5,7 @@
 
 struct ObjFlowerpot;
 
-typedef void (*ObjFlowerpotActionFunc)(struct ObjFlowerpot* this, GlobalContext* globalCtx);
+typedef void (*ObjFlowerpotActionFunc)(struct ObjFlowerpot*, GlobalContext*);
 
 typedef struct ObjFlowerpot {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.h
+++ b/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.h
@@ -5,7 +5,7 @@
 
 struct ObjGrassCarry;
 
-typedef void (*ObjGrassCarryActionFunc)(struct ObjGrassCarry* this, GlobalContext* globalCtx);
+typedef void (*ObjGrassCarryActionFunc)(struct ObjGrassCarry*, GlobalContext*);
 
 typedef struct ObjGrassCarry {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.h
+++ b/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.h
@@ -5,7 +5,7 @@
 
 struct ObjHakaisi;
 
-typedef void (*ObjHakaisiActionFunc)(struct ObjHakaisi* this, GlobalContext* globalCtx);
+typedef void (*ObjHakaisiActionFunc)(struct ObjHakaisi*, GlobalContext*);
 
 typedef struct ObjHakaisi {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Hariko/z_obj_hariko.h
+++ b/src/overlays/actors/ovl_Obj_Hariko/z_obj_hariko.h
@@ -5,7 +5,7 @@
 
 struct ObjHariko;
 
-typedef void (*ObjHarikoActionFunc)(struct ObjHariko* this, GlobalContext* globalCtx);
+typedef void (*ObjHarikoActionFunc)(struct ObjHariko*, GlobalContext*);
 
 typedef struct ObjHariko {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.h
@@ -5,7 +5,7 @@
 
 struct ObjHsblock;
 
-typedef void (*ObjHsblockActionFunc)(struct ObjHsblock* this, GlobalContext* globalCtx);
+typedef void (*ObjHsblockActionFunc)(struct ObjHsblock*, GlobalContext*);
 
 typedef struct ObjHsblock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.h
+++ b/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.h
@@ -5,7 +5,7 @@
 
 struct ObjHugebombiwa;
 
-typedef void (*ObjHugebombiwaActionFunc)(struct ObjHugebombiwa* this, GlobalContext* globalCtx);
+typedef void (*ObjHugebombiwaActionFunc)(struct ObjHugebombiwa*, GlobalContext*);
 
 typedef struct ObjHugebombiwa {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Hunsui/z_obj_hunsui.h
+++ b/src/overlays/actors/ovl_Obj_Hunsui/z_obj_hunsui.h
@@ -5,7 +5,7 @@
 
 struct ObjHunsui;
 
-typedef void (*ObjHunsuiActionFunc)(struct ObjHunsui* this, GlobalContext* globalCtx);
+typedef void (*ObjHunsuiActionFunc)(struct ObjHunsui*, GlobalContext*);
 
 typedef struct ObjHunsui {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.h
@@ -5,7 +5,7 @@
 
 struct ObjIcePoly;
 
-typedef void (*ObjIcePolyActionFunc)(struct ObjIcePoly* this, GlobalContext* globalCtx);
+typedef void (*ObjIcePolyActionFunc)(struct ObjIcePoly*, GlobalContext*);
 
 typedef struct ObjIcePoly {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.h
+++ b/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.h
@@ -5,7 +5,7 @@
 
 struct ObjIceblock;
 
-typedef void (*ObjIceblockActionFunc)(struct ObjIceblock* this, GlobalContext* globalCtx);
+typedef void (*ObjIceblockActionFunc)(struct ObjIceblock*, GlobalContext*);
 
 typedef struct ObjIceblock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Kendo_Kanban/z_obj_kendo_kanban.h
+++ b/src/overlays/actors/ovl_Obj_Kendo_Kanban/z_obj_kendo_kanban.h
@@ -5,7 +5,7 @@
 
 struct ObjKendoKanban;
 
-typedef void (*ObjKendoKanbanActionFunc)(struct ObjKendoKanban* this, GlobalContext* globalCtx);
+typedef void (*ObjKendoKanbanActionFunc)(struct ObjKendoKanban*, GlobalContext*);
 
 typedef struct ObjKendoKanban {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
+++ b/src/overlays/actors/ovl_Obj_Kibako2/z_obj_kibako2.h
@@ -5,7 +5,7 @@
 
 struct ObjKibako2;
 
-typedef void (*ObjKibako2ActionFunc)(struct ObjKibako2* this, GlobalContext* globalCtx);
+typedef void (*ObjKibako2ActionFunc)(struct ObjKibako2*, GlobalContext*);
 
 typedef struct ObjKibako2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Kzsaku/z_obj_kzsaku.h
+++ b/src/overlays/actors/ovl_Obj_Kzsaku/z_obj_kzsaku.h
@@ -5,7 +5,7 @@
 
 struct ObjKzsaku;
 
-typedef void (*ObjKzsakuActionFunc)(struct ObjKzsaku* this, GlobalContext* globalCtx);
+typedef void (*ObjKzsakuActionFunc)(struct ObjKzsaku*, GlobalContext*);
 
 typedef struct ObjKzsaku {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.h
@@ -5,7 +5,7 @@
 
 struct ObjLift;
 
-typedef void (*ObjLiftActionFunc)(struct ObjLift* this, GlobalContext* globalCtx);
+typedef void (*ObjLiftActionFunc)(struct ObjLift*, GlobalContext*);
 
 typedef struct ObjLift {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Lightblock/z_obj_lightblock.h
+++ b/src/overlays/actors/ovl_Obj_Lightblock/z_obj_lightblock.h
@@ -5,7 +5,7 @@
 
 struct ObjLightblock;
 
-typedef void (*ObjLightblockActionFunc)(struct ObjLightblock* this, GlobalContext* globalCtx);
+typedef void (*ObjLightblockActionFunc)(struct ObjLightblock*, GlobalContext*);
 
 typedef struct ObjLightblock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Lupygamelift/z_obj_lupygamelift.h
+++ b/src/overlays/actors/ovl_Obj_Lupygamelift/z_obj_lupygamelift.h
@@ -5,7 +5,7 @@
 
 struct ObjLupygamelift;
 
-typedef void (*ObjLupygameliftActionFunc)(struct ObjLupygamelift* this, GlobalContext* globalCtx);
+typedef void (*ObjLupygameliftActionFunc)(struct ObjLupygamelift*, GlobalContext*);
 
 typedef struct ObjLupygamelift {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Mine/z_obj_mine.h
+++ b/src/overlays/actors/ovl_Obj_Mine/z_obj_mine.h
@@ -5,7 +5,7 @@
 
 struct ObjMine;
 
-typedef void (*ObjMineActionFunc)(struct ObjMine* this, GlobalContext* globalCtx);
+typedef void (*ObjMineActionFunc)(struct ObjMine*, GlobalContext*);
 
 typedef struct ObjMine {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.h
@@ -5,7 +5,7 @@
 
 struct ObjMure;
 
-typedef void (*ObjMureActionFunc)(struct ObjMure* this, GlobalContext* globalCtx);
+typedef void (*ObjMureActionFunc)(struct ObjMure*, GlobalContext*);
 
 typedef struct ObjMure {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.h
@@ -5,7 +5,7 @@
 
 struct ObjMure2;
 
-typedef void (*ObjMure2ActionFunc)(struct ObjMure2* this, GlobalContext* globalCtx);
+typedef void (*ObjMure2ActionFunc)(struct ObjMure2*, GlobalContext*);
 
 typedef struct ObjMure2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.h
@@ -5,7 +5,7 @@
 
 struct ObjMure3;
 
-typedef void (*ObjMure3ActionFunc)(struct ObjMure3* this, GlobalContext* globalCtx);
+typedef void (*ObjMure3ActionFunc)(struct ObjMure3*, GlobalContext*);
 
 typedef struct ObjMure3 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.h
+++ b/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.h
@@ -5,7 +5,7 @@
 
 struct ObjNozoki;
 
-typedef void (*ObjNozokiActionFunc)(struct ObjNozoki* this, GlobalContext* globalCtx);
+typedef void (*ObjNozokiActionFunc)(struct ObjNozoki*, GlobalContext*);
 
 typedef struct ObjNozoki {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.h
+++ b/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.h
@@ -5,7 +5,7 @@
 
 struct ObjOcarinalift;
 
-typedef void (*ObjOcarinaliftActionFunc)(struct ObjOcarinalift* this, GlobalContext* globalCtx);
+typedef void (*ObjOcarinaliftActionFunc)(struct ObjOcarinalift*, GlobalContext*);
 
 typedef struct ObjOcarinalift {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.h
@@ -5,7 +5,7 @@
 
 struct ObjOshihiki;
 
-typedef void (*ObjOshihikiActionFunc)(struct ObjOshihiki* this, GlobalContext* globalCtx);
+typedef void (*ObjOshihikiActionFunc)(struct ObjOshihiki*, GlobalContext*);
 
 typedef struct ObjOshihiki {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Purify/z_obj_purify.h
+++ b/src/overlays/actors/ovl_Obj_Purify/z_obj_purify.h
@@ -5,7 +5,7 @@
 
 struct ObjPurify;
 
-typedef void (*ObjPurifyActionFunc)(struct ObjPurify* this, GlobalContext* globalCtx);
+typedef void (*ObjPurifyActionFunc)(struct ObjPurify*, GlobalContext*);
 
 typedef struct ObjPurify {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.h
@@ -5,7 +5,7 @@
 
 struct ObjRoomtimer;
 
-typedef void (*ObjRoomtimerActionFunc)(struct ObjRoomtimer* this, GlobalContext* globalCtx);
+typedef void (*ObjRoomtimerActionFunc)(struct ObjRoomtimer*, GlobalContext*);
 
 typedef struct ObjRoomtimer {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.h
+++ b/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.h
@@ -5,7 +5,7 @@
 
 struct ObjSkateblock;
 
-typedef void (*ObjSkateblockActionFunc)(struct ObjSkateblock* this, GlobalContext* globalCtx);
+typedef void (*ObjSkateblockActionFunc)(struct ObjSkateblock*, GlobalContext*);
 
 typedef struct ObjSkateblock {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.h
+++ b/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.h
@@ -5,7 +5,7 @@
 
 struct ObjSnowball;
 
-typedef void (*ObjSnowballActionFunc)(struct ObjSnowball* this, GlobalContext* globalCtx);
+typedef void (*ObjSnowballActionFunc)(struct ObjSnowball*, GlobalContext*);
 
 typedef struct ObjSnowball {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Snowball2/z_obj_snowball2.h
+++ b/src/overlays/actors/ovl_Obj_Snowball2/z_obj_snowball2.h
@@ -5,7 +5,7 @@
 
 struct ObjSnowball2;
 
-typedef void (*ObjSnowball2ActionFunc)(struct ObjSnowball2* this, GlobalContext* globalCtx);
+typedef void (*ObjSnowball2ActionFunc)(struct ObjSnowball2*, GlobalContext*);
 
 typedef struct ObjSnowball2 {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.h
+++ b/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.h
@@ -5,7 +5,7 @@
 
 struct ObjSpidertent;
 
-typedef void (*ObjSpidertentActionFunc)(struct ObjSpidertent* this, GlobalContext* globalCtx);
+typedef void (*ObjSpidertentActionFunc)(struct ObjSpidertent*, GlobalContext*);
 
 typedef struct ObjSpidertent {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.h
+++ b/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.h
@@ -5,7 +5,7 @@
 
 struct ObjSpinyroll;
 
-typedef void (*ObjSpinyrollActionFunc)(struct ObjSpinyroll* this, GlobalContext* globalCtx);
+typedef void (*ObjSpinyrollActionFunc)(struct ObjSpinyroll*, GlobalContext*);
 
 typedef struct ObjSpinyroll {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.h
@@ -5,7 +5,7 @@
 
 struct ObjSwitch;
 
-typedef void (*ObjSwitchActionFunc)(struct ObjSwitch* this, GlobalContext* globalCtx);
+typedef void (*ObjSwitchActionFunc)(struct ObjSwitch*, GlobalContext*);
 
 typedef struct ObjSwitch {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.h
+++ b/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.h
@@ -5,7 +5,7 @@
 
 struct ObjSwprize;
 
-typedef void (*ObjSwprizeActionFunc)(struct ObjSwprize* this, GlobalContext* globalCtx);
+typedef void (*ObjSwprizeActionFunc)(struct ObjSwprize*, GlobalContext*);
 
 typedef struct ObjSwprize {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Takaraya_Wall/z_obj_takaraya_wall.h
+++ b/src/overlays/actors/ovl_Obj_Takaraya_Wall/z_obj_takaraya_wall.h
@@ -5,7 +5,7 @@
 
 struct ObjTakarayaWall;
 
-typedef void (*ObjTakarayaWallActionFunc)(struct ObjTakarayaWall* this, GlobalContext* globalCtx);
+typedef void (*ObjTakarayaWallActionFunc)(struct ObjTakarayaWall*, GlobalContext*);
 
 typedef struct ObjTakarayaWall {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Taru/z_obj_taru.h
+++ b/src/overlays/actors/ovl_Obj_Taru/z_obj_taru.h
@@ -5,7 +5,7 @@
 
 struct ObjTaru;
 
-typedef void (*ObjTaruActionFunc)(struct ObjTaru* this, GlobalContext* globalCtx);
+typedef void (*ObjTaruActionFunc)(struct ObjTaru*, GlobalContext*);
 
 typedef struct ObjTaru {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Toge/z_obj_toge.h
+++ b/src/overlays/actors/ovl_Obj_Toge/z_obj_toge.h
@@ -5,7 +5,7 @@
 
 struct ObjToge;
 
-typedef void (*ObjTogeActionFunc)(struct ObjToge* this, GlobalContext* globalCtx);
+typedef void (*ObjTogeActionFunc)(struct ObjToge*, GlobalContext*);
 
 typedef struct ObjToge {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Tokei_Tobira/z_obj_tokei_tobira.h
+++ b/src/overlays/actors/ovl_Obj_Tokei_Tobira/z_obj_tokei_tobira.h
@@ -5,7 +5,7 @@
 
 struct ObjTokeiTobira;
 
-typedef void (*ObjTokeiTobiraActionFunc)(struct ObjTokeiTobira* this, GlobalContext* globalCtx);
+typedef void (*ObjTokeiTobiraActionFunc)(struct ObjTokeiTobira*, GlobalContext*);
 
 typedef struct ObjTokeiTobira {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
@@ -5,7 +5,7 @@
 
 struct ObjTokeidai;
 
-typedef void (*ObjTokeidaiActionFunc)(struct ObjTokeidai* this, GlobalContext* globalCtx);
+typedef void (*ObjTokeidaiActionFunc)(struct ObjTokeidai*, GlobalContext*);
 
 typedef struct ObjTokeidai {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Tree/z_obj_tree.h
+++ b/src/overlays/actors/ovl_Obj_Tree/z_obj_tree.h
@@ -5,7 +5,7 @@
 
 struct ObjTree;
 
-typedef void (*ObjTreeActionFunc)(struct ObjTree* this, GlobalContext* globalCtx);
+typedef void (*ObjTreeActionFunc)(struct ObjTree*, GlobalContext*);
 
 typedef struct ObjTree {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.h
@@ -5,7 +5,7 @@
 
 struct ObjTsubo;
 
-typedef void (*ObjTsuboActionFunc)(struct ObjTsubo* this, GlobalContext* globalCtx);
+typedef void (*ObjTsuboActionFunc)(struct ObjTsubo*, GlobalContext*);
 
 typedef struct ObjTsubo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Um/z_obj_um.h
+++ b/src/overlays/actors/ovl_Obj_Um/z_obj_um.h
@@ -5,7 +5,7 @@
 
 struct ObjUm;
 
-typedef void (*ObjUmActionFunc)(struct ObjUm* this, GlobalContext* globalCtx);
+typedef void (*ObjUmActionFunc)(struct ObjUm*, GlobalContext*);
 
 typedef struct ObjUm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Usiyane/z_obj_usiyane.h
+++ b/src/overlays/actors/ovl_Obj_Usiyane/z_obj_usiyane.h
@@ -5,7 +5,7 @@
 
 struct ObjUsiyane;
 
-typedef void (*ObjUsiyaneActionFunc)(struct ObjUsiyane* this, GlobalContext* globalCtx);
+typedef void (*ObjUsiyaneActionFunc)(struct ObjUsiyane*, GlobalContext*);
 
 typedef struct ObjUsiyane {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.h
+++ b/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.h
@@ -5,7 +5,7 @@
 
 struct ObjVspinyroll;
 
-typedef void (*ObjVspinyrollActionFunc)(struct ObjVspinyroll* this, GlobalContext* globalCtx);
+typedef void (*ObjVspinyrollActionFunc)(struct ObjVspinyroll*, GlobalContext*);
 
 typedef struct ObjVspinyroll {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Obj_Wturn/z_obj_wturn.h
+++ b/src/overlays/actors/ovl_Obj_Wturn/z_obj_wturn.h
@@ -5,7 +5,7 @@
 
 struct ObjWturn;
 
-typedef void (*ObjWturnActionFunc)(struct ObjWturn* this, GlobalContext* globalCtx);
+typedef void (*ObjWturnActionFunc)(struct ObjWturn*, GlobalContext*);
 
 typedef struct ObjWturn {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.h
@@ -5,7 +5,7 @@
 
 struct ObjectKankyo;
 
-typedef void (*ObjectKankyoActionFunc)(struct ObjectKankyo* this, GlobalContext* globalCtx);
+typedef void (*ObjectKankyoActionFunc)(struct ObjectKankyo*, GlobalContext*);
 
 typedef struct ObjectKankyo {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.h
@@ -5,7 +5,7 @@
 
 struct OceffSpot;
 
-typedef void (*OceffSpotActionFunc)(struct OceffSpot* this, GlobalContext* globalCtx);
+typedef void (*OceffSpotActionFunc)(struct OceffSpot*, GlobalContext*);
 
 typedef struct OceffSpot {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.h
@@ -5,7 +5,7 @@
 
 struct OceffStorm;
 
-typedef void (*OceffStormActionFunc)(struct OceffStorm* this, GlobalContext* globalCtx);
+typedef void (*OceffStormActionFunc)(struct OceffStorm*, GlobalContext*);
 
 typedef struct OceffStorm {
     /* 0x0000 */ Actor actor;

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.h
@@ -5,7 +5,7 @@
 
 struct ShotSun;
 
-typedef void (*ShotSunActionFunc)(struct ShotSun* this, GlobalContext* globalCtx);
+typedef void (*ShotSunActionFunc)(struct ShotSun*, GlobalContext*);
 
 typedef struct ShotSun {
     /* 0x0000 */ Actor actor;


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Makes actionFuncs consistent. Names shouldn't be included in typedefs.