### PR TITLE
Update diff-init to be dependent on just the uncompressed rom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ disasm:
 	$(RM) -rf asm data
 	python3 tools/disasm/disasm.py
 
-diff-init: all
+diff-init: uncompressed
 	$(RM) -rf expected/
 	mkdir -p expected/
 	cp -r build expected/build


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
This will stop `make init` from compressing the rom twice, by having diff-init just depend on the uncompressed rom.