### PR TITLE
resetglobalintmask OK

### DIFF
--- a/src/libultra/os/resetglobalintmask.c
+++ b/src/libultra/os/resetglobalintmask.c
@@ -1,3 +1,8 @@
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/resetglobalintmask/__osResetGlobalIntMask.s")
+void __osResetGlobalIntMask(u32 mask) {
+    register s32 prevInt = __osDisableInt();
+
+    __OSGlobalIntMask &= ~(mask & ~0x401);
+    __osRestoreInt(prevInt);
+}


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
The most interesting thing about this file is that `register` makes a significant difference to the codegen.