### PR TITLE
Update diff.py

### DIFF
--- a/tools/asm-differ/.gitrepo
+++ b/tools/asm-differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ.git
 	branch = main
-	commit = 1dfba80e1b36bb31c9ea64cb04583e7b36d839a6
-	parent = f14e8c9d9e68107609c9eeb4408bbfd1cd850eee
+	commit = 6f35aac2647fae44ea6ee1ce15d66097dd6824f6
+	parent = da1265f4bcaec99bc884cb9ee0a5f61535780014
 	method = merge
 	cmdver = 0.4.3

--- a/tools/asm-differ/.pre-commit-config.yaml
+++ b/tools/asm-differ/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+      language_version: python3.6

--- a/tools/asm-differ/README.md
+++ b/tools/asm-differ/README.md
@@ -1,6 +1,6 @@
 # asm-differ
 
-Nice differ for assembly code (MIPS and AArch64; should be easy to hack to support other instruction sets).
+Nice differ for assembly code (MIPS, PPC and AArch64; should be easy to hack to support other instruction sets).
 
 ![](screenshot.png)
 
@@ -13,7 +13,7 @@ Nice differ for assembly code (MIPS and AArch64; should be easy to hack to suppo
 
 Create a file `diff_settings.sh` in some directory (see the one in this repo for an example). Then from that directory, run
 
-```
+```bash
 /path/to/diff.sh [flags] (function|rom addr)
 ```
 
@@ -25,7 +25,7 @@ Recommended flags are `-mwo` (automatically run `make` on source file changes, a
 
 If invoking the script **exactly** as `./diff.py`, the following should be added to the `.bashrc` according to argcomplete's instructions:
 
-```sh
+```bash
 eval "$(register-python-argcomplete ./diff.py)"
 ```
 
@@ -33,8 +33,24 @@ If that doesn't work, run `register-python-argcomplete ./diff.py` in your termin
 
 If setup correctly (don't forget to restart the shell), `complete | grep ./diff.py` should output:
 
-```
+```bash
 complete -o bashdefault -o default -o nospace -F _python_argcomplete ./diff.py
 ```
 
 Note for developers or for general troubleshooting: run `export _ARC_DEBUG=` to enable debug output during tab-completion, it may show otherwise silenced errors. Use `unset _ARC_DEBUG` or restart the terminal to disable.
+
+### Contributing
+
+Contributions are very welcome! Some notes on workflow:
+
+`black` is used for code formatting. You can either run `black diff.py` manually, or set up a pre-commit hook:
+```bash
+pip install pre-commit black
+pre-commit install
+```
+
+Type annotations are used for all Python code. `mypy` should pass without any errors.
+
+PRs that skip the above are still welcome, however.
+
+The targeted Python version is 3.6. There are currently no tests.

--- a/tools/asm-differ/diff-stylesheet.css
+++ b/tools/asm-differ/diff-stylesheet.css
@@ -3,6 +3,9 @@ table.diff {
     font-family: Monospace;
     white-space: pre;
 }
+tr.data-ref {
+    background-color: gray;
+}
 .immediate {
     color: lightblue;
 }

--- a/tools/asm-differ/diff_settings.py
+++ b/tools/asm-differ/diff_settings.py
@@ -3,6 +3,7 @@ def apply(config, args):
     config["myimg"] = "source.bin"
     config["mapfile"] = "build.map"
     config["source_directories"] = ["."]
+    # config["show_line_numbers_default"] = True
     # config["arch"] = "mips"
     # config["map_format"] = "gnu" # gnu or mw
     # config["mw_build_dir"] = "build/" # only needed for mw map format

--- a/tools/asm-differ/mypy.ini
+++ b/tools/asm-differ/mypy.ini
@@ -2,7 +2,6 @@
 check_untyped_defs = True
 disallow_any_generics = True
 disallow_incomplete_defs = True
-disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
@@ -10,6 +9,7 @@ no_implicit_optional = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unused_ignores = True
+ignore_missing_imports = True
 python_version = 3.6
 files = diff.py
 


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Copy-Pasta from an Identical PR over from OoT:

Lots of nice diff.py changes over the past month. Highlights:

- shows line numbers
- shows jump table targets
- shows approximate permuter score
- adds two new flags -U and -V for collapsing matching parts of the diff
- fixes a bug where symbol differences would not be shown in blue
- ignores .rodata+0x... vs D_ differences
- performance improvements/less flicker on refresh