### PR TITLE
Two minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
 
 # Check code syntax with host compiler
 CHECK_WARNINGS := -Wall -Wextra -Wno-format-security -Wno-unknown-pragmas -Wno-unused-parameter -Wno-unused-variable -Wno-missing-braces -Wno-int-conversion -Wno-unused-but-set-variable -Wno-unused-label
-CC_CHECK   := gcc -fno-builtin -fsyntax-only -fsigned-char -std=gnu90 -D _LANGUAGE_C -D NON_MATCHING -Iinclude -Isrc -Iassets -Ibuild -include stdarg.h $(CHECK_WARNINGS)
+CC_CHECK   := gcc -fno-builtin -fsyntax-only -funsigned-char -std=gnu90 -D _LANGUAGE_C -D NON_MATCHING -Iinclude -Isrc -Iassets -Ibuild -include stdarg.h $(CHECK_WARNINGS)
 
 CPP        := cpp
 ELF2ROM    := tools/buildtools/elf2rom

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -179,21 +179,9 @@ static u8 D_80B65078[] = {
 
 // used in limbdraw
 static Vec3f D_80B65084[] = {
-    {
-        2000.0f,
-        4000.0f,
-        0.0f,
-    },
-    {
-        -1000.0f,
-        1500.0f,
-        -2000.0f,
-    },
-    {
-        -1000.0f,
-        1500.0f,
-        2000.0f,
-    },
+    { 2000.0f, 4000.0f, 0.0f },
+    { -1000.0f, 1500.0f, -2000.0f },
+    { -1000.0f, 1500.0f, 2000.0f },
 };
 
 void EnBigpo_Init(Actor* thisx, GlobalContext* globalCtx2) {

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -179,10 +179,22 @@ static u8 D_80B65078[] = {
 
 // used in limbdraw
 static Vec3f D_80B65084[] = {
-    { 2000.0f, 4000.0f, 0.0f,},
-    {-1000.0f, 1500.0f, -2000.0f,},
-    {-1000.0f, 1500.0f, 2000.0f,},
-}; 
+    {
+        2000.0f,
+        4000.0f,
+        0.0f,
+    },
+    {
+        -1000.0f,
+        1500.0f,
+        -2000.0f,
+    },
+    {
+        -1000.0f,
+        1500.0f,
+        2000.0f,
+    },
+};
 
 void EnBigpo_Init(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
@@ -231,7 +243,7 @@ void EnBigpo_Init(Actor* thisx, GlobalContext* globalCtx2) {
     }
 
     if (thisx->params == ENBIGPO_REGULAR) { // the well poe, starts immediately
-        thisx->flags &= ~0x10; // always update OFF
+        thisx->flags &= ~0x10;              // always update OFF
         this->unkBool204 = true;
         EnBigpo_InitWellBigpo(this);
     } else if (thisx->params == ENBIGPO_SUMMONED) { // dampe type

--- a/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
+++ b/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
@@ -279,16 +279,8 @@ static InitChainEntry sInitChain[] = {
 void EnDinofos_Init(Actor* thisx, GlobalContext* globalCtx) {
     static s32 D_8089E364 = 0;
     static EffBlureInit2 D_8089E368 = {
-        0,
-        8,
-        0,
-        { 255, 255, 255, 255 }, 
-        { 255, 255, 255, 64 },
-        { 255, 255, 255, 0 },
-        { 255, 255, 255, 0 },
-        8, 0, 2, 0,
-        { 0, 0, 0, 0 },
-        { 0, 0, 0, 0 },
+        0, 8, 0, { 255, 255, 255, 255 }, { 255, 255, 255, 64 }, { 255, 255, 255, 0 }, { 255, 255, 255, 0 }, 8,
+        0, 2, 0, { 0, 0, 0, 0 },         { 0, 0, 0, 0 },
     };
     EnDinofos* this = THIS;
     s32 i;

--- a/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
+++ b/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
@@ -346,8 +346,8 @@ void func_80A52DC8(EnDnq* this, GlobalContext* globalCtx) {
 
     if (!(gSaveContext.weekEventReg[23] & 0x20)) {
         this->unk_390 = 70.0f;
-        if (func_80114F2C(ITEM_DEKU_PRINCESS) && !func_801690CC(globalCtx) && (func_80152498(&globalCtx->msgCtx) == 0) &&
-            (ActorCutscene_GetCurrentIndex() == -1)) {
+        if (func_80114F2C(ITEM_DEKU_PRINCESS) && !func_801690CC(globalCtx) &&
+            (func_80152498(&globalCtx->msgCtx) == 0) && (ActorCutscene_GetCurrentIndex() == -1)) {
             if ((DECR(this->unk_384) == 0) && (gSaveContext.weekEventReg[29] & 0x40)) {
                 func_801518B0(globalCtx, 0x969, NULL);
                 this->unk_384 = 200;

--- a/src/overlays/actors/ovl_En_Holl/z_en_holl.c
+++ b/src/overlays/actors/ovl_En_Holl/z_en_holl.c
@@ -139,7 +139,7 @@ void EnHoll_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 
 void EnHoll_ChangeRooms(GlobalContext* globalCtx) {
     Room tempRoom = globalCtx->roomCtx.currRoom;
-    
+
     globalCtx->roomCtx.currRoom = globalCtx->roomCtx.prevRoom;
     globalCtx->roomCtx.prevRoom = tempRoom;
     globalCtx->roomCtx.activeMemPage ^= 1;
@@ -226,7 +226,7 @@ void EnHoll_TransparentIdle(EnHoll* this, GlobalContext* globalCtx) {
     Actor_CalcOffsetOrientedToDrawRotation(&this->actor, &transformedPlayerPos,
                                            useViewEye ? &globalCtx->view.eye : &player->actor.world.pos);
     enHollTop = (globalCtx->sceneNum == SCENE_PIRATE) ? EN_HOLL_TOP_PIRATE : EN_HOLL_TOP_DEFAULT;
-    
+
     if ((transformedPlayerPos.y > EN_HOLL_BOTTOM_DEFAULT) && (transformedPlayerPos.y < enHollTop) &&
         (fabsf(transformedPlayerPos.x) < EN_HOLL_HALFWIDTH_TRANSPARENT)) {
         if (playerDistFromCentralPlane = fabsf(transformedPlayerPos.z),
@@ -238,7 +238,7 @@ void EnHoll_TransparentIdle(EnHoll* this, GlobalContext* globalCtx) {
             s8 room = transitionActorEntry->sides[playerSide].room;
 
             this->actor.room = room;
-            
+
             if ((this->actor.room != globalCtx->roomCtx.currRoom.num) &&
                 Room_StartRoomTransition(globalCtx, &globalCtx->roomCtx, this->actor.room)) {
                 this->actionFunc = EnHoll_RoomTransitionIdle;
@@ -263,7 +263,7 @@ void EnHoll_VerticalBgCoverIdle(EnHoll* this, GlobalContext* globalCtx) {
             s32 playerSide = (this->actor.yDistToPlayer > 0.0f) ? EN_HOLL_ABOVE : EN_HOLL_BELOW;
 
             this->actor.room = globalCtx->doorCtx.transitionActorList[enHollId].sides[playerSide].room;
-            
+
             if ((this->actor.room != globalCtx->roomCtx.currRoom.num) &&
                 Room_StartRoomTransition(globalCtx, &globalCtx->roomCtx, this->actor.room)) {
                 this->actionFunc = EnHoll_RoomTransitionIdle;

--- a/src/overlays/actors/ovl_En_Pametfrog/z_en_pametfrog.c
+++ b/src/overlays/actors/ovl_En_Pametfrog/z_en_pametfrog.c
@@ -879,7 +879,8 @@ void EnPametfrog_FallInAir(EnPametfrog* this, GlobalContext* globalCtx) {
     } else {
         this->spinYaw += 0xF00;
         if (this->camId != 0) {
-            Play_CameraSetAtEye(globalCtx, this->camId, &this->actor.world.pos, &Play_GetCamera(globalCtx, this->camId)->eye);
+            Play_CameraSetAtEye(globalCtx, this->camId, &this->actor.world.pos,
+                                &Play_GetCamera(globalCtx, this->camId)->eye);
         }
 
         if (this->actor.bgCheckFlags & 1) {

--- a/sym_info.py
+++ b/sym_info.py
@@ -10,7 +10,7 @@ parser.add_argument(
     "name",
     type=str,
     default="",
-    help="symbol name or ROM/RAM address to lookup"
+    help="symbol name or VROM/VRAM address to lookup"
 )
 parser.add_argument(
     "-e",
@@ -73,10 +73,10 @@ def search_address(target_addr):
                 continue
 
             if rom == target_addr or (is_ram and ram == target_addr):
-                return f"{sym} (RAM 0x{ram:X}, ROM 0x{rom:X}, {cur_file})"
+                return f"{sym} (VRAM 0x{ram:X}, VROM 0x{rom:X}, {cur_file})"
             if rom > target_addr or (is_ram and ram > target_addr):
                 offset = target_addr - prev_ram if is_ram else target_addr - prev_rom
-                return f"at 0x{offset:X} bytes inside {prev_sym} (RAM 0x{prev_ram:X}, ROM 0x{prev_rom:X}, {prev_file})"
+                return f"at 0x{offset:X} bytes inside {prev_sym} (VRAM 0x{prev_ram:X}, VROM 0x{prev_rom:X}, {prev_file})"
 
             prev_ram = ram
             prev_rom = rom
@@ -134,6 +134,6 @@ except ValueError:
         sym_rom = sym_info[0]
         sym_file = sym_info[1]
         sym_ram = sym_info[2]
-        print(f"Symbol {args.name} (RAM: 0x{sym_ram:08X}, ROM: 0x{sym_rom:06X}, {sym_file})")
+        print(f"Symbol {args.name} (VRAM: 0x{sym_ram:08X}, VROM: 0x{sym_rom:06X}, {sym_file})")
     else:
         print(f"Symbol {args.name} not found in map file {mymap}")


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Two very minor things:
- changed the `CC_CHECK` to use `-funsigned-char` since IDO apparently uses unsigned `char`s (we should think about if we want to avoid `char` altogether, but we don't really need to make that change yet since we are nowhere near supporting other compilers).
- Changed `sym_info.py` to print "VROM" and "VRAM" instead of "ROM" and "RAM", since technically it's always been VRAM, and the mapfile (which `sym_info.py` reads to get its data) only knows about VROM. I didn't change the internal variable names since anyone modifying the script hopefully knows enough to distinguish.
- Run the formatter, seems like a few recent PRs missed it.