### PR TITLE
`z_debug` OK

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1547,7 +1547,7 @@ s32 func_800E8FA4(Actor* actor, Vec3f* param_2, Vec3s* param_3, Vec3s* param_4);
 s32 func_800E9138(GlobalContext* globalCtx, Actor* actor, Vec3s* param_3, Vec3s* param_4, f32 param_5);
 s32 func_800E9250(GlobalContext* globalCtx, Actor* actor, Vec3s* param_3, Vec3s* param_4, Vec3f param_5);
 u8 func_800E9360(void);
-void static_context_init(void);
+void GameInfo_Init(void);
 // void func_800E9470(void);
 void DebugDisplay_AddObject(f32 posX, f32 posY, f32 posZ, s16 rotX, s16 rotY, s16 rotZ, f32 scaleX, f32 scaleY, f32 scaleZ, u8 red, u8 green, u8 blue, u8 alpha, s16 type, GraphicsContext* gfxCtx);
 void DebugDisplay_DrawObjects(GlobalContext* globalCtx);

--- a/include/functions.h
+++ b/include/functions.h
@@ -1547,7 +1547,7 @@ s32 func_800E8FA4(Actor* actor, Vec3f* param_2, Vec3s* param_3, Vec3s* param_4);
 s32 func_800E9138(GlobalContext* globalCtx, Actor* actor, Vec3s* param_3, Vec3s* param_4, f32 param_5);
 s32 func_800E9250(GlobalContext* globalCtx, Actor* actor, Vec3s* param_3, Vec3s* param_4, Vec3f param_5);
 u8 func_800E9360(void);
-// void static_context_init(void);
+void static_context_init(void);
 // void func_800E9470(void);
 void DebugDisplay_AddObject(f32 posX, f32 posY, f32 posZ, s16 rotX, s16 rotY, s16 rotZ, f32 scaleX, f32 scaleY, f32 scaleZ, u8 red, u8 green, u8 blue, u8 alpha, s16 type, GraphicsContext* gfxCtx);
 void DebugDisplay_DrawObjects(GlobalContext* globalCtx);

--- a/include/z64.h
+++ b/include/z64.h
@@ -35,6 +35,7 @@
 #include "z64scene.h"
 #include "z64save.h"
 #include "z64transition.h"
+#include "regs.h"
 
 #define SCREEN_WIDTH  320
 #define SCREEN_HEIGHT 240
@@ -237,15 +238,27 @@ typedef struct {
     /* 0x11D88 */ u8 unk_11D88;
 } Font; // size = 0x11D8C
 
+// Game Info aka. Static Context
+// Data normally accessed through REG macros (see regs.h)
 typedef struct {
-    /* 0x0000 */ u8 unk0;
-    /* 0x0001 */ u8 unk1;
-    /* 0x0002 */ u8 unk2;
-    /* 0x0003 */ u8 unk3;
-    /* 0x0004 */ u32 unk4;
-    /* 0x0008 */ UNK_TYPE1 pad8[0xC];
-    /* 0x0014 */ s16 data[2784]; // Accessed through REG macros
+    /* 0x00 */ u8  unk_00; // regPage;?   // 1 is first page
+    /* 0x01 */ u8  unk_01; // regGroup;?  // "register" group (R, RS, RO, RP etc.)
+    /* 0x02 */ u8  unk_02; // regCur;?    // selected register within page
+    /* 0x03 */ u8  unk_03; // dpadLast;?
+    /* 0x04 */ u32 unk_04; // repeat;?
+    /* 0x08 */ char pad_08[0xC];
+    /* 0x14 */ s16 data[REG_GROUPS * REG_PER_GROUP]; // 0xAE0 entries
 } GameInfo; // size = 0x15D4
