### PR TITLE
Add ability to replace asm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ setup:
 disasm:
 	$(RM) -rf asm data
 	python3 tools/disasm/disasm.py
+	python3 replace_asm.py
 
 diff-init: all
 	$(RM) -rf expected/

--- a/asm_replacements.txt
+++ b/asm_replacements.txt
@@ -1,0 +1,9 @@
+// Format:
+// file path
+//      offset: new line
+
+asm/non_matchings/overlays/ovl_En_Tru/func_80A85F84.s
+    000A78: lui         $at, %hi(D_80A8B25C+12)
+    000A88: lwc1        $f4, %lo(D_80A8B25C+12)($at)
+    000BDC: lui         $t8, %hi(D_80A8B25C+12)
+    000BF0: addiu       $t8, $t8, %lo(D_80A8B25C+12)

--- a/replace_asm.py
+++ b/replace_asm.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+replacements = Path("asm_replacements.txt").read_text().splitlines()
+
+i = 0
+while i < len(replacements):
+    while not replacements[i] or replacements[i].startswith("#") or replacements[i].startswith("//"):
+        i += 1
+        if i >= len(replacements):
+            break
+
+    if i >= len(replacements):
+        break
+    file = replacements[i]
+    i += 1
+
+    file_path = Path(f"./{file}")
+    fd = file_path.read_text()
+
+    line = replacements[i]
+    while line and line.startswith(" "):
+        replace_line, replace_text = line.split(":")
+        replace_text = replace_text.strip()
+        replace_line = replace_line.strip()
+
+        line_pos = fd.find(f"\n/* {replace_line}")
+        if line_pos >= 0:
+            line_pos = fd.find("*/", line_pos) + 4
+            
+            fd = fd[:line_pos] + replace_text + fd[fd.find("\n", line_pos):] 
+        
+        i += 1
+        if i >= len(replacements):
+            break
+        line = replacements[i]
+
+    file_path.write_text(fd)


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

This PR adds a basic ability to replace asm lines in the generated asm. This helps PRs where functions which access wrong data offsets are not matching (En_Tru and Boss_02 currently). Included the fixes I need for En_Tru as an example of the format.