### PR TITLE
obj_aqua OK

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1108,8 +1108,7 @@ u32 func_800C9D8C(CollisionContext* param_1, CollisionPoly* param_2, s32 param_3
 u32 func_800C9E18(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
 u32 func_800C9E40(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
 u32 func_800C9E88(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
-// void func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, UNK_TYPE1 param_3, UNK_TYPE1 param_4, UNK_TYPE4 param_5, UNK_TYPE4 param_6, UNK_TYPE4 param_7);
-s32 func_800CA1AC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox);
+s32 func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox, s32* bgId);s32 func_800CA1AC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox);
 void func_800CA1E8(GlobalContext* globalCtx, CollisionContext* colCtx, f32 arg2, f32 arg3, f32* arg4, UNK_PTR arg5);
 // void func_800CA22C(UNK_TYPE1 param_1, UNK_TYPE1 param_2, UNK_TYPE1 param_3, UNK_TYPE1 param_4, UNK_TYPE4 param_5, UNK_TYPE4 param_6);
 // void func_800CA568(void);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1108,7 +1108,8 @@ u32 func_800C9D8C(CollisionContext* param_1, CollisionPoly* param_2, s32 param_3
 u32 func_800C9E18(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
 u32 func_800C9E40(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
 u32 func_800C9E88(CollisionContext* colCtx, CollisionPoly* polygon, s32 index);
-s32 func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox, s32* bgId);s32 func_800CA1AC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox);
+s32 func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox, s32* bgId);
+s32 func_800CA1AC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface, WaterBox** outWaterBox);
 void func_800CA1E8(GlobalContext* globalCtx, CollisionContext* colCtx, f32 arg2, f32 arg3, f32* arg4, UNK_PTR arg5);
 // void func_800CA22C(UNK_TYPE1 param_1, UNK_TYPE1 param_2, UNK_TYPE1 param_3, UNK_TYPE1 param_4, UNK_TYPE4 param_5, UNK_TYPE4 param_6);
 // void func_800CA568(void);

--- a/spec
+++ b/spec
@@ -3588,11 +3588,7 @@ beginseg
     name "ovl_Obj_Aqua"
     compress
     include "build/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_Obj_Aqua/ovl_Obj_Aqua_reloc.o"
-#else
-    include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -3588,7 +3588,7 @@ beginseg
     name "ovl_Obj_Aqua"
     compress
     include "build/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.o"
-    include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.data.o"
+    //include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.data.o"
     include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.reloc.o"
 endseg
 

--- a/spec
+++ b/spec
@@ -3588,8 +3588,11 @@ beginseg
     name "ovl_Obj_Aqua"
     compress
     include "build/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.o"
-    //include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.data.o"
+#ifdef NON_MATCHING
+    include "build/src/overlays/actors/ovl_Obj_Aqua/ovl_Obj_Aqua_reloc.o"
+#else
     include "build/data/ovl_Obj_Aqua/ovl_Obj_Aqua.reloc.o"
