### PR TITLE
Remove `.mdebug` sections by default

### DIFF
--- a/diff_settings.py
+++ b/diff_settings.py
@@ -5,3 +5,4 @@ def apply(config, args):
     config['myimg'] = 'mm.us.rev1.rom_uncompressed.z64'
     config['mapfile'] = 'build/mm.map'
     config['source_directories'] = ['./src','./include']
+    config['makeflags'] = ['KEEP_MDEBUG=1']


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Since `-g3` produces a very large `.mdebug` section, MM currently produces much larger object files (`.o` files, to be unambiguous), and often it takes forever to link. Therefore @Thar0 and I came up with a way to remove the `.mdebug` section from the files at build time. 
- This speeds up linking considerably, dwarfing the earlier timeloss from the extra `objdump`ing required, and meaning that even on a slow computer like mine, linking takes less than a minute instead of the 5+ it was taking with the section included.
- The output object files are far smaller: this is the size difference between an `expected/build` with mdebug and `build` without:
```
$ du build/src -sh
253M    build/src
$ du expected/build/src -sh
784M    expected/build/src
```
- The only thing most people would use `.mdebug` for is `diff.py` with the `--source` flag, which uses it to print the code above the lines of assembly it compiles to. (Yes, this option exists!) To enable this, and any other uses people might want to put mdebug to, we made it so that a flag can be passed to the makefile to keep it: `KEEP_MDEBUG=1`. This has been added to the diff settings to work by default as well. If you want to keep the mdebug section by default when building, you can replace `KEEP_MDEBUG ?= 0` by `KEEP_MDEBUG ?= 1` in the makefile.