### PR TITLE
Prevent building unused asm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,8 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_PNG:.png=.inc.c),build/$f) \
 					 $(foreach f,$(TEXTURE_FILES_JPG:.jpg=.jpg.inc.c),build/$f) \
 
 C_FILES       := $(foreach dir,$(SRC_DIRS),$(wildcard $(dir)/*.c))
-S_FILES       := $(shell grep -F "build/asm" spec  | cut -d '"' -f2 - | sed 's/build\/// ; s/\.o/\.s/') \
-                 $(shell grep -F "build/data" spec  | cut -d '"' -f2 - | sed 's/build\/// ; s/\.o/\.s/')
+S_FILES       := $(shell grep -F "build/asm" spec | sed 's/.*build\/// ; s/\.o\".*/.s/') \
+                 $(shell grep -F "build/data" spec | sed 's/.*build\/// ; s/\.o\".*/.s/')
 O_FILES       := $(foreach f,$(S_FILES:.s=.o),build/$f) \
                  $(foreach f,$(wildcard baserom/*),build/$f.o) \
                  $(foreach f,$(C_FILES:.c=.o),build/$f) \


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Use the `spec` to know which `.asm` files should be built instead of just building all of them.
This reduced the assembly building step time from ~20 seconds to ~10 seconds (this does not include building other files, like .c ones). This time should eventually decrease when more files  are decomped.