### PR TITLE
Fix some dummy label matches

### DIFF
--- a/src/code/game.c
+++ b/src/code/game.c
@@ -200,21 +200,24 @@ void Game_StateInit(GameState* gamestate, GameStateFunc gameStateInit, GraphicsC
     gamestate->nextGameStateInit = NULL;
     gamestate->nextGameStateSize = 0U;
 
-lblUnk:;
-    Gamealloc_Init(&gamestate->alloc);
-    Game_InitHeap(gamestate, 0x100000);
-    Game_SetFramerateDivisor(gamestate, 3);
+    {
+        s32 pad;
+        
+        Gamealloc_Init(&gamestate->alloc);
+        Game_InitHeap(gamestate, 0x100000);
+        Game_SetFramerateDivisor(gamestate, 3);
 
-    gameStateInit(gamestate);
+        gameStateInit(gamestate);
 
-    func_80140CE0(&D_801F8010);
-    func_801420C0(&D_801F8020);
-    func_801418B0(&sMonoColors);
-    func_80140898(&D_801F8048);
-    func_801773A0(&D_801F7FF0);
-    func_8013ED9C();
+        func_80140CE0(&D_801F8010);
+        func_801420C0(&D_801F8020);
+        func_801418B0(&sMonoColors);
+        func_80140898(&D_801F8048);
+        func_801773A0(&D_801F7FF0);
+        func_8013ED9C();
 
-    osSendMesg(&gamestate->gfxCtx->unk5C, NULL, 1);
+        osSendMesg(&gamestate->gfxCtx->unk5C, NULL, 1);
+    }
 }
 
 void Game_StateFini(GameState* gamestate) {

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -92,6 +92,7 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
     // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
     {
         s32 pad;
+        
         func_800E9F78(gfxCtx);
     }
 

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -89,8 +89,11 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
     Graph_BranchDlist(_polyOpa, nextDisplayList);
     gfxCtx->polyOpa.p = nextDisplayList;
 
-lblUnk:; // Label prevents reordering, if(1) around the above block don't seem to help unlike in OoT
-    func_800E9F78(gfxCtx);
+    // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
+    {
+        s32 pad;
+        func_800E9F78(gfxCtx);
+    }
 
     if (R_ENABLE_ARENA_DBG != 0) {
         SpeedMeter_DrawTimeEntries(&D_801F7FF0, gfxCtx);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -92,7 +92,7 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
     // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
     {
         s32 pad;
-        
+
         func_800E9F78(gfxCtx);
     }
 

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -68,14 +68,14 @@ void Game_Nop80173534(GameState* gamestate) {
 
 void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
     Gfx* nextDisplayList;
-    Gfx* _polyOpa;
-    // Unused vars impact regalloc
-    Gfx* temp_t2;
-    u32 temp_v1;
+    Gfx* polyOpa;
 
-    _polyOpa = gfxCtx->polyOpa.p;
-    nextDisplayList = Graph_GfxPlusOne(gfxCtx->polyOpa.p);
-    gSPDisplayList(gfxCtx->overlay.p++, nextDisplayList);
+    OPEN_DISPS(gfxCtx);
+
+    polyOpa = POLY_OPA_DISP;
+    nextDisplayList = Graph_GfxPlusOne(POLY_OPA_DISP);
+
+    gSPDisplayList(OVERLAY_DISP++, nextDisplayList);
 
     if (R_FB_FILTER_TYPE && R_FB_FILTER_ENV_COLOR(3) == 0) {
         GameState_SetFBFilter(&nextDisplayList, (u32)gfxCtx->zbuffer);
@@ -86,8 +86,8 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
     }
 
     gSPEndDisplayList(nextDisplayList++);
-    Graph_BranchDlist(_polyOpa, nextDisplayList);
-    gfxCtx->polyOpa.p = nextDisplayList;
+    Graph_BranchDlist(polyOpa, nextDisplayList);
+    POLY_OPA_DISP = nextDisplayList;
 
     // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
     {
@@ -99,6 +99,8 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
         SpeedMeter_DrawTimeEntries(&D_801F7FF0, gfxCtx);
         SpeedMeter_DrawAllocEntries(&D_801F7FF0, gfxCtx, gamestate);
     }
+
+    CLOSE_DISPS(gfxCtx);
 }
 
 void Game_ResetSegments(GraphicsContext* gfxCtx) {

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -91,7 +91,7 @@ void GameState_Draw(GameState* gamestate, GraphicsContext* gfxCtx) {
 
     // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
     {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         func_800E9F78(gfxCtx);
     }
@@ -204,7 +204,7 @@ void Game_StateInit(GameState* gamestate, GameStateFunc gameStateInit, GraphicsC
     gamestate->nextGameStateSize = 0U;
 
     {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         Gamealloc_Init(&gamestate->alloc);
         Game_InitHeap(gamestate, 0x100000);

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -202,7 +202,7 @@ void Game_StateInit(GameState* gamestate, GameStateFunc gameStateInit, GraphicsC
 
     {
         s32 pad;
-        
+
         Gamealloc_Init(&gamestate->alloc);
         Game_InitHeap(gamestate, 0x100000);
         Game_SetFramerateDivisor(gamestate, 3);

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -130,7 +130,7 @@ void DoorAna_WaitOpen(DoorAna* this, GlobalContext* globalCtx) {
 
             if (dooranaType == DOORANA_TYPE_ADJACENT) {
                 s32 pad;
-                
+
                 // 300 uses scene exit addresses, not static DoorAna entrance addresses,
                 // eg. deku playground gets address in the NCT scene exit table
 

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -129,7 +129,7 @@ void DoorAna_WaitOpen(DoorAna* this, GlobalContext* globalCtx) {
             (player->stateFlags1 & 0x80000000) && (player->unk_AE7 == 0)) {
 
             if (dooranaType == DOORANA_TYPE_ADJACENT) {
-                s32 pad;
+                s32 requiredScopeTemp;
 
                 // 300 uses scene exit addresses, not static DoorAna entrance addresses,
                 // eg. deku playground gets address in the NCT scene exit table

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -129,13 +129,13 @@ void DoorAna_WaitOpen(DoorAna* this, GlobalContext* globalCtx) {
             (player->stateFlags1 & 0x80000000) && (player->unk_AE7 == 0)) {
 
             if (dooranaType == DOORANA_TYPE_ADJACENT) {
+                s32 pad;
+                
                 // 300 uses scene exit addresses, not static DoorAna entrance addresses,
                 // eg. deku playground gets address in the NCT scene exit table
 
                 entranceIndex = GET_DOORANA_ADJACENT_ENTRANCE(this);
                 globalCtx->nextEntranceIndex = globalCtx->setupExitList[entranceIndex];
-            lblUnk_808E03B8:; // required to convince compiler to not use delay slot
-
             } else {
                 // unused in vanilla, the highest params bits can directly index an address
                 entranceIndex = GET_DOORANA_DIRECT_ENTRANCE(this);

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -245,7 +245,7 @@ void EnClearTag_CreateLightRayEffect(EnClearTag* this, Vec3f* position, Vec3f* v
     for (i = 0; i < ARRAY_COUNT(this->effect) - 1; i++, effect++) {
         if (effect->type == CLEAR_TAG_EFFECT_AVAILABLE) {
             s32 pad;
-            
+
             effect->type = CLEAR_TAG_EFFECT_LIGHT_RAYS;
 
             effect->position = *position;

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -244,7 +244,7 @@ void EnClearTag_CreateLightRayEffect(EnClearTag* this, Vec3f* position, Vec3f* v
     // Look for an available effect to allocate a light ray effect to.
     for (i = 0; i < ARRAY_COUNT(this->effect) - 1; i++, effect++) {
         if (effect->type == CLEAR_TAG_EFFECT_AVAILABLE) {
-            s32 pad;
+            s32 requiredScopeTemp;
 
             effect->type = CLEAR_TAG_EFFECT_LIGHT_RAYS;
 

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -244,6 +244,7 @@ void EnClearTag_CreateLightRayEffect(EnClearTag* this, Vec3f* position, Vec3f* v
     // Look for an available effect to allocate a light ray effect to.
     for (i = 0; i < ARRAY_COUNT(this->effect) - 1; i++, effect++) {
         if (effect->type == CLEAR_TAG_EFFECT_AVAILABLE) {
+            s32 pad;
             effect->type = CLEAR_TAG_EFFECT_LIGHT_RAYS;
 
             effect->position = *position;
@@ -271,7 +272,6 @@ void EnClearTag_CreateLightRayEffect(EnClearTag* this, Vec3f* position, Vec3f* v
 
             break;
         }
-    dummy:;
     }
 }
 

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -245,6 +245,7 @@ void EnClearTag_CreateLightRayEffect(EnClearTag* this, Vec3f* position, Vec3f* v
     for (i = 0; i < ARRAY_COUNT(this->effect) - 1; i++, effect++) {
         if (effect->type == CLEAR_TAG_EFFECT_AVAILABLE) {
             s32 pad;
+            
             effect->type = CLEAR_TAG_EFFECT_LIGHT_RAYS;
 
             effect->position = *position;

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -501,6 +501,7 @@ u16 func_808F3DD4(GlobalContext* globalCtx, EnIn* this, u32 arg2) {
 
     if (Player_GetMask(globalCtx) == PLAYER_MASK_CIRCUS_LEADERS_MASK) {
         s32 pad;
+
         if (!(gSaveContext.weekEventReg[63] & 0x40)) {
             return 0x34A9;
         } else if (this->unk4AC & 8) {
@@ -1260,6 +1261,7 @@ s32 func_808F5728(GlobalContext* globalCtx, EnIn* this, s32 arg2, s32* arg3) {
     }
     if (*arg3 == 1) {
         s32 pad;
+        
         player = PLAYER;
         func_808F5994(this, globalCtx, &player->actor.world.pos, 0xC80);
     } else {

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -500,7 +500,7 @@ u16 func_808F3DD4(GlobalContext* globalCtx, EnIn* this, u32 arg2) {
     u16 textId = 0;
 
     if (Player_GetMask(globalCtx) == PLAYER_MASK_CIRCUS_LEADERS_MASK) {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         if (!(gSaveContext.weekEventReg[63] & 0x40)) {
             return 0x34A9;
@@ -1260,7 +1260,7 @@ s32 func_808F5728(GlobalContext* globalCtx, EnIn* this, s32 arg2, s32* arg3) {
         return 1;
     }
     if (*arg3 == 1) {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         player = PLAYER;
         func_808F5994(this, globalCtx, &player->actor.world.pos, 0xC80);

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -500,6 +500,7 @@ u16 func_808F3DD4(GlobalContext* globalCtx, EnIn* this, u32 arg2) {
     u16 textId = 0;
 
     if (Player_GetMask(globalCtx) == PLAYER_MASK_CIRCUS_LEADERS_MASK) {
+        s32 pad;
         if (!(gSaveContext.weekEventReg[63] & 0x40)) {
             return 0x34A9;
         } else if (this->unk4AC & 8) {
@@ -507,7 +508,6 @@ u16 func_808F3DD4(GlobalContext* globalCtx, EnIn* this, u32 arg2) {
         } else {
             textId = 0x34AF;
         }
-    dummy_label_895710:; // POSSIBLE FAKE MATCH
     } else {
         switch (arg2) {
             case 0:
@@ -1259,9 +1259,9 @@ s32 func_808F5728(GlobalContext* globalCtx, EnIn* this, s32 arg2, s32* arg3) {
         return 1;
     }
     if (*arg3 == 1) {
+        s32 pad;
         player = PLAYER;
         func_808F5994(this, globalCtx, &player->actor.world.pos, 0xC80);
-    dummy_label_895711:; // POSSIBLE FAKE MATCH
     } else {
         rotDiff = this->actor.home.rot.y - this->actor.world.rot.y;
         if (rotDiff > 0x320) {

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -1261,7 +1261,7 @@ s32 func_808F5728(GlobalContext* globalCtx, EnIn* this, s32 arg2, s32* arg3) {
     }
     if (*arg3 == 1) {
         s32 pad;
-        
+
         player = PLAYER;
         func_808F5994(this, globalCtx, &player->actor.world.pos, 0xC80);
     } else {

--- a/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -2682,6 +2682,7 @@ void func_80B48AD4(EnInvadepoh* this, GlobalContext* globalCtx) {
 
     if (this->rand == 0) {
         s32 pad;
+        
         if ((this->actor.xzDistToPlayer < 350.0f) && ((globalCtx->gameplayFrames & 0x60) != 0)) {
             player = PLAYER;
             temp_v1 = Math_Vec3f_Pitch(&this->actor.focus.pos, &player->actor.focus.pos) * 0.85f;

--- a/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -2681,6 +2681,7 @@ void func_80B48AD4(EnInvadepoh* this, GlobalContext* globalCtx) {
     }
 
     if (this->rand == 0) {
+        s32 pad;
         if ((this->actor.xzDistToPlayer < 350.0f) && ((globalCtx->gameplayFrames & 0x60) != 0)) {
             player = PLAYER;
             temp_v1 = Math_Vec3f_Pitch(&this->actor.focus.pos, &player->actor.focus.pos) * 0.85f;
@@ -2690,9 +2691,6 @@ void func_80B48AD4(EnInvadepoh* this, GlobalContext* globalCtx) {
             temp_v1 = new_var3 * 0.7f;
             substruct->unk26.y = CLAMP(temp_v1, -0x1F40, 0x1F40);
         }
-
-    dummy:;
-
     } else {
         substruct->unk26.x = 0;
         substruct->unk26.y = 0;

--- a/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -2681,7 +2681,7 @@ void func_80B48AD4(EnInvadepoh* this, GlobalContext* globalCtx) {
     }
 
     if (this->rand == 0) {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         if ((this->actor.xzDistToPlayer < 350.0f) && ((globalCtx->gameplayFrames & 0x60) != 0)) {
             player = PLAYER;

--- a/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -2682,7 +2682,7 @@ void func_80B48AD4(EnInvadepoh* this, GlobalContext* globalCtx) {
 
     if (this->rand == 0) {
         s32 pad;
-        
+
         if ((this->actor.xzDistToPlayer < 350.0f) && ((globalCtx->gameplayFrames & 0x60) != 0)) {
             player = PLAYER;
             temp_v1 = Math_Vec3f_Pitch(&this->actor.focus.pos, &player->actor.focus.pos) * 0.85f;

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -325,7 +325,7 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, GlobalContext* globalCtx) {
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
                 s32 pad;
-                
+
                 invFrozenTimer = 1.0f / this->frozenTimer;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);
                 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -324,7 +324,7 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, GlobalContext* globalCtx) {
             Math_Vec3f_Copy(&this->shakeRefPos, &this->actor.world.pos);
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
-                s32 pad;
+                s32 requiredScopeTemp;
 
                 invFrozenTimer = 1.0f / this->frozenTimer;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -325,6 +325,7 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, GlobalContext* globalCtx) {
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
                 s32 pad;
+                
                 invFrozenTimer = 1.0f / this->frozenTimer;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);
                 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -324,6 +324,7 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, GlobalContext* globalCtx) {
             Math_Vec3f_Copy(&this->shakeRefPos, &this->actor.world.pos);
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
+                s32 pad;
                 invFrozenTimer = 1.0f / this->frozenTimer;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);
                 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;
@@ -331,7 +332,6 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, GlobalContext* globalCtx) {
                 randFloat = Rand_ZeroFloat(invFrozenTimer);
                 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;
                 this->actor.world.pos.z = randSign * (invFrozenTimer + randFloat) + this->shakeRefPos.z;
-            dummy:; // required for match
             }
         }
     } else {

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -392,6 +392,7 @@ void func_80BA5E18(EnRailgibud* this, GlobalContext* globalCtx) {
         case 1:
             if (this->unk_3F2 == 20) {
                 s16 pad;
+                
                 sp32 = player->ageProperties->unk_92 + 0x6805;
                 globalCtx->damagePlayer(globalCtx, -8);
                 func_800B8E58(&player->actor, sp32);

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -392,7 +392,7 @@ void func_80BA5E18(EnRailgibud* this, GlobalContext* globalCtx) {
         case 1:
             if (this->unk_3F2 == 20) {
                 s16 pad;
-                
+
                 sp32 = player->ageProperties->unk_92 + 0x6805;
                 globalCtx->damagePlayer(globalCtx, -8);
                 func_800B8E58(&player->actor, sp32);

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -391,7 +391,7 @@ void func_80BA5E18(EnRailgibud* this, GlobalContext* globalCtx) {
 
         case 1:
             if (this->unk_3F2 == 20) {
-                s16 pad;
+                s16 requiredScopeTemp;
 
                 sp32 = player->ageProperties->unk_92 + 0x6805;
                 globalCtx->damagePlayer(globalCtx, -8);

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -391,12 +391,12 @@ void func_80BA5E18(EnRailgibud* this, GlobalContext* globalCtx) {
 
         case 1:
             if (this->unk_3F2 == 20) {
+                s16 pad;
                 sp32 = player->ageProperties->unk_92 + 0x6805;
                 globalCtx->damagePlayer(globalCtx, -8);
                 func_800B8E58(&player->actor, sp32);
                 func_8013ECE0(this->actor.xzDistToPlayer, 240, 1, 12);
                 this->unk_3F2 = 0;
-            label:;
             } else {
                 this->unk_3F2++;
             }

--- a/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
+++ b/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
@@ -234,7 +234,7 @@ void ObjRaillift_Update(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
     if (OBJRAILLIFT_SHOULD_REACT_TO_WEIGHT(thisx)) {
-        s32 pad;
+        s32 requiredScopeTemp;
 
         this->isWeightOnPrev = this->isWeightOn;
         if (func_800CAF70(&this->dyna)) {

--- a/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
+++ b/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
@@ -235,6 +235,7 @@ void ObjRaillift_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
     if (OBJRAILLIFT_SHOULD_REACT_TO_WEIGHT(thisx)) {
         s32 pad;
+        
         this->isWeightOnPrev = this->isWeightOn;
         if (func_800CAF70(&this->dyna)) {
             this->isWeightOn = true;

--- a/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
+++ b/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
@@ -235,7 +235,7 @@ void ObjRaillift_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
     if (OBJRAILLIFT_SHOULD_REACT_TO_WEIGHT(thisx)) {
         s32 pad;
-        
+
         this->isWeightOnPrev = this->isWeightOn;
         if (func_800CAF70(&this->dyna)) {
             this->isWeightOn = true;

--- a/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
+++ b/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
@@ -234,6 +234,7 @@ void ObjRaillift_Update(Actor* thisx, GlobalContext* globalCtx) {
         }
     }
     if (OBJRAILLIFT_SHOULD_REACT_TO_WEIGHT(thisx)) {
+        s32 pad;
         this->isWeightOnPrev = this->isWeightOn;
         if (func_800CAF70(&this->dyna)) {
             this->isWeightOn = true;
@@ -251,7 +252,6 @@ void ObjRaillift_Update(Actor* thisx, GlobalContext* globalCtx) {
         target = this->isWeightOn ? -8.0f : 0.0f;
         Math_StepToF(&this->cycleSpeed, target, step);
         this->dyna.actor.shape.yOffset = ((Math_SinS(this->cycle) * this->maxHeight) + this->cycleSpeed) * 10.0f;
-    dummy:;
     }
     if (OBJRAILLIFT_GET_TYPE(thisx) == DEKU_FLOWER_PLATFORM && this->dyna.actor.child != NULL) {
         if (this->dyna.actor.child->update == NULL) {


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

In my PR for Obj_Etcetera, I fixed a match that involved a dummy label by using a scoped pad. I found out that a few other dummy labels in the codebase can be fixed the same way:

- For the actors, I'm pretty sure all of them are "true" matches.
- For game.c, I'm not sure if either of the things I changed are a "true" match or not, but they get rid of the dummy labels. If people don't like it, I'm happy to remove it from this PR.
- `DmaMgr_Start` in z_std_dma.c: I found that you can remove the dummy labels just by replacing them with `{ s32 pad }`. However, it looked so bad I didn't bother to include it in this PR.