### PR TITLE
Match last function in z_prenmi, add DISPS macros to ArmsHook

### DIFF
--- a/src/code/z_prenmi.c
+++ b/src/code/z_prenmi.c
@@ -16,21 +16,25 @@ void PreNMI_Update(PreNMIContext* prenmiCtx) {
     prenmiCtx->timer--;
 }
 
-#ifdef NON_MATCHING
+// #ifdef NON_MATCHING
 // Minor reordering around call to func_8012C470
 void PreNMI_Draw(PreNMIContext* prenmiCtx) {
     GraphicsContext* gfxCtx = prenmiCtx->state.gfxCtx;
 
     func_8012CF0C(gfxCtx, 1, 1, 0, 0, 0);
+
+    OPEN_DISPS(gfxCtx);
+    
     func_8012C470(gfxCtx);
 
-    gDPSetFillColor(gfxCtx->polyOpa.p++,
+    gDPSetFillColor(POLY_OPA_DISP++,
                     (GPACK_RGBA5551(0xFF, 0xFF, 0xFF, 1) << 16) | GPACK_RGBA5551(0xFF, 0xFF, 0xFF, 1));
-    gDPFillRectangle(gfxCtx->polyOpa.p++, 0, prenmiCtx->timer + 100, 320 /*SCREEN_WIDTH*/ - 1, prenmiCtx->timer + 100);
+    gDPFillRectangle(POLY_OPA_DISP++, 0, prenmiCtx->timer + 100, 320 /*SCREEN_WIDTH*/ - 1, prenmiCtx->timer + 100);
+    CLOSE_DISPS(gfxCtx);
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_prenmi/PreNMI_Draw.s")
-#endif
+// #else
+// #pragma GLOBAL_ASM("asm/non_matchings/code/z_prenmi/PreNMI_Draw.s")
+// #endif
 
 void PreNMI_Main(PreNMIContext* prenmiCtx) {
     PreNMI_Update(prenmiCtx);

--- a/src/code/z_prenmi.c
+++ b/src/code/z_prenmi.c
@@ -22,12 +22,11 @@ void PreNMI_Draw(PreNMIContext* prenmiCtx) {
     func_8012CF0C(gfxCtx, 1, 1, 0, 0, 0);
 
     OPEN_DISPS(gfxCtx);
-    
+
     func_8012C470(gfxCtx);
 
-    gDPSetFillColor(POLY_OPA_DISP++,
-                    (GPACK_RGBA5551(255, 255, 255, 1) << 16) | GPACK_RGBA5551(255, 255, 255, 1));
-    gDPFillRectangle(POLY_OPA_DISP++, 0, prenmiCtx->timer + 100, 320 /*SCREEN_WIDTH*/ - 1, prenmiCtx->timer + 100);
+    gDPSetFillColor(POLY_OPA_DISP++, (GPACK_RGBA5551(255, 255, 255, 1) << 16) | GPACK_RGBA5551(255, 255, 255, 1));
+    gDPFillRectangle(POLY_OPA_DISP++, 0, prenmiCtx->timer + 100, SCREEN_WIDTH - 1, prenmiCtx->timer + 100);
 
     CLOSE_DISPS(gfxCtx);
 }

--- a/src/code/z_prenmi.c
+++ b/src/code/z_prenmi.c
@@ -16,8 +16,6 @@ void PreNMI_Update(PreNMIContext* prenmiCtx) {
     prenmiCtx->timer--;
 }
 
-// #ifdef NON_MATCHING
-// Minor reordering around call to func_8012C470
 void PreNMI_Draw(PreNMIContext* prenmiCtx) {
     GraphicsContext* gfxCtx = prenmiCtx->state.gfxCtx;
 
@@ -28,13 +26,11 @@ void PreNMI_Draw(PreNMIContext* prenmiCtx) {
     func_8012C470(gfxCtx);
 
     gDPSetFillColor(POLY_OPA_DISP++,
-                    (GPACK_RGBA5551(0xFF, 0xFF, 0xFF, 1) << 16) | GPACK_RGBA5551(0xFF, 0xFF, 0xFF, 1));
+                    (GPACK_RGBA5551(255, 255, 255, 1) << 16) | GPACK_RGBA5551(255, 255, 255, 1));
     gDPFillRectangle(POLY_OPA_DISP++, 0, prenmiCtx->timer + 100, 320 /*SCREEN_WIDTH*/ - 1, prenmiCtx->timer + 100);
+
     CLOSE_DISPS(gfxCtx);
 }
-// #else
-// #pragma GLOBAL_ASM("asm/non_matchings/code/z_prenmi/PreNMI_Draw.s")
-// #endif
 
 void PreNMI_Main(PreNMIContext* prenmiCtx) {
     PreNMI_Update(prenmiCtx);

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -287,50 +287,47 @@ static Vec3f D_808C1C4C = { 0.0f, -500.0f, 0.0f };
 
 void ArmsHook_Draw(Actor* thisx, GlobalContext* globalCtx) {
     ArmsHook* this = THIS;
-    s32 pad;
+    f32 f0;
     Player* player = PLAYER;
-    Vec3f sp68;
-    Vec3f sp5C;
-    Vec3f sp50;
-    f32 sp4C;
-    f32 sp48;
 
     if (player->actor.draw != NULL && player->rightHandType == 0xB) {
-        // OPEN_DISP macro
-        {
-            GraphicsContext* sp44 = globalCtx->state.gfxCtx;
-            f32 f0;
+        Vec3f sp68;
+        Vec3f sp5C;
+        Vec3f sp50;
+        f32 sp4C;
+        f32 sp48;
 
-            if ((ArmsHook_Shoot != this->actionFunc) || (this->timer <= 0)) {
-                SysMatrix_MultiplyVector3fByState(&D_808C1C10, &this->unk1E0);
-                SysMatrix_MultiplyVector3fByState(&D_808C1C28, &sp5C);
-                SysMatrix_MultiplyVector3fByState(&D_808C1C34, &sp50);
-                this->unk1C4 = 0;
-            } else {
-                SysMatrix_MultiplyVector3fByState(&D_808C1C1C, &this->unk1E0);
-                SysMatrix_MultiplyVector3fByState(&D_808C1C40, &sp5C);
-                SysMatrix_MultiplyVector3fByState(&D_808C1C4C, &sp50);
-            }
-            func_80126440(globalCtx, &this->collider.base, &this->unk1C4, &sp5C, &sp50);
-            func_8012C28C(globalCtx->state.gfxCtx);
-            func_80122868(globalCtx, player);
+        OPEN_DISPS(globalCtx->state.gfxCtx);
 
-            gSPMatrix(sp44->polyOpa.p++, Matrix_NewMtx(globalCtx->state.gfxCtx),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(sp44->polyOpa.p++, D_0601D960);
-            SysMatrix_InsertTranslation(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
-                                        MTXMODE_NEW);
-            Math_Vec3f_Diff(&player->rightHandWorld.pos, &this->actor.world.pos, &sp68);
-            sp48 = SQ(sp68.x) + SQ(sp68.z);
-            sp4C = sqrtf(sp48);
-            Matrix_RotateY(Math_Atan2S(sp68.x, sp68.z), MTXMODE_APPLY);
-            SysMatrix_InsertXRotation_s(Math_Atan2S(-sp68.y, sp4C), MTXMODE_APPLY);
-            f0 = sqrtf(SQ(sp68.y) + sp48);
-            Matrix_Scale(0.015f, 0.015f, f0 * 0.01f, MTXMODE_APPLY);
-            gSPMatrix(sp44->polyOpa.p++, Matrix_NewMtx(globalCtx->state.gfxCtx),
-                      G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(sp44->polyOpa.p++, D_040008D0);
-            func_801229A0(globalCtx, player);
+        if ((ArmsHook_Shoot != this->actionFunc) || (this->timer <= 0)) {
+            SysMatrix_MultiplyVector3fByState(&D_808C1C10, &this->unk1E0);
+            SysMatrix_MultiplyVector3fByState(&D_808C1C28, &sp5C);
+            SysMatrix_MultiplyVector3fByState(&D_808C1C34, &sp50);
+            this->unk1C4 = 0;
+        } else {
+            SysMatrix_MultiplyVector3fByState(&D_808C1C1C, &this->unk1E0);
+            SysMatrix_MultiplyVector3fByState(&D_808C1C40, &sp5C);
+            SysMatrix_MultiplyVector3fByState(&D_808C1C4C, &sp50);
         }
+        func_80126440(globalCtx, &this->collider.base, &this->unk1C4, &sp5C, &sp50);
+        func_8012C28C(globalCtx->state.gfxCtx);
+        func_80122868(globalCtx, player);
+
+        gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPDisplayList(POLY_OPA_DISP++, D_0601D960);
+        SysMatrix_InsertTranslation(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
+                                    MTXMODE_NEW);
+        Math_Vec3f_Diff(&player->rightHandWorld.pos, &this->actor.world.pos, &sp68);
+        sp48 = SQ(sp68.x) + SQ(sp68.z);
+        sp4C = sqrtf(SQ(sp68.x) + SQ(sp68.z));
+        Matrix_RotateY(Math_Atan2S(sp68.x, sp68.z), MTXMODE_APPLY);
+        SysMatrix_InsertXRotation_s(Math_Atan2S(-sp68.y, sp4C), MTXMODE_APPLY);
+        f0 = sqrtf(SQ(sp68.y) + sp48);
+        Matrix_Scale(0.015f, 0.015f, f0 * 0.01f, MTXMODE_APPLY);
+        gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+        gSPDisplayList(POLY_OPA_DISP++, D_040008D0);
+        func_801229A0(globalCtx, player);
+
+        CLOSE_DISPS(globalCtx->state.gfxCtx);
     }
 }

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -318,8 +318,8 @@ void ArmsHook_Draw(Actor* thisx, GlobalContext* globalCtx) {
         SysMatrix_InsertTranslation(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z,
                                     MTXMODE_NEW);
         Math_Vec3f_Diff(&player->rightHandWorld.pos, &this->actor.world.pos, &sp68);
-        sp48 = SQ(sp68.x) + SQ(sp68.z);
-        sp4C = sqrtf(SQ(sp68.x) + SQ(sp68.z));
+        sp48 = SQXZ(sp68);
+        sp4C = sqrtf(SQXZ(sp68));
         Matrix_RotateY(Math_Atan2S(sp68.x, sp68.z), MTXMODE_APPLY);
         SysMatrix_InsertXRotation_s(Math_Atan2S(-sp68.y, sp4C), MTXMODE_APPLY);
         f0 = sqrtf(SQ(sp68.y) + sp48);


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
PreNMI_Draw just needed the DISPS macros to match, so I added them. Also did ArmsHook, although I had to fake-match it a bit.