### PR TITLE
sethwinterrupt OK

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -479,7 +479,7 @@ void* osViGetCurrentFramebuffer(void);
 s32 __osSpSetPc(void* data);
 // void __osVoiceContWrite4(void);
 void __osGetHWIntrRoutine(s32 idx, OSMesgQueue** outQueue, OSMesg* outMsg);
-// void __osSetHWIntrRoutine(void);
+void __osSetHWIntrRoutine(s32 idx, OSMesgQueue* queue, OSMesg msg);
 u32 __osGetWatchLo(void);
 void __osSetWatchLo(u32 value);
 f32 fmodf(f32 dividend, f32 divisor);

--- a/src/libultra/os/sethwinterrupt.c
+++ b/src/libultra/os/sethwinterrupt.c
@@ -1,3 +1,10 @@
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/sethwinterrupt/__osSetHWIntrRoutine.s")
+void __osSetHWIntrRoutine(s32 idx, OSMesgQueue* queue, OSMesg msg) {
+    register s32 prevInt = __osDisableInt();
+
+    __osHwIntTable[idx].queue = queue;
+    __osHwIntTable[idx].msg = msg;
+
+    __osRestoreInt(prevInt);
+}


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Last function in libultra/os matched. 2/6 libultra folders complete.