+#endif
 endseg
 
 beginseg

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -78,7 +78,7 @@ void func_80ACB6A0(ObjAqua* this, GlobalContext* globalCtx) {
     for (i = 0; i < 4; i++) {
         sp58.x = this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f;
         sp58.z = this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f;
-        EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x78);
+        EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 120);
         angleOffset += 0x4000;
     }
     sp58.x = this->actor.world.pos.x;

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -185,7 +185,7 @@ void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx) {
             func_80ACBD34(this);
         } else {
             func_80ACB6A0(this, globalCtx);
-            func_800F0568(globalCtx, &this->actor.world.pos, 0x28, 0x2817);
+            Audio_PlaySoundAtPosition(globalCtx, &this->actor.world.pos, 0x28, 0x2817);
             Actor_MarkForDeath(&this->actor);
         }
     } else if (this->counter <= 0) {

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -83,7 +83,7 @@ void func_80ACB6A0(ObjAqua* this, GlobalContext* globalCtx) {
     }
     sp58.x = this->actor.world.pos.x;
     sp58.z = this->actor.world.pos.z;
-    EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x12C);
+    EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 300);
 }
 
 void func_80ACB7F4(ObjAqua* this, GlobalContext* globalCtx) {
@@ -136,9 +136,9 @@ s32 func_80ACBA60(ObjAqua* this, GlobalContext* globalCtx) {
     if (func_800C9EBC(globalCtx, &globalCtx->colCtx, this->actor.world.pos.x, this->actor.world.pos.z, &ySurface,
                       &waterBox, &bgId) &&
         (this->actor.world.pos.y < ySurface)) {
-        return 1;
+        return true;
     }
-    return 0;
+    return false;
 }
 
 void ObjAqua_Init(Actor* thisx, GlobalContext* globalCtx) {
@@ -152,7 +152,7 @@ void ObjAqua_Init(Actor* thisx, GlobalContext* globalCtx) {
     Collider_InitCylinder(globalCtx, &this->collider);
     Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &sCylinderInit);
     ActorShape_Init(&this->actor.shape, 0.0f, func_800B3FC0, 60.0f);
-    if (0) {};
+    if (1) {};
     this->actor.shape.shadowAlpha = 140;
     this->alpha = 255;
     if (func_80ACBA60(this, globalCtx)) {
@@ -181,11 +181,11 @@ void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx) {
         if (this->actor.bgCheckFlags & 1) {
             func_80ACB7F4(this, globalCtx);
             func_80ACBA10(this);
-            Audio_PlayActorSound2(&this->actor, 0x2920);
+            Audio_PlayActorSound2(&this->actor, NA_SE_EV_BOTTLE_WATERING);
             func_80ACBD34(this);
         } else {
             func_80ACB6A0(this, globalCtx);
-            Audio_PlaySoundAtPosition(globalCtx, &this->actor.world.pos, 0x28, 0x2817);
+            Audio_PlaySoundAtPosition(globalCtx, &this->actor.world.pos, 0x28, NA_SE_EV_BOMB_DROP_WATER);
             Actor_MarkForDeath(&this->actor);
         }
     } else if (this->counter <= 0) {
@@ -247,7 +247,7 @@ void ObjAqua_Update(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad;
 
     if (this->counter > 0) {
-        this->counter -= 1;
+        this->counter--;
     }
     this->actionFunc(this, globalCtx);
     if (this->actor.update) {
@@ -273,7 +273,7 @@ void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;
     s32 framesTemp;
     s32 pad;
-    s16 cameraTemp = func_800DFCDC(globalCtx->cameraPtrs[globalCtx->activeCamera]) + 0x8000;
+    s16 yaw = func_800DFCDC(globalCtx->cameraPtrs[globalCtx->activeCamera]) + 0x8000;
     s32 actionFuncTemp = this->actionFunc == func_80ACBDFC;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -288,12 +288,13 @@ void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx) {
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 150, 255, 0);
     if (actionFuncTemp) {
         s16 rotation = Math_SinS(this->unk_198) * 8000.0f;
+
         SysMatrix_InsertZRotation_s(rotation, 1);
         Matrix_Scale(1.3f, 1.0f, 1.0f, 1);
         SysMatrix_InsertZRotation_s(rotation * -1, 1);
         Matrix_Scale(10.0f / 13.0f, 1.0f, 1.0f, 1);
     }
-    Matrix_RotateY(cameraTemp, 1);
+    Matrix_RotateY(yaw, 1);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_XLU_DISP++, D_0407D590);
     CLOSE_DISPS(globalCtx->state.gfxCtx);

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -23,6 +23,11 @@ void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBD48(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx);
 
+void func_80ACB6A0(ObjAqua *this, GlobalContext *globalCtx);
+void func_80ACB7F4(ObjAqua *this, GlobalContext *globalCtx);
+void func_80ACBA10(ObjAqua* this);
+void func_80ACBD34(ObjAqua* this);
+
 const ActorInit Obj_Aqua_InitVars = {
     ACTOR_OBJ_AQUA,
     ACTORCAT_ITEMACTION,
@@ -52,44 +57,132 @@ static InitChainEntry D_80ACC2EC[] = {
     ICHAIN_F32(uncullZoneScale, 300, ICHAIN_CONTINUE),
     ICHAIN_F32(uncullZoneDownward, 300, ICHAIN_STOP),
 };
+Vec3f D_80ACC308 = {1.0f/1000.0f, 7.0f/10000.0f, 1.0f/1000.0f};
+Vec3f D_80ACC314 = {8.6f/1000.0f, 8.0f/10000.0f, 8.6f/1000.0f};
+Vec3f D_80ACC320 = {1.0f/100.0f, 2.6f/1000.0f, 1.0f/100.0f};
 
-s32 D_80ACC308[] = {0x3A83126F, 0x3A378034, 0x3A83126F};
-s32 D_80ACC314[] = {0x3C0CE704, 0x3A51B717, 0x3C0CE704};
-s32 D_80ACC320[] = {0x3C23D70A, 0x3B2A64C3, 0x3C23D70A};
+extern Gfx D_0407D590[];
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB6A0.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB6A0.s")
+// dropping water on top of waterbox
+void func_80ACB6A0(ObjAqua *this, GlobalContext *globalCtx)
+{
+    s32 pad;
+    Vec3f sp58;
+    s32 phi_s0;
+    s32 i;
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB7F4.s")
+    sp58.y = this->actor.world.pos.y + this->actor.yDistToWater;
+    phi_s0 = 0;
+    for (i = 0; i < 4; i++)
+    {
+        sp58.x = this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f;
+        sp58.z = this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f;
+        EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x78);
+        phi_s0 += 0x4000;
+    }
+    sp58.x = this->actor.world.pos.x;
+    sp58.z = this->actor.world.pos.z;
+    EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x12C);
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB940.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA10.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB7F4.s")
+// dropping water on solid ground
+void func_80ACB7F4(ObjAqua *this, GlobalContext *globalCtx)
+{
+    s32 pad;
+    Vec3f sp58;
+    s32 phi_s0;
+    s32 i;
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA60.s")
+    sp58.y = this->actor.floorHeight;
+    phi_s0 = 0;
+    for (i = 0; i < 4; i++)
+    {
+        sp58.x = (this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f);
+        sp58.z = (this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f);
+        EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x78);
+        phi_s0 += 0x4000;
+    }
+    sp58.x = this->actor.world.pos.x;
+    sp58.z = this->actor.world.pos.z;
+    EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x12C);
+}
+
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB940.s")
+void func_80ACB940(ObjAqua *this, GlobalContext *globalCtx)
+{
+    s32 pad;
+    Vec3f sp30; //pos
+    Vec3f sp24; //velocity
+
+    sp24.x = Rand_ZeroOne() - 0.5f;
+    sp24.y = 2.0f;
+    sp24.z = Rand_ZeroOne() - 0.5f;
+    sp30.x = this->actor.world.pos.x + (sp24.x * 40.0f);
+    sp30.y = this->actor.world.pos.y;
+    sp30.z = this->actor.world.pos.z + (sp24.z * 40.0f);
+    EffectSsIceSmoke_Spawn(globalCtx, &sp30, &sp24, &D_801D15B0, (s32)(Rand_ZeroOne() * 24.0f) + 70);
+}
+
+
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA10.s")
+void func_80ACBA10(ObjAqua *this)
+{
+    s32 pad;
+    MtxF sp2C;
+
+    func_800C0094(this->actor.floorPoly, this->actor.world.pos.x, this->actor.floorHeight, this->actor.world.pos.z, &sp2C);
+    func_8018219C(&sp2C, &this->actor.shape.rot, 0);
+}
+
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA60.s")
+//WaterBox_GetSurfaceImpl
+//from mzx's bgcheck branch
+extern s32 func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface,
+WaterBox** outWaterBox, s32* bgId);
+s32 func_80ACBA60(ObjAqua *this, GlobalContext *globalCtx)
+{
+    s32 pad;
+    WaterBox* waterBox;
+    f32 ySurface;
+    s32 bgId;
+
+    if (func_800C9EBC(
+        globalCtx,
+        &globalCtx->colCtx,
+        this->actor.world.pos.x,
+        this->actor.world.pos.z,
+        &ySurface, &waterBox, &bgId) && (this->actor.world.pos.y < ySurface))
+    {
+        return 1;
+    }
+    return 0;
+}
 
 // #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Init.s")
 void ObjAqua_Init(Actor* thisx, GlobalContext *globalCtx)
 {
     ObjAqua* this = THIS;
-    s32 phi_s0;
+    s32 i;
 
     Actor_ProcessInitChain(&this->actor, D_80ACC2EC);
     this->actor.scale.x = 0.0009f;
-    this->actor.scale.z = 0.0009f;
     this->actor.scale.y = 0.0005f;
+    this->actor.scale.z = 0.0009f;
     Collider_InitCylinder(globalCtx, &this->collider);
     Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &D_80ACC2C0);
     ActorShape_Init(&this->actor.shape, 0.0f, func_800B3FC0, 60.0f);
