### PR TITLE
Update makefile so compression only starts if checksum matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ endif
 
 .PHONY: all uncompressed compressed clean assetclean distclean disasm init setup
 .DEFAULT_GOAL := uncompressed
-all: uncompressed compressed
+all: compressed
 
 $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@

--- a/Makefile
+++ b/Makefile
@@ -175,8 +175,8 @@ all: uncompressed compressed
 $(ROM): $(ELF)
 	$(ELF2ROM) -cic 6105 $< $@
 
-$(ROMC): $(ROM)
-	python3 tools/z64compress_wrapper.py --mb 32 --matching --threads $(N_THREADS) $< $@ $(ELF) build/$(SPEC)
+$(ROMC): uncompressed
+	python3 tools/z64compress_wrapper.py --mb 32 --matching --threads $(N_THREADS) $(ROM) $@ $(ELF) build/$(SPEC)
 
 $(ELF): $(TEXTURE_FILES_OUT) $(OVERLAY_RELOC_FILES) $(O_FILES) build/ldscript.txt build/undefined_syms.txt
 	$(LD) -T build/undefined_syms.txt -T build/ldscript.txt --no-check-sections --accept-unknown-input-arch --emit-relocs -Map build/mm.map -o $@


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Change Makefile so that compression only starts if checksum matches, or compare is turned off.
Relevant Discord discussion https://discord.com/channels/688807550715560050/740615251011174401/874027259634286592