### PR TITLE
Match 2 of the 6 remaining functions in En_Sw

### DIFF
--- a/src/overlays/actors/ovl_En_Sw/z_en_sw.c
+++ b/src/overlays/actors/ovl_En_Sw/z_en_sw.c
@@ -571,7 +571,7 @@ s32 func_808D9C18(EnSw* this) {
         this->actor.velocity.x *= Math_SinS(this->actor.world.rot.y);
         this->actor.velocity.z *= Math_CosS(this->actor.world.rot.y);
     } else {
-        new_var = this->actor.speedXZ * this->unk_350.x;  
+        new_var = this->actor.speedXZ * this->unk_350.x;
         this->actor.velocity.x = new_var + (this->actor.speedXZ * this->unk_368.x);
         new_var = this->actor.speedXZ * this->unk_350.z;
         this->actor.velocity.z = new_var + this->actor.speedXZ * this->unk_368.z;
@@ -1084,7 +1084,6 @@ void func_808DAEB4(EnSw* this, GlobalContext* globalCtx) {
             } else {
                 this->unk_45C = 20;
             }
-
         }
     }
 }


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Also made improvements in a third function. I looked at all the other non-matchings in the file but no luck yet.