+    if(0){};
     this->actor.shape.shadowAlpha = 140;
-    this->unk_196 = 0xFF;
-    phi_s0 = 0;
+    this->unk_196 = 255;
     if (func_80ACBA60(this, globalCtx))
     {
-        while (phi_s0 != 8)
+        for (i = 0; i < 8; i++)
         {
             EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, -4.0f, 4.0f, 4.0f, (Rand_ZeroOne() * 0.09f) + 0.03f);
-            phi_s0++;
-        } 
+        }
         func_80ACBDCC(this);
     }
     else
@@ -98,20 +191,177 @@ void ObjAqua_Init(Actor* thisx, GlobalContext *globalCtx)
     }
 }
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Destroy.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Destroy.s")
+void ObjAqua_Destroy(Actor* thisx, GlobalContext *globalCtx)
+{
+    ObjAqua* this = THIS;
+    Collider_DestroyCylinder(globalCtx, &this->collider);
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC70.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC8C.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC70.s")
+void func_80ACBC70(ObjAqua *this)
+{
+    this->unk_194 = 200;
+    this->actionFunc = func_80ACBC8C;
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD34.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC8C.s")
+void func_80ACBC8C(ObjAqua *this, GlobalContext *globalCtx)
+{
+    if (this->actor.bgCheckFlags & 0x21)
+    {
+        if (this->actor.bgCheckFlags & 1)
+        {
+            func_80ACB7F4(this, globalCtx);
+            func_80ACBA10(this);
+            Audio_PlayActorSound2(&this->actor, 0x2920);
+            func_80ACBD34(this);
+        }
+        else
+        {
+            func_80ACB6A0(this, globalCtx);
+            func_800F0568(globalCtx, &this->actor.world.pos, 0x28, 0x2817);
+            Actor_MarkForDeath(&this->actor);
+        }
+    }
+    else if (this->unk_194 <= 0)
+    {
+        Actor_MarkForDeath(&this->actor);
+    }
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD48.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD34.s")
+void func_80ACBD34(ObjAqua* this)
+{
+    this->actionFunc = func_80ACBD48;
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDCC.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD48.s")
+void func_80ACBD48(ObjAqua *this, GlobalContext *globalCtx)
+{
+    if (((this->actor.params & 1) == 1) && (this->unk_196 >= 91))
+    {
+        func_80ACB940(this, globalCtx);
+    }
+    if (this->unk_196 >= 6)
+    {
+        this->unk_196 -= 5;
+    }
+    else
+    {
+        this->unk_196 = 0;
+    }
+    if (this->actor.shape.shadowAlpha >= 3)
+    {
+        this->actor.shape.shadowAlpha -= 2;
+    }
+    else
+    {
+        Actor_MarkForDeath(&this->actor);
+    }
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDFC.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDCC.s")
+void func_80ACBDCC(ObjAqua *this)
+{
+    this->actor.gravity = -0.1f;
+    this->unk_194 = 40;
+    this->unk_196 = 140;
+    this->actionFunc = func_80ACBDFC;
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Update.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDFC.s")
+void func_80ACBDFC(ObjAqua *this, GlobalContext *globalCtx)
+{
+    f32 temp_f2;
+    f32 temp = this->unk_194 * 3.25f;
+    
+    this->unk_198 += 1000;
+    this->actor.shape.shadowAlpha = this->unk_196 = (s32)(temp) + 10;
+    if ((this->actor.params & 1) == 1)
+    {
+        temp_f2 = this->actor.scale.x * 10000.0f;
+        EffectSsBubble_Spawn(
+            globalCtx,
+            &this->actor.world.pos,
+            temp_f2 * -0.5f,
+            temp_f2,
+            temp_f2,
+            (Rand_ZeroOne() * 0.1f) + 0.03f);
+    }
+    if (this->unk_194 <= 0)
+    {
+        Actor_MarkForDeath(&this->actor);
+    }
+}
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Draw.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Update.s")
+void ObjAqua_Update(Actor* thisx, GlobalContext *globalCtx)
+{
+    ObjAqua* this = THIS;
+    s32 pad;
+
+    if (this->unk_194 > 0)
+    {
+        this->unk_194 -= 1;
+    }
+    this->actionFunc(this, globalCtx);
+    if (this->actor.update)
+    {
+        if (this->actionFunc == func_80ACBC8C)
+        {
+            Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC308, 0.00006f);
+        }
+        else if (this->actionFunc == func_80ACBD48)
+        {
+            Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC314, 0.00095f);
+        }
+        else
+        {
+            Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC320, 0.0004f);
+        }
+        this->actor.velocity.y *= 0.9f;
+        Actor_SetVelocityAndMoveYRotationAndGravity(&this->actor);
+        Actor_UpdateBgCheckInfo(globalCtx, &this->actor, 12.0f, 4.0f, 0.0f, 5);
+        if (this->actionFunc != func_80ACBDFC)
+        {
+            Collider_UpdateCylinder(&this->actor, &this->collider);
+            this->collider.dim.radius = this->actor.scale.x * 3000.0f;
+            CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
+        }
+    }
+}
+
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Draw.s")
+void ObjAqua_Draw(Actor* thisx, GlobalContext *globalCtx)
+{
+    ObjAqua* this = THIS;
+    s32 framesTemp;
+    s32 pad;
+    s16 cameraTemp = func_800DFCDC(globalCtx->cameraPtrs[globalCtx->activeCamera]) + 0x8000;
+    s32 actionFuncTemp = this->actionFunc == func_80ACBDFC;
+    
+    OPEN_DISPS(globalCtx->state.gfxCtx);
+    func_8012C2DC(globalCtx->state.gfxCtx);
+    framesTemp = ((globalCtx->gameplayFrames & 0x7FFFFFFF) * -0xA) & 0x1FF;
+    if (actionFuncTemp)
+    {
+        framesTemp = framesTemp >> 1;
+    }
+    gSPSegment(POLY_XLU_DISP++, 0x08, Gfx_TwoTexScroll(globalCtx->state.gfxCtx,0,0,0,0x20,0x40,1,0,framesTemp,0x20,0x80));
+    gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 170, 255, 255, this->unk_196);
+    gDPSetEnvColor(POLY_XLU_DISP++, 0, 150, 255, 0);
+    if (actionFuncTemp)
+    {
+        s16 rotation = Math_SinS(this->unk_198) * 8000.0f;
+        SysMatrix_InsertZRotation_s(rotation, 1);
+        Matrix_Scale(1.3f, 1.0f, 1.0f, 1);
+        SysMatrix_InsertZRotation_s(rotation * -1, 1);
+        Matrix_Scale(10.0f/13.0f, 1.0f, 1.0f, 1);
+    }
+    Matrix_RotateY(cameraTemp, 1);
+    gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPDisplayList(POLY_XLU_DISP++, D_0407D590);
+    CLOSE_DISPS(globalCtx->state.gfxCtx);
+}

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -15,17 +15,12 @@ void ObjAqua_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void ObjAqua_Update(Actor* thisx, GlobalContext* globalCtx);
 void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx);
 
-s32 func_80ACBA60(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBC70(ObjAqua* this);
 void func_80ACBDCC(ObjAqua* this);
-
 void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBD48(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx);
 
-void func_80ACB6A0(ObjAqua *this, GlobalContext *globalCtx);
-void func_80ACB7F4(ObjAqua *this, GlobalContext *globalCtx);
-void func_80ACBA10(ObjAqua* this);
 void func_80ACBD34(ObjAqua* this);
 
 const ActorInit Obj_Aqua_InitVars = {
@@ -40,292 +35,233 @@ const ActorInit Obj_Aqua_InitVars = {
     (ActorFunc)ObjAqua_Draw,
 };
 
-// static ColliderCylinderInit sCylinderInit = {
-static ColliderCylinderInit D_80ACC2C0 = {
-    { COLTYPE_NONE, AT_ON | AT_TYPE_OTHER, AC_NONE, OC1_NONE, OC2_NONE, COLSHAPE_CYLINDER, },
-    { ELEMTYPE_UNK0, { 0xF7CFFFFF, 0x00, 0x00 }, { 0x00000000, 0x00, 0x00 }, TOUCH_ON | TOUCH_SFX_NONE, BUMP_NONE, OCELEM_NONE, },
+static ColliderCylinderInit sCylinderInit = {
+    {
+        COLTYPE_NONE,
+        AT_ON | AT_TYPE_OTHER,
+        AC_NONE,
+        OC1_NONE,
+        OC2_NONE,
+        COLSHAPE_CYLINDER,
+    },
+    {
+        ELEMTYPE_UNK0,
+        { 0xF7CFFFFF, 0x00, 0x00 },
+        { 0x00000000, 0x00, 0x00 },
+        TOUCH_ON | TOUCH_SFX_NONE,
+        BUMP_NONE,
+        OCELEM_NONE,
+    },
     { 6, 10, 0, { 0, 0, 0 } },
 };
 
-// static InitChainEntry sInitChain[] = {
-static InitChainEntry D_80ACC2EC[] = {
-    ICHAIN_VEC3S(shape.rot, 0, ICHAIN_CONTINUE),
-    ICHAIN_VEC3S(world.rot, 0, ICHAIN_CONTINUE),
-    ICHAIN_F32_DIV1000(gravity, -900, ICHAIN_CONTINUE),
-    ICHAIN_F32_DIV1000(minVelocityY, -4000, ICHAIN_CONTINUE),
-    ICHAIN_F32(uncullZoneForward, 4000, ICHAIN_CONTINUE),
-    ICHAIN_F32(uncullZoneScale, 300, ICHAIN_CONTINUE),
+static InitChainEntry sInitChain[] = {
+    ICHAIN_VEC3S(shape.rot, 0, ICHAIN_CONTINUE),          ICHAIN_VEC3S(world.rot, 0, ICHAIN_CONTINUE),
+    ICHAIN_F32_DIV1000(gravity, -900, ICHAIN_CONTINUE),   ICHAIN_F32_DIV1000(minVelocityY, -4000, ICHAIN_CONTINUE),
+    ICHAIN_F32(uncullZoneForward, 4000, ICHAIN_CONTINUE), ICHAIN_F32(uncullZoneScale, 300, ICHAIN_CONTINUE),
     ICHAIN_F32(uncullZoneDownward, 300, ICHAIN_STOP),
 };
-Vec3f D_80ACC308 = {1.0f/1000.0f, 7.0f/10000.0f, 1.0f/1000.0f};
-Vec3f D_80ACC314 = {8.6f/1000.0f, 8.0f/10000.0f, 8.6f/1000.0f};
-Vec3f D_80ACC320 = {1.0f/100.0f, 2.6f/1000.0f, 1.0f/100.0f};
+
+Vec3f D_80ACC308 = { 1.0f / 1000.0f, 7.0f / 10000.0f, 1.0f / 1000.0f };
+Vec3f D_80ACC314 = { 8.6f / 1000.0f, 8.0f / 10000.0f, 8.6f / 1000.0f };
+Vec3f D_80ACC320 = { 1.0f / 100.0f, 2.6f / 1000.0f, 1.0f / 100.0f };
 
 extern Gfx D_0407D590[];
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB6A0.s")
-// dropping water on top of waterbox
-void func_80ACB6A0(ObjAqua *this, GlobalContext *globalCtx)
-{
+void func_80ACB6A0(ObjAqua* this, GlobalContext* globalCtx) {
     s32 pad;
     Vec3f sp58;
-    s32 phi_s0;
+    s32 angleOffset = 0;
     s32 i;
 
     sp58.y = this->actor.world.pos.y + this->actor.yDistToWater;
-    phi_s0 = 0;
-    for (i = 0; i < 4; i++)
-    {
-        sp58.x = this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f;
-        sp58.z = this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f;
+    for (i = 0; i < 4; i++) {
+        sp58.x = this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f;
+        sp58.z = this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f;
         EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x78);
-        phi_s0 += 0x4000;
+        angleOffset += 0x4000;
     }
     sp58.x = this->actor.world.pos.x;
     sp58.z = this->actor.world.pos.z;
     EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x12C);
 }
 
-
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB7F4.s")
-// dropping water on solid ground
-void func_80ACB7F4(ObjAqua *this, GlobalContext *globalCtx)
-{
+void func_80ACB7F4(ObjAqua* this, GlobalContext* globalCtx) {
     s32 pad;
-    Vec3f sp58;
-    s32 phi_s0;
+    Vec3f effectPos;
+    s32 angleOffset = 0;
     s32 i;
 
-    sp58.y = this->actor.floorHeight;
-    phi_s0 = 0;
-    for (i = 0; i < 4; i++)
-    {
-        sp58.x = (this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f);
-        sp58.z = (this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + phi_s0) * 8.0f);
-        EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x78);
-        phi_s0 += 0x4000;
+    effectPos.y = this->actor.floorHeight;
+    for (i = 0; i < 4; i++) {
+        effectPos.x = (this->actor.world.pos.x + Math_SinS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f);
+        effectPos.z = (this->actor.world.pos.z + Math_CosS((s32)(Rand_ZeroOne() * 7200.0f) + angleOffset) * 8.0f);
+        EffectSsGSplash_Spawn(globalCtx, &effectPos, NULL, NULL, 0, 120);
+        angleOffset += 0x4000;
     }
-    sp58.x = this->actor.world.pos.x;
-    sp58.z = this->actor.world.pos.z;
-    EffectSsGSplash_Spawn(globalCtx, &sp58, NULL, NULL, 0, 0x12C);
+    effectPos.x = this->actor.world.pos.x;
+    effectPos.z = this->actor.world.pos.z;
+    EffectSsGSplash_Spawn(globalCtx, &effectPos, NULL, NULL, 0, 300);
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB940.s")
-void func_80ACB940(ObjAqua *this, GlobalContext *globalCtx)
-{
+void func_80ACB940(ObjAqua* this, GlobalContext* globalCtx) {
     s32 pad;
-    Vec3f sp30; //pos
-    Vec3f sp24; //velocity
+    Vec3f effectPos;
+    Vec3f effectVel;
 
-    sp24.x = Rand_ZeroOne() - 0.5f;
-    sp24.y = 2.0f;
-    sp24.z = Rand_ZeroOne() - 0.5f;
-    sp30.x = this->actor.world.pos.x + (sp24.x * 40.0f);
-    sp30.y = this->actor.world.pos.y;
-    sp30.z = this->actor.world.pos.z + (sp24.z * 40.0f);
-    EffectSsIceSmoke_Spawn(globalCtx, &sp30, &sp24, &D_801D15B0, (s32)(Rand_ZeroOne() * 24.0f) + 70);
+    effectVel.x = Rand_ZeroOne() - 0.5f;
+    effectVel.y = 2.0f;
+    effectVel.z = Rand_ZeroOne() - 0.5f;
+    effectPos.x = this->actor.world.pos.x + (effectVel.x * 40.0f);
+    effectPos.y = this->actor.world.pos.y;
+    effectPos.z = this->actor.world.pos.z + (effectVel.z * 40.0f);
+    EffectSsIceSmoke_Spawn(globalCtx, &effectPos, &effectVel, &D_801D15B0, (s32)(Rand_ZeroOne() * 24.0f) + 70);
 }
 
-
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA10.s")
-void func_80ACBA10(ObjAqua *this)
-{
+void func_80ACBA10(ObjAqua* this) {
     s32 pad;
     MtxF sp2C;
 
-    func_800C0094(this->actor.floorPoly, this->actor.world.pos.x, this->actor.floorHeight, this->actor.world.pos.z, &sp2C);
+    func_800C0094(this->actor.floorPoly, this->actor.world.pos.x, this->actor.floorHeight, this->actor.world.pos.z,
+                  &sp2C);
     func_8018219C(&sp2C, &this->actor.shape.rot, 0);
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA60.s")
-//WaterBox_GetSurfaceImpl
-//from mzx's bgcheck branch
-extern s32 func_800C9EBC(GlobalContext* globalCtx, CollisionContext* colCtx, f32 x, f32 z, f32* ySurface,
-WaterBox** outWaterBox, s32* bgId);
-s32 func_80ACBA60(ObjAqua *this, GlobalContext *globalCtx)
-{
+s32 func_80ACBA60(ObjAqua* this, GlobalContext* globalCtx) {
     s32 pad;
     WaterBox* waterBox;
     f32 ySurface;
     s32 bgId;
 
-    if (func_800C9EBC(
-        globalCtx,
-        &globalCtx->colCtx,
-        this->actor.world.pos.x,
-        this->actor.world.pos.z,
-        &ySurface, &waterBox, &bgId) && (this->actor.world.pos.y < ySurface))
-    {
+    if (func_800C9EBC(globalCtx, &globalCtx->colCtx, this->actor.world.pos.x, this->actor.world.pos.z, &ySurface,
+                      &waterBox, &bgId) &&
+        (this->actor.world.pos.y < ySurface)) {
         return 1;
     }
     return 0;
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Init.s")
-void ObjAqua_Init(Actor* thisx, GlobalContext *globalCtx)
-{
+void ObjAqua_Init(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;
     s32 i;
 
-    Actor_ProcessInitChain(&this->actor, D_80ACC2EC);
+    Actor_ProcessInitChain(&this->actor, sInitChain);
     this->actor.scale.x = 0.0009f;
     this->actor.scale.y = 0.0005f;
     this->actor.scale.z = 0.0009f;
     Collider_InitCylinder(globalCtx, &this->collider);
-    Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &D_80ACC2C0);
+    Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &sCylinderInit);
     ActorShape_Init(&this->actor.shape, 0.0f, func_800B3FC0, 60.0f);
-    if(0){};
+    if (0) {};
     this->actor.shape.shadowAlpha = 140;
-    this->unk_196 = 255;
-    if (func_80ACBA60(this, globalCtx))
-    {
-        for (i = 0; i < 8; i++)
-        {
-            EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, -4.0f, 4.0f, 4.0f, (Rand_ZeroOne() * 0.09f) + 0.03f);
+    this->alpha = 255;
+    if (func_80ACBA60(this, globalCtx)) {
+        for (i = 0; i < 8; i++) {
+            EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, -4.0f, 4.0f, 4.0f,
+                                 (Rand_ZeroOne() * 0.09f) + 0.03f);
         }
         func_80ACBDCC(this);
-    }
-    else
-    {
+    } else {
         func_80ACBC70(this);
     }
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Destroy.s")
-void ObjAqua_Destroy(Actor* thisx, GlobalContext *globalCtx)
-{
+void ObjAqua_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;
     Collider_DestroyCylinder(globalCtx, &this->collider);
 }
 
-
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC70.s")
-void func_80ACBC70(ObjAqua *this)
-{
-    this->unk_194 = 200;
+void func_80ACBC70(ObjAqua* this) {
+    this->counter = 200;
     this->actionFunc = func_80ACBC8C;
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBC8C.s")
-void func_80ACBC8C(ObjAqua *this, GlobalContext *globalCtx)
-{
-    if (this->actor.bgCheckFlags & 0x21)
-    {
-        if (this->actor.bgCheckFlags & 1)
-        {
+void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx) {
+    if (this->actor.bgCheckFlags & 0x21) {
+        if (this->actor.bgCheckFlags & 1) {
             func_80ACB7F4(this, globalCtx);
             func_80ACBA10(this);
             Audio_PlayActorSound2(&this->actor, 0x2920);
             func_80ACBD34(this);
-        }
-        else
-        {
+        } else {
             func_80ACB6A0(this, globalCtx);
             func_800F0568(globalCtx, &this->actor.world.pos, 0x28, 0x2817);
             Actor_MarkForDeath(&this->actor);
         }
-    }
-    else if (this->unk_194 <= 0)
-    {
+    } else if (this->counter <= 0) {
         Actor_MarkForDeath(&this->actor);
     }
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD34.s")
-void func_80ACBD34(ObjAqua* this)
-{
+void func_80ACBD34(ObjAqua* this) {
     this->actionFunc = func_80ACBD48;
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBD48.s")
-void func_80ACBD48(ObjAqua *this, GlobalContext *globalCtx)
-{
-    if (((this->actor.params & 1) == 1) && (this->unk_196 >= 91))
-    {
+void func_80ACBD48(ObjAqua* this, GlobalContext* globalCtx) {
+    if ((AQUA_HOT(&this->actor) == 1) && (this->alpha > 90)) {
         func_80ACB940(this, globalCtx);
     }
-    if (this->unk_196 >= 6)
-    {
-        this->unk_196 -= 5;
+    if (this->alpha > 5) {
+        this->alpha -= 5;
+    } else {
+        this->alpha = 0;
     }
-    else
-    {
-        this->unk_196 = 0;
-    }
-    if (this->actor.shape.shadowAlpha >= 3)
-    {
+    if (this->actor.shape.shadowAlpha > 2) {
         this->actor.shape.shadowAlpha -= 2;
-    }
-    else
-    {
+    } else {
         Actor_MarkForDeath(&this->actor);
     }
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDCC.s")
-void func_80ACBDCC(ObjAqua *this)
-{
+void func_80ACBDCC(ObjAqua* this) {
     this->actor.gravity = -0.1f;
-    this->unk_194 = 40;
-    this->unk_196 = 140;
+    this->counter = 40;
+    this->alpha = 140;
     this->actionFunc = func_80ACBDFC;
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDFC.s")
-void func_80ACBDFC(ObjAqua *this, GlobalContext *globalCtx)
-{
-    f32 temp_f2;
-    f32 temp = this->unk_194 * 3.25f;
-    
+#ifdef NON_MATCHING
+void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx) {
+    f32 temp = this->counter * 3.25f;
+    s32 pad;
+
+    this->alpha = (s32)(temp) + 10;
+    this->actor.shape.shadowAlpha = this->alpha;
     this->unk_198 += 1000;
-    this->actor.shape.shadowAlpha = this->unk_196 = (s32)(temp) + 10;
-    if ((this->actor.params & 1) == 1)
-    {
-        temp_f2 = this->actor.scale.x * 10000.0f;
-        EffectSsBubble_Spawn(
-            globalCtx,
-            &this->actor.world.pos,
-            temp_f2 * -0.5f,
-            temp_f2,
-            temp_f2,
-            (Rand_ZeroOne() * 0.1f) + 0.03f);
+    if (AQUA_HOT(&this->actor)) {
+        f32 temp_f2 = this->actor.scale.x * 10000.0f;
+
+        EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, temp_f2 * -0.5f, temp_f2, temp_f2,
+                             (Rand_ZeroOne() * 0.1f) + 0.03f);
     }
-    if (this->unk_194 <= 0)
-    {
+    if (this->counter <= 0) {
         Actor_MarkForDeath(&this->actor);
     }
 }
+#else
+#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDFC.s")
+#endif
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Update.s")
-void ObjAqua_Update(Actor* thisx, GlobalContext *globalCtx)
-{
+void ObjAqua_Update(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;
     s32 pad;
 
-    if (this->unk_194 > 0)
-    {
-        this->unk_194 -= 1;
+    if (this->counter > 0) {
+        this->counter -= 1;
     }
     this->actionFunc(this, globalCtx);
-    if (this->actor.update)
-    {
-        if (this->actionFunc == func_80ACBC8C)
-        {
+    if (this->actor.update) {
+        if (this->actionFunc == func_80ACBC8C) {
             Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC308, 0.00006f);
-        }
-        else if (this->actionFunc == func_80ACBD48)
-        {
+        } else if (this->actionFunc == func_80ACBD48) {
             Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC314, 0.00095f);
-        }
-        else
-        {
+        } else {
             Math_Vec3f_StepTo(&this->actor.scale, &D_80ACC320, 0.0004f);
         }
         this->actor.velocity.y *= 0.9f;
         Actor_SetVelocityAndMoveYRotationAndGravity(&this->actor);
         Actor_UpdateBgCheckInfo(globalCtx, &this->actor, 12.0f, 4.0f, 0.0f, 5);
-        if (this->actionFunc != func_80ACBDFC)
-        {
+        if (this->actionFunc != func_80ACBDFC) {
             Collider_UpdateCylinder(&this->actor, &this->collider);
             this->collider.dim.radius = this->actor.scale.x * 3000.0f;
             CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
@@ -333,32 +269,29 @@ void ObjAqua_Update(Actor* thisx, GlobalContext *globalCtx)
     }
 }
 
-// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Draw.s")
-void ObjAqua_Draw(Actor* thisx, GlobalContext *globalCtx)
-{
+void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;
     s32 framesTemp;
     s32 pad;
     s16 cameraTemp = func_800DFCDC(globalCtx->cameraPtrs[globalCtx->activeCamera]) + 0x8000;
     s32 actionFuncTemp = this->actionFunc == func_80ACBDFC;
-    
+
     OPEN_DISPS(globalCtx->state.gfxCtx);
     func_8012C2DC(globalCtx->state.gfxCtx);
     framesTemp = ((globalCtx->gameplayFrames & 0x7FFFFFFF) * -0xA) & 0x1FF;
-    if (actionFuncTemp)
-    {
-        framesTemp = framesTemp >> 1;
+    if (actionFuncTemp) {
+        framesTemp >>= 1;
     }
-    gSPSegment(POLY_XLU_DISP++, 0x08, Gfx_TwoTexScroll(globalCtx->state.gfxCtx,0,0,0,0x20,0x40,1,0,framesTemp,0x20,0x80));
-    gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 170, 255, 255, this->unk_196);
+    gSPSegment(POLY_XLU_DISP++, 0x08,
+               Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 0, 0, 0x20, 0x40, 1, 0, framesTemp, 0x20, 0x80));
+    gDPSetPrimColor(POLY_XLU_DISP++, 0x80, 0x80, 170, 255, 255, this->alpha);
     gDPSetEnvColor(POLY_XLU_DISP++, 0, 150, 255, 0);
-    if (actionFuncTemp)
-    {
+    if (actionFuncTemp) {
         s16 rotation = Math_SinS(this->unk_198) * 8000.0f;
         SysMatrix_InsertZRotation_s(rotation, 1);
         Matrix_Scale(1.3f, 1.0f, 1.0f, 1);
         SysMatrix_InsertZRotation_s(rotation * -1, 1);
-        Matrix_Scale(10.0f/13.0f, 1.0f, 1.0f, 1);
+        Matrix_Scale(10.0f / 13.0f, 1.0f, 1.0f, 1);
     }
     Matrix_RotateY(cameraTemp, 1);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_aqua.c
+ * Overlay: ovl_Obj_Aqua
+ * Description: Water poured out of a bottle
+ */
+
 #include "z_obj_aqua.h"
 
 #define FLAGS 0x00000010
@@ -9,11 +15,14 @@ void ObjAqua_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void ObjAqua_Update(Actor* thisx, GlobalContext* globalCtx);
 void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx);
 
+s32 func_80ACBA60(ObjAqua* this, GlobalContext* globalCtx);
+void func_80ACBC70(ObjAqua* this);
+void func_80ACBDCC(ObjAqua* this);
+
 void func_80ACBC8C(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBD48(ObjAqua* this, GlobalContext* globalCtx);
 void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx);
 
-#if 0
 const ActorInit Obj_Aqua_InitVars = {
     ACTOR_OBJ_AQUA,
     ACTORCAT_ITEMACTION,
@@ -44,10 +53,9 @@ static InitChainEntry D_80ACC2EC[] = {
     ICHAIN_F32(uncullZoneDownward, 300, ICHAIN_STOP),
 };
 
-#endif
-
-extern ColliderCylinderInit D_80ACC2C0;
-extern InitChainEntry D_80ACC2EC[];
+s32 D_80ACC308[] = {0x3A83126F, 0x3A378034, 0x3A83126F};
+s32 D_80ACC314[] = {0x3C0CE704, 0x3A51B717, 0x3C0CE704};
+s32 D_80ACC320[] = {0x3C23D70A, 0x3B2A64C3, 0x3C23D70A};
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACB6A0.s")
 
@@ -59,7 +67,36 @@ extern InitChainEntry D_80ACC2EC[];
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBA60.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Init.s")
+// #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Init.s")
+void ObjAqua_Init(Actor* thisx, GlobalContext *globalCtx)
+{
+    ObjAqua* this = THIS;
+    s32 phi_s0;
+
+    Actor_ProcessInitChain(&this->actor, D_80ACC2EC);
+    this->actor.scale.x = 0.0009f;
+    this->actor.scale.z = 0.0009f;
+    this->actor.scale.y = 0.0005f;
+    Collider_InitCylinder(globalCtx, &this->collider);
+    Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &D_80ACC2C0);
+    ActorShape_Init(&this->actor.shape, 0.0f, func_800B3FC0, 60.0f);
+    this->actor.shape.shadowAlpha = 140;
+    this->unk_196 = 0xFF;
+    phi_s0 = 0;
+    if (func_80ACBA60(this, globalCtx))
+    {
+        while (phi_s0 != 8)
+        {
+            EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, -4.0f, 4.0f, 4.0f, (Rand_ZeroOne() * 0.09f) + 0.03f);
+            phi_s0++;
+        } 
+        func_80ACBDCC(this);
+    }
+    else
+    {
+        func_80ACBC70(this);
+    }
+}
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/ObjAqua_Destroy.s")
 

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -220,15 +220,14 @@ void func_80ACBDCC(ObjAqua* this) {
     this->actionFunc = func_80ACBDFC;
 }
 
-#ifdef NON_MATCHING
 void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx) {
-    f32 temp = this->counter * 3.25f;
     s32 pad;
+    f32 temp = this->counter;
 
-    this->alpha = (s32)(temp) + 10;
+    this->alpha = (s32)(temp * 3.25f) + 10;
     this->actor.shape.shadowAlpha = this->alpha;
     this->unk_198 += 1000;
-    if (AQUA_HOT(&this->actor)) {
+    if (AQUA_HOT(&this->actor) == 1) {
         f32 temp_f2 = this->actor.scale.x * 10000.0f;
 
         EffectSsBubble_Spawn(globalCtx, &this->actor.world.pos, temp_f2 * -0.5f, temp_f2, temp_f2,
@@ -238,9 +237,6 @@ void func_80ACBDFC(ObjAqua* this, GlobalContext* globalCtx) {
         Actor_MarkForDeath(&this->actor);
     }
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Aqua/func_80ACBDFC.s")
-#endif
 
 void ObjAqua_Update(Actor* thisx, GlobalContext* globalCtx) {
     ObjAqua* this = THIS;

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
@@ -9,9 +9,11 @@ typedef void (*ObjAquaActionFunc)(struct ObjAqua*, GlobalContext*);
 
 typedef struct ObjAqua {
     /* 0x0000 */ Actor actor;
-    /* 0x0144 */ char unk_144[0x4C];
+    /* 0x0144 */ ColliderCylinder collider;
     /* 0x0190 */ ObjAquaActionFunc actionFunc;
-    /* 0x0194 */ char unk_194[0x8];
+    /* 0x0194 */ char unk_194[0x2];
+    /* 0x0196 */ u8 unk_196;
+    /* 0x0197 */ char unk_197[0x5];
 } ObjAqua; // size = 0x19C
 
 extern const ActorInit Obj_Aqua_InitVars;

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
@@ -11,9 +11,10 @@ typedef struct ObjAqua {
     /* 0x0000 */ Actor actor;
     /* 0x0144 */ ColliderCylinder collider;
     /* 0x0190 */ ObjAquaActionFunc actionFunc;
-    /* 0x0194 */ char unk_194[0x2];
-    /* 0x0196 */ u8 unk_196;
-    /* 0x0197 */ char unk_197[0x5];
+    /* 0x0194 */ s16 unk_194; //counter for how long the actor lives?
+    /* 0x0196 */ u8 unk_196; // alpha?
+    /* 0x0197 */ char unk_197;
+    /* 0x0198 */ s16 unk_198; // some sort of angle?
 } ObjAqua; // size = 0x19C
 
 extern const ActorInit Obj_Aqua_InitVars;

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.h
@@ -3,6 +3,8 @@
 
 #include "global.h"
 
+#define AQUA_HOT(thisx) ((thisx)->params & 1)
+
 struct ObjAqua;
 
 typedef void (*ObjAquaActionFunc)(struct ObjAqua*, GlobalContext*);
@@ -11,10 +13,9 @@ typedef struct ObjAqua {
     /* 0x0000 */ Actor actor;
     /* 0x0144 */ ColliderCylinder collider;
     /* 0x0190 */ ObjAquaActionFunc actionFunc;
-    /* 0x0194 */ s16 unk_194; //counter for how long the actor lives?
-    /* 0x0196 */ u8 unk_196; // alpha?
-    /* 0x0197 */ char unk_197;
-    /* 0x0198 */ s16 unk_198; // some sort of angle?
+    /* 0x0194 */ s16 counter;
+    /* 0x0196 */ u8 alpha;
+    /* 0x0198 */ s16 unk_198;
 } ObjAqua; // size = 0x19C
 
 extern const ActorInit Obj_Aqua_InitVars;


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Bottled water has it's damage flags set to 0xF7CFFFFF interestingly enough, acting as every damage type except normal shield, light ray, and whatever the 28th bit flag is. Unfortunately it only has AT_TYPE_OTHER set, and most colliders don't check for this type.

Sun blocks have AC_TYPE_OTHER set and check for light arrows, so bottled water can melt them. I haven't exhaustively checked every collider but I did find you can blow up bomb flowers with bottled water.