+
+// typedef struct {
+//     /* 0x0000 */ u8 unk0;
+//     /* 0x0001 */ u8 unk1;
+//     /* 0x0002 */ u8 unk2;
+//     /* 0x0003 */ u8 unk3;
+//     /* 0x0004 */ u32 unk4;
+//     /* 0x0008 */ UNK_TYPE1 pad8[0xC];
+//     /* 0x0014 */ s16 data[2784]; // Accessed through REG macros
+// } GameInfo; // size = 0x15D4
 
 typedef struct {
     /* 0x0000 */ u32    size;

--- a/include/z64.h
+++ b/include/z64.h
@@ -250,16 +250,6 @@ typedef struct {
     /* 0x14 */ s16 data[REG_GROUPS * REG_PER_GROUP]; // 0xAE0 entries
 } GameInfo; // size = 0x15D4
 
-// typedef struct {
-//     /* 0x0000 */ u8 unk0;
-//     /* 0x0001 */ u8 unk1;
-//     /* 0x0002 */ u8 unk2;
-//     /* 0x0003 */ u8 unk3;
-//     /* 0x0004 */ u32 unk4;
-//     /* 0x0008 */ UNK_TYPE1 pad8[0xC];
-//     /* 0x0014 */ s16 data[2784]; // Accessed through REG macros
-// } GameInfo; // size = 0x15D4
-
 typedef struct {
     /* 0x0000 */ u32    size;
     /* 0x0004 */ void*  bufp;

--- a/spec
+++ b/spec
@@ -471,7 +471,6 @@ beginseg
     include "build/src/code/z_common_data.o"
     include "build/data/code/z_common_data.bss.o"
     include "build/src/code/z_debug.o"
-    include "build/data/code/z_debug.bss.o"
     include "build/src/code/z_debug_display.o"
     include "build/data/code/z_debug_display.data.o"
     include "build/data/code/z_debug_display.bss.o"

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -2,9 +2,9 @@
 
 GameInfo* gGameInfo;
 
-// #pragma GLOBAL_ASM("asm/non_matchings/code/z_debug/static_context_init.s")
-void static_context_init(void) {
+void GameInfo_Init(void) {
     s32 i;
+
     gGameInfo = (GameInfo*)SystemArena_Malloc(sizeof(GameInfo));
     if (1) {}
     gGameInfo->unk_00 = 0;

--- a/src/code/z_debug.c
+++ b/src/code/z_debug.c
@@ -1,3 +1,19 @@
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_debug/static_context_init.s")
+GameInfo* gGameInfo;
+
+// #pragma GLOBAL_ASM("asm/non_matchings/code/z_debug/static_context_init.s")
+void static_context_init(void) {
+    s32 i;
+    gGameInfo = (GameInfo*)SystemArena_Malloc(sizeof(GameInfo));
+    if (1) {}
+    gGameInfo->unk_00 = 0;
+    gGameInfo->unk_01 = 0;
+    gGameInfo->unk_02 = 0;
+    gGameInfo->unk_04 = 0;
+    gGameInfo->unk_03 = 0;
+    
+    for (i = 0; i < ARRAY_COUNT(gGameInfo->data); i++) {
+        gGameInfo->data[i] = 0;
+    }
+}

--- a/tools/disasm/functions.txt
+++ b/tools/disasm/functions.txt
@@ -1519,7 +1519,7 @@
     0x800E9138:("func_800E9138",),
     0x800E9250:("func_800E9250",),
     0x800E9360:("func_800E9360",),
-    0x800E93E0:("static_context_init",),
+    0x800E93E0:("GameInfo_Init",),
     0x800E9470:("func_800E9470",),
     0x800E9488:("DebugDisplay_AddObject",),
     0x800E9564:("DebugDisplay_DrawObjects",),

--- a/tools/sizes/code_functions.csv
+++ b/tools/sizes/code_functions.csv
@@ -1033,7 +1033,7 @@ asm/non_matchings/code/code_800E8EA0/func_800E8FA4.s,func_800E8FA4,0x800E8FA4,0x
 asm/non_matchings/code/code_800E8EA0/func_800E9138.s,func_800E9138,0x800E9138,0x46
 asm/non_matchings/code/code_800E8EA0/func_800E9250.s,func_800E9250,0x800E9250,0x44
 asm/non_matchings/code/z_common_data/func_800E9360.s,func_800E9360,0x800E9360,0x20
-asm/non_matchings/code/z_debug/static_context_init.s,static_context_init,0x800E93E0,0x24
+asm/non_matchings/code/z_debug/GameInfo_Init.s,GameInfo_Init,0x800E93E0,0x24
 asm/non_matchings/code/z_debug_display/func_800E9470.s,func_800E9470,0x800E9470,0x6
 asm/non_matchings/code/z_debug_display/DebugDisplay_AddObject.s,DebugDisplay_AddObject,0x800E9488,0x37
 asm/non_matchings/code/z_debug_display/DebugDisplay_DrawObjects.s,DebugDisplay_DrawObjects,0x800E9564,0x24


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Thought I might as well polish this one off since it's only used in Main. Unfortunately documentation is not really possible for most of the members of `GameInfo`, at least for now, since the first few are very likely only used in the functions that only exist in this file on debug. Notably, they changed in size from OoT and are set in a different order, so I would not want to assert that they're the same without evidence. I have left the OoT documentation in just in case anyway.