### PR TITLE
Add an explanatory comment header for every actor that doesn't have one

### DIFF
--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_arms_hook.c
+ * Overlay: ovl_Arms_Hook
+ * Description: Hookshot tip
+ */
+
 #include "z_arms_hook.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
+++ b/src/overlays/actors/ovl_Arrow_Fire/z_arrow_fire.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_arrow_fire.c
+ * Overlay: ovl_Arrow_Fire
+ * Description: Fire Arrow
+ */
+
 #include "z_arrow_fire.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
+++ b/src/overlays/actors/ovl_Arrow_Light/z_arrow_light.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_arrow_light.c
+ * Overlay: ovl_Arrow_Light
+ * Description: Light Arrow
+ */
+
 #include "z_arrow_light.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Bg_Astr_Bombwall/z_bg_astr_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Astr_Bombwall/z_bg_astr_bombwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_astr_bombwall.c
+ * Overlay: ovl_Bg_Astr_Bombwall
+ * Description: Astral Observatory - Bombable Wall
+ */
+
 #include "z_bg_astr_bombwall.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Botihasira/z_bg_botihasira.c
+++ b/src/overlays/actors/ovl_Bg_Botihasira/z_bg_botihasira.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_botihasira.c
+ * Overlay: ovl_Bg_Botihasira
+ * Description: Captain Keeta Race - Gatepost
+ */
+
 #include "z_bg_botihasira.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_breakwall.c
+ * Overlay: ovl_Bg_Breakwall
+ * Description: Great Bay Temple? (or the weather around it?)
+ */
+
 #include "z_bg_breakwall.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Crace_Movebg/z_bg_crace_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Crace_Movebg/z_bg_crace_movebg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_crace_movebg.c
+ * Overlay: ovl_Bg_Crace_Movebg
+ * Description: Huge sliding doors in Deku Shrine
+ */
+
 #include "z_bg_crace_movebg.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Danpei_Movebg/z_bg_danpei_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Danpei_Movebg/z_bg_danpei_movebg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_danpei_movebg.c
+ * Overlay: ovl_Bg_Danpei_Movebg
+ * Description: Moving platforms beneath Dampe's house
+ */
+
 #include "z_bg_danpei_movebg.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Dblue_Balance/z_bg_dblue_balance.c
+++ b/src/overlays/actors/ovl_Bg_Dblue_Balance/z_bg_dblue_balance.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dblue_balance.c
+ * Overlay: ovl_Bg_Dblue_Balance
+ * Description: Great Bay Temple - See-Saw
+ */
+
 #include "z_bg_dblue_balance.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Dblue_Elevator/z_bg_dblue_elevator.c
+++ b/src/overlays/actors/ovl_Bg_Dblue_Elevator/z_bg_dblue_elevator.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dblue_elevator.c
+ * Overlay: ovl_Bg_Dblue_Elevator
+ * Description: Great Bay Temple - Elevator
+ */
+
 #include "z_bg_dblue_elevator.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Dblue_Movebg/z_bg_dblue_movebg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dblue_movebg.c
+ * Overlay: ovl_Bg_Dblue_Movebg
+ * Description: Great Bay Temple - Waterwheels and push switches
+ */
+
 #include "z_bg_dblue_movebg.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Dblue_Waterfall/z_bg_dblue_waterfall.c
+++ b/src/overlays/actors/ovl_Bg_Dblue_Waterfall/z_bg_dblue_waterfall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dblue_waterfall.c
+ * Overlay: ovl_Bg_Dblue_Waterfall
+ * Description: Great Bay Temple - Freezable Geyser
+ */
+
 #include "z_bg_dblue_waterfall.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.c
+++ b/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dkjail_ivy.c
+ * Overlay: ovl_Bg_Dkjail_Ivy
+ * Description: Ivy in Deku Jail
+ */
+
 #include "z_bg_dkjail_ivy.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
+++ b/src/overlays/actors/ovl_Bg_Dy_Yoseizo/z_bg_dy_yoseizo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_dy_yoseizo.c
+ * Overlay: ovl_Bg_Dy_Yoseizo
+ * Description: Great Fairy
+ */
+
 #include "z_bg_dy_yoseizo.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_Bg_F40_Block/z_bg_f40_block.c
+++ b/src/overlays/actors/ovl_Bg_F40_Block/z_bg_f40_block.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_f40_block.c
+ * Overlay: ovl_Bg_F40_Block
+ * Description: Stone Tower Block
+ */
+
 #include "z_bg_f40_block.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_F40_Flift/z_bg_f40_flift.c
+++ b/src/overlays/actors/ovl_Bg_F40_Flift/z_bg_f40_flift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_f40_flift.c
+ * Overlay: ovl_Bg_F40_Flift
+ * Description: Stone Tower Temple - Grey Square Stone Elevator
+ */
+
 #include "z_bg_f40_flift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.c
+++ b/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_f40_switch.c
+ * Overlay: ovl_Bg_F40_Switch
+ * Description: Stone Tower Switch
+ */
+
 #include "z_bg_f40_switch.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
+++ b/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_f40_swlift.c
+ * Overlay: ovl_Bg_F40_Swlift
+ * Description:
+ */
+
 #include "z_bg_f40_swlift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Fire_Wall/z_bg_fire_wall.c
+++ b/src/overlays/actors/ovl_Bg_Fire_Wall/z_bg_fire_wall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_fire_wall.c
+ * Overlay: ovl_Bg_Fire_Wall
+ * Description: Wall of fire spawned by ovl_Bg_Spout_Fire
+ */
+
 #include "z_bg_fire_wall.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
+++ b/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_fu_kaiten.c
+ * Overlay: ovl_Bg_Fu_Kaiten
+ * Description: Honey & Darling's Shop - Rotating Platform
+ */
+
 #include "z_bg_fu_kaiten.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Fu_Mizu/z_bg_fu_mizu.c
+++ b/src/overlays/actors/ovl_Bg_Fu_Mizu/z_bg_fu_mizu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_fu_mizu.c
+ * Overlay: ovl_Bg_Fu_Mizu
+ * Description:
+ */
+
 #include "z_bg_fu_mizu.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Goron_Oyu/z_bg_goron_oyu.c
+++ b/src/overlays/actors/ovl_Bg_Goron_Oyu/z_bg_goron_oyu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_goron_oyu.c
+ * Overlay: ovl_Bg_Goron_Oyu
+ * Description: Goron Hot Spring Water
+ */
+
 #include "z_bg_goron_oyu.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Haka_Bombwall/z_bg_haka_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Bombwall/z_bg_haka_bombwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_haka_bombwall.c
+ * Overlay: ovl_Bg_Haka_Bombwall
+ * Description: Beneath the Grave - Bombable Wall
+ */
+
 #include "z_bg_haka_bombwall.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Haka_Curtain/z_bg_haka_curtain.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Curtain/z_bg_haka_curtain.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_haka_curtain.c
+ * Overlay: ovl_Bg_Haka_Curtain
+ * Description: Curtain That Lifts to Reveal Flat's Tomb
+ */
+
 #include "z_bg_haka_curtain.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Haka_Tomb/z_bg_haka_tomb.c
+++ b/src/overlays/actors/ovl_Bg_Haka_Tomb/z_bg_haka_tomb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_haka_tomb.c
+ * Overlay: ovl_Bg_Haka_Tomb
+ * Description: Flat's Tomb
+ */
+
 #include "z_bg_haka_tomb.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_hakugin_bombwall.c
+ * Overlay: ovl_Bg_Hakugin_Bombwall
+ * Description: Snowhead Temple - Bombable Wall
+ */
+
 #include "z_bg_hakugin_bombwall.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Hakugin_Elvpole/z_bg_hakugin_elvpole.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Elvpole/z_bg_hakugin_elvpole.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_hakugin_elvpole.c
+ * Overlay: ovl_Bg_Hakugin_Elvpole
+ * Description: Raisable pillar in Snowhead Temple Map room
+ */
+
 #include "z_bg_hakugin_elvpole.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Hakugin_Switch/z_bg_hakugin_switch.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Switch/z_bg_hakugin_switch.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_hakugin_switch.c
+ * Overlay: ovl_Bg_Hakugin_Switch
+ * Description: Goron Link Switch
+ */
+
 #include "z_bg_hakugin_switch.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Icefloe/z_bg_icefloe.c
+++ b/src/overlays/actors/ovl_Bg_Icefloe/z_bg_icefloe.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_icefloe.c
+ * Overlay: ovl_Bg_Icefloe
+ * Description: Ice Platform Created by Ice Arrow
+ */
+
 #include "z_bg_icefloe.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Block/z_bg_ikana_block.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_block.c
+ * Overlay: ovl_Bg_Ikana_Block
+ * Description: Stone Tower Temple - Rotating Room Pushblock
+ */
+
 #include "z_bg_ikana_block.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Ikana_Bombwall/z_bg_ikana_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Bombwall/z_bg_ikana_bombwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_bombwall.c
+ * Overlay: ovl_Bg_Ikana_Bombwall
+ * Description: Stone Tower Temple - Bombable Tan Floor Tile
+ */
+
 #include "z_bg_ikana_bombwall.h"
 
 #define FLAGS 0x10000000

--- a/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_dharma.c
+ * Overlay: ovl_Bg_Ikana_Dharma
+ * Description: Ikana Castle - Punchable Pillar Segments
+ */
+
 #include "z_bg_ikana_dharma.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Ikana_Mirror/z_bg_ikana_mirror.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Mirror/z_bg_ikana_mirror.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_mirror.c
+ * Overlay: ovl_Bg_Ikana_Mirror
+ * Description: Stone Tower Temple - Mirror
+ */
+
 #include "z_bg_ikana_mirror.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Ikana_Ray/z_bg_ikana_ray.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Ray/z_bg_ikana_ray.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_ray.c
+ * Overlay: ovl_Bg_Ikana_Ray
+ * Description: Large light ray in Stone Tower Temple
+ */
+
 #include "z_bg_ikana_ray.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Ikana_Rotaryroom/z_bg_ikana_rotaryroom.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Rotaryroom/z_bg_ikana_rotaryroom.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_rotaryroom.c
+ * Overlay: ovl_Bg_Ikana_Rotaryroom
+ * Description: Stone Tower Temple - Rotating Room
+ */
+
 #include "z_bg_ikana_rotaryroom.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Ikana_Shutter/z_bg_ikana_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Shutter/z_bg_ikana_shutter.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikana_shutter.c
+ * Overlay: ovl_Bg_Ikana_Shutter
+ * Description: Metal shutter in switch room of Stone Tower Temple
+ */
+
 #include "z_bg_ikana_shutter.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Iknin_Susceil/z_bg_iknin_susceil.c
+++ b/src/overlays/actors/ovl_Bg_Iknin_Susceil/z_bg_iknin_susceil.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_iknin_susceil.c
+ * Overlay: ovl_Bg_Iknin_Susceil
+ * Description: Ikana Castle - Hot Checkered Ceiling
+ */
+
 #include "z_bg_iknin_susceil.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Ikninside/z_bg_ikninside.c
+++ b/src/overlays/actors/ovl_Bg_Ikninside/z_bg_ikninside.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ikninside.c
+ * Overlay: ovl_Bg_Ikninside
+ * Description: Ancient Castle of Ikana Objects
+ */
+
 #include "z_bg_ikninside.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Iknv_Doukutu/z_bg_iknv_doukutu.c
+++ b/src/overlays/actors/ovl_Bg_Iknv_Doukutu/z_bg_iknv_doukutu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_iknv_doukutu.c
+ * Overlay: ovl_Bg_Iknv_Doukutu
+ * Description: Sharp's Cave
+ */
+
 #include "z_bg_iknv_doukutu.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Iknv_Obj/z_bg_iknv_obj.c
+++ b/src/overlays/actors/ovl_Bg_Iknv_Obj/z_bg_iknv_obj.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_iknv_obj.c
+ * Overlay: ovl_Bg_Iknv_Obj
+ * Description: Ikana - waterwheel, stone tower door, sakon's hideout door
+ */
+
 #include "z_bg_iknv_obj.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
+++ b/src/overlays/actors/ovl_Bg_Ingate/z_bg_ingate.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_ingate.c
+ * Overlay: ovl_Bg_Ingate
+ * Description: Swamp Tour Boat
+ */
+
 #include "z_bg_ingate.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Inibs_Movebg/z_bg_inibs_movebg.c
+++ b/src/overlays/actors/ovl_Bg_Inibs_Movebg/z_bg_inibs_movebg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_inibs_movebg.c
+ * Overlay: ovl_Bg_Inibs_Movebg
+ * Description: Twinmold Arena
+ */
+
 #include "z_bg_inibs_movebg.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Keikoku_Saku/z_bg_keikoku_saku.c
+++ b/src/overlays/actors/ovl_Bg_Keikoku_Saku/z_bg_keikoku_saku.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_keikoku_saku.c
+ * Overlay: ovl_Bg_Keikoku_Saku
+ * Description: Termina Field Spiked Fence
+ */
+
 #include "z_bg_keikoku_saku.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Kin2_Bombwall/z_bg_kin2_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Kin2_Bombwall/z_bg_kin2_bombwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_kin2_bombwall.c
+ * Overlay: ovl_Bg_Kin2_Bombwall
+ * Description: Ocean Spider House - Bombable Wall
+ */
+
 #include "z_bg_kin2_bombwall.h"
 
 #define FLAGS 0x10000010

--- a/src/overlays/actors/ovl_Bg_Kin2_Fence/z_bg_kin2_fence.c
+++ b/src/overlays/actors/ovl_Bg_Kin2_Fence/z_bg_kin2_fence.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_kin2_fence.c
+ * Overlay: ovl_Bg_Kin2_Fence
+ * Description: Ocean Spider House - Fireplace Grate
+ */
+
 #include "z_bg_kin2_fence.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.c
+++ b/src/overlays/actors/ovl_Bg_Kin2_Picture/z_bg_kin2_picture.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_kin2_picture.c
+ * Overlay: ovl_Bg_Kin2_Picture
+ * Description: Ocean Spider House - Skullkid Painting
+ */
+
 #include "z_bg_kin2_picture.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Kin2_Shelf/z_bg_kin2_shelf.c
+++ b/src/overlays/actors/ovl_Bg_Kin2_Shelf/z_bg_kin2_shelf.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_kin2_shelf.c
+ * Overlay: ovl_Bg_Kin2_Shelf
+ * Description: Ocean Spider House - Drawers
+ */
+
 #include "z_bg_kin2_shelf.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Last_Bwall/z_bg_last_bwall.c
+++ b/src/overlays/actors/ovl_Bg_Last_Bwall/z_bg_last_bwall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_last_bwall.c
+ * Overlay: ovl_Bg_Last_Bwall
+ * Description: Link Moon Dungeon - Bombable, Climbable Wall
+ */
+
 #include "z_bg_last_bwall.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Lbfshot/z_bg_lbfshot.c
+++ b/src/overlays/actors/ovl_Bg_Lbfshot/z_bg_lbfshot.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_lbfshot.c
+ * Overlay: ovl_Bg_Lbfshot
+ * Description: Rainbow Hookshot Pillar
+ */
+
 #include "z_bg_lbfshot.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Market_Step/z_bg_market_step.c
+++ b/src/overlays/actors/ovl_Bg_Market_Step/z_bg_market_step.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_market_step.c
+ * Overlay: ovl_Bg_Market_Step
+ * Description: West Clocktown - Stairs
+ */
+
 #include "z_bg_market_step.h"
 
 #define FLAGS 0x10000020

--- a/src/overlays/actors/ovl_Bg_Mbar_Chair/z_bg_mbar_chair.c
+++ b/src/overlays/actors/ovl_Bg_Mbar_Chair/z_bg_mbar_chair.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_mbar_chair.c
+ * Overlay: ovl_Bg_Mbar_Chair
+ * Description: Milk Bar - Chair
+ */
+
 #include "z_bg_mbar_chair.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.c
+++ b/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_numa_hana.c
+ * Overlay: ovl_Bg_Numa_Hana
+ * Description: Big wooden flower in Woodfall Temple
+ */
+
 #include "z_bg_numa_hana.h"
 
 #define FLAGS 0x00000410

--- a/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_open_shutter.c
+ * Overlay: ovl_Bg_Open_Shutter
+ * Description:
+ */
+
 #include "z_bg_open_shutter.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Open_Spot/z_bg_open_spot.c
+++ b/src/overlays/actors/ovl_Bg_Open_Spot/z_bg_open_spot.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_open_spot.c
+ * Overlay: ovl_Bg_Open_Spot
+ * Description: Star Light Rays in Intro Scene
+ */
+
 #include "z_bg_open_spot.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Sinkai_Kabe/z_bg_sinkai_kabe.c
+++ b/src/overlays/actors/ovl_Bg_Sinkai_Kabe/z_bg_sinkai_kabe.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_sinkai_kabe.c
+ * Overlay: ovl_Bg_Sinkai_Kabe
+ * Description: Large Rotating Green Rupee
+ */
+
 #include "z_bg_sinkai_kabe.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Bg_Spdweb/z_bg_spdweb.c
+++ b/src/overlays/actors/ovl_Bg_Spdweb/z_bg_spdweb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_spdweb.c
+ * Overlay: ovl_Bg_Spdweb
+ * Description: Spiderweb
+ */
+
 #include "z_bg_spdweb.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Spout_Fire/z_bg_spout_fire.c
+++ b/src/overlays/actors/ovl_Bg_Spout_Fire/z_bg_spout_fire.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_spout_fire.c
+ * Overlay: ovl_Bg_Spout_Fire
+ * Description: Proximity-Activated Fire Wall Spawner
+ */
+
 #include "z_bg_spout_fire.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Bg_Tobira01/z_bg_tobira01.c
+++ b/src/overlays/actors/ovl_Bg_Tobira01/z_bg_tobira01.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_tobira01.c
+ * Overlay: ovl_Bg_Tobira01
+ * Description: Gate to Goron Shrine
+ */
+
 #include "z_bg_tobira01.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.c
+++ b/src/overlays/actors/ovl_Bg_Umajump/z_bg_umajump.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_bg_umajump.c
+ * Overlay: ovl_Bg_Umajump
+ * Description: Horse Jumping Fence
+ */
+
 #include "z_bg_umajump.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Boss_01/z_boss_01.c
+++ b/src/overlays/actors/ovl_Boss_01/z_boss_01.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_01.c
+ * Overlay: ovl_Boss_01
+ * Description: Odolwa
+ */
+
 #include "z_boss_01.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_02/z_boss_02.c
+++ b/src/overlays/actors/ovl_Boss_02/z_boss_02.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_02.c
+ * Overlay: ovl_Boss_02
+ * Description: Twinmold
+ */
+
 #include "z_boss_02.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_03/z_boss_03.c
+++ b/src/overlays/actors/ovl_Boss_03/z_boss_03.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_03.c
+ * Overlay: ovl_Boss_03
+ * Description: Gyorg
+ */
+
 #include "z_boss_03.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_04/z_boss_04.c
+++ b/src/overlays/actors/ovl_Boss_04/z_boss_04.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_04.c
+ * Overlay: ovl_Boss_04
+ * Description: Wart
+ */
+
 #include "z_boss_04.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_05/z_boss_05.c
+++ b/src/overlays/actors/ovl_Boss_05/z_boss_05.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_05.c
+ * Overlay: ovl_Boss_05
+ * Description: Bio Deku Baba
+ */
+
 #include "z_boss_05.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_Boss_06/z_boss_06.c
+++ b/src/overlays/actors/ovl_Boss_06/z_boss_06.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_06.c
+ * Overlay: ovl_Boss_06
+ * Description: Igos du Ikana window - curtains and ray effects
+ */
+
 #include "z_boss_06.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_07/z_boss_07.c
+++ b/src/overlays/actors/ovl_Boss_07/z_boss_07.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_07.c
+ * Overlay: ovl_Boss_07
+ * Description: Majora
+ */
+
 #include "z_boss_07.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.c
+++ b/src/overlays/actors/ovl_Boss_Hakugin/z_boss_hakugin.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_boss_hakugin.c
+ * Overlay: ovl_Boss_Hakugin
+ * Description: Goht
+ */
+
 #include "z_boss_hakugin.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_effect.c
+ * Overlay: ovl_Demo_Effect
+ * Description: Obtaining Masks (?)
+ */
+
 #include "z_demo_effect.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.c
+++ b/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_getitem.c
+ * Overlay: ovl_Demo_Getitem
+ * Description:
+ */
+
 #include "z_demo_getitem.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -1,7 +1,7 @@
 /*
  * File: z_demo_kankyo.c
  * Overlay: ovl_Demo_Kankyo
- * Description: Background Lost Woods Particles
+ * Description: Background Lost Woods/Giant's Chamber/Moon Particles
  */
 
 #include "z_demo_kankyo.h"

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_kankyo.c
+ * Overlay: ovl_Demo_Kankyo
+ * Description: Background Lost Woods Particles
+ */
+
 #include "z_demo_kankyo.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Moonend/z_demo_moonend.c
+++ b/src/overlays/actors/ovl_Demo_Moonend/z_demo_moonend.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_moonend.c
+ * Overlay: ovl_Demo_Moonend
+ * Description: Moon Disappearing (cutscene)
+ */
+
 #include "z_demo_moonend.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
+++ b/src/overlays/actors/ovl_Demo_Shd/z_demo_shd.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_shd.c
+ * Overlay: ovl_Demo_Shd
+ * Description:
+ */
+
 #include "z_demo_shd.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.c
+++ b/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_syoten.c
+ * Overlay: ovl_Demo_Syoten
+ * Description:
+ */
+
 #include "z_demo_syoten.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_demo_tre_lgt.c
+ * Overlay: ovl_Demo_Tre_Lgt
+ * Description: Light Radiating From Treasure Chest
+ */
+
 #include "z_demo_tre_lgt.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Dm_Ah/z_dm_ah.c
+++ b/src/overlays/actors/ovl_Dm_Ah/z_dm_ah.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_ah.c
+ * Overlay: ovl_Dm_Ah
+ * Description: Anju's Mother (cutscene)
+ */
+
 #include "z_dm_ah.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Dm_Al/z_dm_al.c
+++ b/src/overlays/actors/ovl_Dm_Al/z_dm_al.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_al.c
+ * Overlay: ovl_Dm_Al
+ * Description: Madame Aroma (cutscene)
+ */
+
 #include "z_dm_al.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Dm_An/z_dm_an.c
+++ b/src/overlays/actors/ovl_Dm_An/z_dm_an.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_an.c
+ * Overlay: ovl_Dm_An
+ * Description: Anju (cutscene)
+ */
+
 #include "z_dm_an.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Dm_Bal/z_dm_bal.c
+++ b/src/overlays/actors/ovl_Dm_Bal/z_dm_bal.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_bal.c
+ * Overlay: ovl_Dm_Bal
+ * Description: Tingle (cutscene)
+ */
+
 #include "z_dm_bal.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.c
+++ b/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char00.c
+ * Overlay: ovl_Dm_Char00
+ * Description: Tatl (cutscene)
+ */
+
 #include "z_dm_char00.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.c
+++ b/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char01.c
+ * Overlay: ovl_Dm_Char01
+ * Description: Tatl and Tael (cutscene)
+ */
+
 #include "z_dm_char01.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.c
+++ b/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char02.c
+ * Overlay: ovl_Dm_Char02
+ * Description:
+ */
+
 #include "z_dm_char02.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char03/z_dm_char03.c
+++ b/src/overlays/actors/ovl_Dm_Char03/z_dm_char03.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char03.c
+ * Overlay: ovl_Dm_Char03
+ * Description:
+ */
+
 #include "z_dm_char03.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.c
+++ b/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char04.c
+ * Overlay: ovl_Dm_Char04
+ * Description:
+ */
+
 #include "z_dm_char04.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.c
+++ b/src/overlays/actors/ovl_Dm_Char05/z_dm_char05.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char05.c
+ * Overlay: ovl_Dm_Char05
+ * Description: Cutscene mask objects
+ */
+
 #include "z_dm_char05.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
+++ b/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char06.c
+ * Overlay: ovl_Dm_Char06
+ * Description: Some unseen Mountain Village cutscene actor?
+ */
+
 #include "z_dm_char06.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
+++ b/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char08.c
+ * Overlay: ovl_Dm_Char08
+ * Description: Large Great Bay Turtle
+ */
+
 #include "z_dm_char08.h"
 
 #define FLAGS 0x02000000

--- a/src/overlays/actors/ovl_Dm_Char09/z_dm_char09.c
+++ b/src/overlays/actors/ovl_Dm_Char09/z_dm_char09.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_char09.c
+ * Overlay: ovl_Dm_Char09
+ * Description: Pirates' Fortress cutscene characters
+ */
+
 #include "z_dm_char09.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Gm/z_dm_gm.c
+++ b/src/overlays/actors/ovl_Dm_Gm/z_dm_gm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_gm.c
+ * Overlay: ovl_Dm_Gm
+ * Description: Anju (cutscene) (duplicate of Dm_An?)
+ */
+
 #include "z_dm_gm.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Dm_Hina/z_dm_hina.c
+++ b/src/overlays/actors/ovl_Dm_Hina/z_dm_hina.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_hina.c
+ * Overlay: ovl_Dm_Hina
+ * Description: Boss mask cutscene objects
+ */
+
 #include "z_dm_hina.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.c
+++ b/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_opstage.c
+ * Overlay: ovl_Dm_Opstage
+ * Description: Lost Woods cutscene objects
+ */
+
 #include "z_dm_opstage.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
+++ b/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_sa.c
+ * Overlay: ovl_Dm_Sa
+ * Description:
+ */
+
 #include "z_dm_sa.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Statue/z_dm_statue.c
+++ b/src/overlays/actors/ovl_Dm_Statue/z_dm_statue.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_statue.c
+ * Overlay: ovl_Dm_Statue
+ * Description: Elegy of Emptiness - Beam of Light When Creating Statue
+ */
+
 #include "z_dm_statue.h"
 
 #define FLAGS 0x04000030

--- a/src/overlays/actors/ovl_Dm_Stk/z_dm_stk.c
+++ b/src/overlays/actors/ovl_Dm_Stk/z_dm_stk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_stk.c
+ * Overlay: ovl_Dm_Stk
+ * Description: Skull Kid (cutscene)
+ */
+
 #include "z_dm_stk.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.c
+++ b/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_tag.c
+ * Overlay: ovl_Dm_Tag
+ * Description:
+ */
+
 #include "z_dm_tag.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Dm_Tsg/z_dm_tsg.c
+++ b/src/overlays/actors/ovl_Dm_Tsg/z_dm_tsg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_tsg.c
+ * Overlay: ovl_Dm_Tsg
+ * Description: Handles all the masks scrolling by as Link falls in the intro
+ */
+
 #include "z_dm_tsg.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.c
+++ b/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_dm_zl.c
+ * Overlay: ovl_Dm_Zl
+ * Description: Child Zelda (Cutscenes)
+ */
+
 #include "z_dm_zl.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_door_ana.c
+ * Overlay: ovl_Door_Ana
+ * Description: Grotto Hole Entrance
+ */
+
 #include "z_door_ana.h"
 
 #define FLAGS 0x02000000

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_door_shutter.c
+ * Overlay: ovl_Door_Shutter
+ * Description: Studded Lifting Door / Ikana Castle Rolling Door
+ */
+
 #include "z_door_shutter.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
+++ b/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_door_spiral.c
+ * Overlay: ovl_Door_Spiral
+ * Description: Staircase
+ */
+
 #include "z_door_spiral.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
+++ b/src/overlays/actors/ovl_Door_Warp1/z_door_warp1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_door_warp1.c
+ * Overlay: ovl_Door_Warp1
+ * Description: Blue Warp
+ */
+
 #include "z_door_warp1.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Eff_Change/z_eff_change.c
+++ b/src/overlays/actors/ovl_Eff_Change/z_eff_change.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_eff_change.c
+ * Overlay: ovl_Eff_Change
+ * Description:
+ */
+
 #include "z_eff_change.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.c
+++ b/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.c
@@ -1,3 +1,9 @@
+/*
+ * File z_eff_kamejima_wave.c
+ * Overlay: ovl_Eff_Kamejima_Wave
+ * Description: Wave Created by Turtle Awakening
+ */
+
 #include "z_eff_kamejima_wave.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.c
+++ b/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.c
@@ -1,3 +1,9 @@
+/*
+ * File z_eff_lastday.c
+ * Overlay: ovl_Eff_Lastday
+ * Description: Moon Crash Cutscene Fire Wall
+ */
+
 #include "z_eff_lastday.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.c
+++ b/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.c
@@ -1,3 +1,9 @@
+/*
+ * File z_eff_stk.c
+ * Overlay: ovl_Eff_Stk
+ * Description: Skullkid Effects (calling down moon / cursing Link)
+ */
+
 #include "z_eff_stk.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
+++ b/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
@@ -1,3 +1,9 @@
+/*
+ * File z_eff_zoraband.c
+ * Overlay: ovl_Eff_Zoraband
+ * Description:
+ */
+
 #include "z_eff_zoraband.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg.c
+ * Overlay: ovl_Elf_Msg
+ * Description: Tatl Hint (proximity-activated C-up hint?)
+ */
+
 #include "z_elf_msg.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg2.c
+ * Overlay: ovl_Elf_Msg2
+ * Description: Tatl Hint (Z-target-activated C-up hint?)
+ */
+
 #include "z_elf_msg2.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
+++ b/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg3.c
+ * Overlay: ovl_Elf_Msg3
+ * Description: Tatl Message (Proximity-activated dialogue?)
+ */
+
 #include "z_elf_msg3.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
+++ b/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg4.c
+ * Overlay: ovl_Elf_Msg4
+ * Description: Tatl Hint (another proximity-activated C-up hint?)
+ */
+
 #include "z_elf_msg4.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.c
+++ b/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg5.c
+ * Overlay: ovl_Elf_Msg5
+ * Description: Tatl Message (Another proximity-activated dialogue?)
+ */
+
 #include "z_elf_msg5.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
+++ b/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
@@ -1,3 +1,9 @@
+/*
+ * File z_elf_msg6.c
+ * Overlay: ovl_Elf_Msg6
+ * Description: Tatl Hint (another proximity-activated C-up hint?)
+ */
+
 #include "z_elf_msg6.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Ah/z_en_ah.c
+++ b/src/overlays/actors/ovl_En_Ah/z_en_ah.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_ah.c
+ * Overlay: ovl_En_Ah
+ * Description: Anju's Mother
+ */
+
 #include "z_en_ah.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_akindonuts.c
+ * Overlay: ovl_En_Akindonuts
+ * Description: Woodfall - Business Scrub
+ */
+
 #include "z_en_akindonuts.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Al/z_en_al.c
+++ b/src/overlays/actors/ovl_En_Al/z_en_al.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_al.c
+ * Overlay: ovl_En_Al
+ * Description: Madame Aroma
+ */
+
 #include "z_en_al.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_am.c
+ * Overlay: ovl_En_Am
+ * Description: Armos
+ */
+
 #include "z_en_am.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_An/z_en_an.c
+++ b/src/overlays/actors/ovl_En_An/z_en_an.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_an.c
+ * Overlay: ovl_En_An
+ * Description: Anju
+ */
+
 #include "z_en_an.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_And/z_en_and.c
+++ b/src/overlays/actors/ovl_En_And/z_en_and.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_and.c
+ * Overlay: ovl_En_And
+ * Description: Anju in Wedding Dress
+ */
+
 #include "z_en_and.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_ani.c
+ * Overlay: ovl_En_Ani
+ * Description: Part-Timer
+ */
+
 #include "z_en_ani.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
+++ b/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_aob_01.c
+ * Overlay: ovl_En_Aob_01
+ * Description: Mamamu Yan
+ */
+
 #include "z_en_aob_01.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_arrow.c
+ * Overlay: ovl_En_Arrow
+ * Description: Arrows and other projectiles
+ */
+
 #include "z_en_arrow.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_attack_niw.c
+ * Overlay: ovl_En_Attack_Niw
+ * Description: Attacking cucco
+ */
+
 #include "z_en_attack_niw.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Az/z_en_az.c
+++ b/src/overlays/actors/ovl_En_Az/z_en_az.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_az.c
+ * Overlay: ovl_En_Az
+ * Description: Beaver Bros
+ */
+
 #include "z_en_az.h"
 
 #define FLAGS 0x80000010

--- a/src/overlays/actors/ovl_En_Baba/z_en_baba.c
+++ b/src/overlays/actors/ovl_En_Baba/z_en_baba.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_baba.c
+ * Overlay: ovl_En_Baba
+ * Description: Bomb Shop Lady
+ */
+
 #include "z_en_baba.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Baguo/z_en_baguo.c
+++ b/src/overlays/actors/ovl_En_Baguo/z_en_baguo.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_baguo.c
+ * Overlay: ovl_En_Baguo
+ * Description: Nejiron
+ */
+
 #include "z_en_baguo.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Bal/z_en_bal.c
+++ b/src/overlays/actors/ovl_En_Bal/z_en_bal.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bal.c
+ * Overlay: ovl_En_Bal
+ * Description: Tingle With Balloon
+ */
+
 #include "z_en_bal.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Bat/z_en_bat.c
+++ b/src/overlays/actors/ovl_En_Bat/z_en_bat.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bat.c
+ * Overlay: ovl_En_Bat
+ * Description: Bad Bat
+ */
+
 #include "z_en_bat.h"
 
 #define FLAGS 0x00005005

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bb.c
+ * Overlay: ovl_En_Bb
+ * Description: Blue Bubble
+ */
+
 #include "z_en_bb.h"
 
 #define FLAGS 0x00000205

--- a/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
+++ b/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bba_01.c
+ * Overlay: ovl_En_Bba_01
+ * Description:
+ */
+
 #include "z_en_bba_01.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.c
+++ b/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bbfall.c
+ * Overlay: ovl_En_Bbfall
+ * Description: Red Bubble
+ */
+
 #include "z_en_bbfall.h"
 
 #define FLAGS 0x00000215

--- a/src/overlays/actors/ovl_En_Bee/z_en_bee.c
+++ b/src/overlays/actors/ovl_En_Bee/z_en_bee.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bee.c
+ * Overlay: ovl_En_Bee
+ * Description: Giant Bee
+ */
+
 #include "z_en_bee.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Bh/z_en_bh.c
+++ b/src/overlays/actors/ovl_En_Bh/z_en_bh.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bh.c
+ * Overlay: ovl_En_Bh
+ * Description: Brown Bird
+ */
+
 #include "z_en_bh.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bigokuta.c
+ * Overlay: ovl_En_Bigokuta
+ * Description: Big Octo
+ */
+
 #include "z_en_bigokuta.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.c
+++ b/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bigpamet.c
+ * Overlay: ovl_En_Bigpamet
+ * Description: Gekko & Snapper Miniboss - Snapper
+ */
+
 #include "z_en_bigpamet.h"
 
 #define FLAGS 0x00000435

--- a/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bigslime.c
+ * Overlay: ovl_En_Bigslime
+ * Description: Mad Jelly (miniboss)
+ */
+
 #include "z_en_bigslime.h"
 
 #define FLAGS 0x00000235

--- a/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
+++ b/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bjt.c
+ * Overlay: ovl_En_Bjt
+ * Description: Hand in Toilet
+ */
+
 #include "z_en_bjt.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Boj_01/z_en_boj_01.c
+++ b/src/overlays/actors/ovl_En_Boj_01/z_en_boj_01.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boj_01.c
+ * Overlay: ovl_En_Boj_01
+ * Description: [Empty]
+ */
+
 #include "z_en_boj_01.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Boj_02/z_en_boj_02.c
+++ b/src/overlays/actors/ovl_En_Boj_02/z_en_boj_02.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boj_02.c
+ * Overlay: ovl_En_Boj_02
+ * Description: [Empty]
+ */
+
 #include "z_en_boj_02.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Boj_03/z_en_boj_03.c
+++ b/src/overlays/actors/ovl_En_Boj_03/z_en_boj_03.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boj_03.c
+ * Overlay: ovl_En_Boj_03
+ * Description: [Empty]
+ */
+
 #include "z_en_boj_03.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Boj_04/z_en_boj_04.c
+++ b/src/overlays/actors/ovl_En_Boj_04/z_en_boj_04.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boj_04.c
+ * Overlay: ovl_En_Boj_04
+ * Description: [Empty]
+ */
+
 #include "z_en_boj_04.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Boj_05/z_en_boj_05.c
+++ b/src/overlays/actors/ovl_En_Boj_05/z_en_boj_05.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boj_05.c
+ * Overlay: ovl_En_Boj_05
+ * Description: [Empty]
+ */
+
 #include "z_en_boj_05.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bom.c
+ * Overlay: ovl_En_Bom
+ * Description: Bomb / Powder Keg
+ */
+
 #include "z_en_bom.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bom_bowl_man.c
+ * Overlay: ovl_En_Bom_Bowl_Man
+ * Description: Line of Bombers?
+ */
+
 #include "z_en_bom_bowl_man.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bom_chu.c
+ * Overlay: ovl_En_Bom_Chu
+ * Description: Bombchus
+ */
+
 #include "z_en_bom_chu.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Bombal/z_en_bombal.c
+++ b/src/overlays/actors/ovl_En_Bombal/z_en_bombal.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bombal.c
+ * Overlay: ovl_En_Bombal
+ * Description: Bombers - Majora Balloon
+ */
+
 #include "z_en_bombal.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
+++ b/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bombers.c
+ * Overlay: ovl_En_Bombers
+ * Description: Bombers - Blue-Hatted Bomber
+ */
+
 #include "z_en_bombers.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
+++ b/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bombers2.c
+ * Overlay: ovl_En_Bombers2
+ * Description: Bombers - Hideout Guard
+ */
+
 #include "z_en_bombers2.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bombf.c
+ * Overlay: ovl_En_Bombf
+ * Description: Bomb flower
+ */
+
 #include "z_en_bombf.h"
 
 #define FLAGS 0x00000011

--- a/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
+++ b/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bomjima.c
+ * Overlay: ovl_En_Bomjima
+ * Description: Bombers - Jim
+ */
+
 #include "z_en_bomjima.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
+++ b/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bomjimb.c
+ * Overlay: ovl_En_Bomjimb
+ * Description: Bomber Jim B
+ */
+
 #include "z_en_bomjimb.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_boom.c
+ * Overlay: ovl_En_Boom
+ * Description: Zora boomerangs
+ */
+
 #include "z_en_boom.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_box.c
+ * Overlay: ovl_En_Box
+ * Description: Chest
+ */
+
 #include "z_en_box.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Bsb/z_en_bsb.c
+++ b/src/overlays/actors/ovl_En_Bsb/z_en_bsb.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bsb.c
+ * Overlay: ovl_En_Bsb
+ * Description: Captain Keeta
+ */
+
 #include "z_en_bsb.h"
 
 #define FLAGS 0x02000035

--- a/src/overlays/actors/ovl_En_Bu/z_en_bu.c
+++ b/src/overlays/actors/ovl_En_Bu/z_en_bu.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bu.c
+ * Overlay: ovl_En_Bu
+ * Description: Unused dummied-out enemy
+ */
+
 #include "z_en_bu.h"
 
 #define FLAGS 0x00000001

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_bubble.c
+ * Overlay: ovl_En_Bubble
+ * Description: Bubble (flying skull enemy)
+ */
+
 #include "z_en_bubble.h"
 
 #define FLAGS 0x00000001

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_butte.c
+ * Overlay: ovl_En_Butte
+ * Description: Butterflies
+ */
+
 #include "z_en_butte.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
+++ b/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_cne_01.c
+ * Overlay: ovl_En_Cne_01
+ * Description:
+ */
+
 #include "z_en_cne_01.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
+++ b/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_col_man.c
+ * Overlay: ovl_En_Col_Man
+ * Description: Gives you a Piece of Heart when you touch it?
+ */
+
 #include "z_en_col_man.h"
 
 #define FLAGS 0x00100000

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_cow.c
+ * Overlay: ovl_En_Cow
+ * Description: Cow
+ */
+
 #include "z_en_cow.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_crow.c
+ * Overlay: ovl_En_Crow
+ * Description: Guay
+ */
+
 #include "z_en_crow.h"
 
 #define FLAGS 0x00005005

--- a/src/overlays/actors/ovl_En_Death/z_en_death.c
+++ b/src/overlays/actors/ovl_En_Death/z_en_death.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_death.c
+ * Overlay: ovl_En_Death
+ * Description: Gomess
+ */
+
 #include "z_en_death.h"
 
 #define FLAGS 0x00001035

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_dekubaba.c
+ * Overlay: ovl_En_Dekubaba
+ * Description: Deku Baba
+ */
+
 #include "z_en_dekubaba.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
+++ b/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
@@ -1,3 +1,9 @@
+/*
+ * File z_en_demo_heishi.c
+ * Overlay: ovl_En_Demo_heishi
+ * Description: Unused(?) version of Shiro
+ */
+
 #include "z_en_demo_heishi.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
+++ b/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_dnh.c
+ * Overlay: ovl_En_Dnh
+ * Description: Koume in boat house
+ */
+
 #include "z_en_dnh.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_door.c
+ * Overlay: ovl_En_Door
+ * Description: Wooden Door
+ */
+
 #include "z_en_door.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Door_Etc/z_en_door_etc.c
+++ b/src/overlays/actors/ovl_En_Door_Etc/z_en_door_etc.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_door_etc.c
+ * Overlay: ovl_En_Door_Etc
+ * Description: Wooden Door
+ */
+
 #include "z_en_door_etc.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Dragon/z_en_dragon.c
+++ b/src/overlays/actors/ovl_En_Dragon/z_en_dragon.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_dragon.c
+ * Overlay: ovl_En_Dragon
+ * Description: Deep Python
+ */
+
 #include "z_en_dragon.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Drs/z_en_drs.c
+++ b/src/overlays/actors/ovl_En_Drs/z_en_drs.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_drs.c
+ * Overlay: ovl_En_Drs
+ * Description: Wedding dress manequin
+ */
+
 #include "z_en_drs.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
+++ b/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ds2n.c
+ * Overlay: ovl_En_Ds2n
+ * Description:
+ */
+
 #include "z_en_ds2n.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Dt/z_en_dt.c
+++ b/src/overlays/actors/ovl_En_Dt/z_en_dt.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_dt.c
+ * Overlay: ovl_En_Dt
+ * Description: Mayor Dotour
+ */
+
 #include "z_en_dt.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
+++ b/src/overlays/actors/ovl_En_Dy_Extra/z_en_dy_extra.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_dy_extra.c
+ * Overlay: ovl_En_Dy_Extra
+ * Description: Great Fairy beam
+ */
+
 #include "z_en_dy_extra.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Egblock/z_en_egblock.c
+++ b/src/overlays/actors/ovl_En_Egblock/z_en_egblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_egblock.c
+ * Overlay: ovl_En_Egblock
+ * Description: Eyegore Block
+ */
+
 #include "z_en_egblock.h"
 
 #define FLAGS 0x08000000

--- a/src/overlays/actors/ovl_En_Egol/z_en_egol.c
+++ b/src/overlays/actors/ovl_En_Egol/z_en_egol.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_egol.c
+ * Overlay: ovl_En_Egol
+ * Description: Eyegore
+ */
+
 #include "z_en_egol.h"
 
 #define FLAGS 0x80000035

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_elf.c
+ * Overlay: ovl_En_Elf
+ * Description: Fairies
+ */
+
 #include "z_en_elf.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.c
+++ b/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_elfgrp.c
+ * Overlay: ovl_En_Elfgrp
+ * Description: Group of Stray Fairies in Fairy Fountain
+ */
+
 #include "z_en_elfgrp.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_encount1.c
+ * Overlay: ovl_En_Encount1
+ * Description:
+ */
+
 #include "z_en_encount1.h"
 
 #define FLAGS 0x08100010

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_encount2.c
+ * Overlay: ovl_En_Encount2
+ * Description: Astral Observatory - Majora's Mask Balloon
+ */
+
 #include "z_en_encount2.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Encount3/z_en_encount3.c
+++ b/src/overlays/actors/ovl_En_Encount3/z_en_encount3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_encount3.c
+ * Overlay: ovl_En_Encount3
+ * Description:
+ */
+
 #include "z_en_encount3.h"
 
 #define FLAGS 0x08000030

--- a/src/overlays/actors/ovl_En_Encount4/z_en_encount4.c
+++ b/src/overlays/actors/ovl_En_Encount4/z_en_encount4.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_encount4.c
+ * Overlay: ovl_En_Encount4
+ * Description:
+ */
+
 #include "z_en_encount4.h"
 
 #define FLAGS 0x08000010

--- a/src/overlays/actors/ovl_En_Ending_Hero/z_en_ending_hero.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero/z_en_ending_hero.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ending_hero.c
+ * Overlay: ovl_En_Ending_Hero
+ * Description:
+ */
+
 #include "z_en_ending_hero.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ending_Hero2/z_en_ending_hero2.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero2/z_en_ending_hero2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ending_hero2.c
+ * Overlay: ovl_En_Ending_Hero2
+ * Description:
+ */
+
 #include "z_en_ending_hero2.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ending_Hero3/z_en_ending_hero3.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero3/z_en_ending_hero3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ending_hero3.c
+ * Overlay: ovl_En_Ending_Hero3
+ * Description:
+ */
+
 #include "z_en_ending_hero3.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ending_Hero4/z_en_ending_hero4.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero4/z_en_ending_hero4.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ending_hero4.c
+ * Overlay: ovl_En_Ending_Hero4
+ * Description:
+ */
+
 #include "z_en_ending_hero4.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ending_Hero5/z_en_ending_hero5.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero5/z_en_ending_hero5.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ending_hero5.c
+ * Overlay: ovl_En_Ending_Hero5
+ * Description:
+ */
+
 #include "z_en_ending_hero5.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Estone/z_en_estone.c
+++ b/src/overlays/actors/ovl_En_Estone/z_en_estone.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_estone.c
+ * Overlay: ovl_En_Estone
+ * Description: Eyegore Rubble
+ */
+
 #include "z_en_estone.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Fall/z_en_fall.c
+++ b/src/overlays/actors/ovl_En_Fall/z_en_fall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fall.c
+ * Overlay: ovl_En_Fall
+ * Description: The Moon and related effects
+ */
+
 #include "z_en_fall.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Fall2/z_en_fall2.c
+++ b/src/overlays/actors/ovl_En_Fall2/z_en_fall2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fall2.c
+ * Overlay: ovl_En_Fall2
+ * Description: "Warp Beam" from Moon's Mouth in Cutscene?
+ */
+
 #include "z_en_fall2.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Famos/z_en_famos.c
+++ b/src/overlays/actors/ovl_En_Famos/z_en_famos.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_famos.c
+ * Overlay: ovl_En_Famos
+ * Description: Death Armos
+ */
+
 #include "z_en_famos.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
+++ b/src/overlays/actors/ovl_En_Fire_Rock/z_en_fire_rock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fire_rock.c
+ * Overlay: ovl_En_Fire_Rock
+ * Description: [Empty]
+ */
+
 #include "z_en_fire_rock.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Firefly2/z_en_firefly2.c
+++ b/src/overlays/actors/ovl_En_Firefly2/z_en_firefly2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_firefly2.c
+ * Overlay: ovl_En_Firefly2
+ * Description: [Empty]
+ */
+
 #include "z_en_firefly2.h"
 
 #define FLAGS 0x00005015

--- a/src/overlays/actors/ovl_En_Fish/z_en_fish.c
+++ b/src/overlays/actors/ovl_En_Fish/z_en_fish.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fish.c
+ * Overlay: ovl_En_Fish
+ * Description: Fish
+ */
+
 #include "z_en_fish.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_floormas.c
+ * Overlay: ovl_En_Floormas
+ * Description: Floormaster
+ */
+
 #include "z_en_floormas.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Fr/z_en_fr.c
+++ b/src/overlays/actors/ovl_En_Fr/z_en_fr.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fr.c
+ * Overlay: ovl_En_Fr
+ * Description:
+ */
+
 #include "z_en_fr.h"
 
 #define FLAGS 0x40000000

--- a/src/overlays/actors/ovl_En_Fu_Kago/z_en_fu_kago.c
+++ b/src/overlays/actors/ovl_En_Fu_Kago/z_en_fu_kago.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fu_kago.c
+ * Overlay: ovl_En_Fu_Kago
+ * Description: Honey & Darling's Shop - Bomb Basket
+ */
+
 #include "z_en_fu_kago.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Fu_Mato/z_en_fu_mato.c
+++ b/src/overlays/actors/ovl_En_Fu_Mato/z_en_fu_mato.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fu_mato.c
+ * Overlay: ovl_En_Fu_Mato
+ * Description: Honey & Darling's Shop - Target
+ */
+
 #include "z_en_fu_mato.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Fz/z_en_fz.c
+++ b/src/overlays/actors/ovl_En_Fz/z_en_fz.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_fz.c
+ * Overlay: ovl_En_Fz
+ * Description: Freezard
+ */
+
 #include "z_en_fz.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.c
+++ b/src/overlays/actors/ovl_En_Gakufu/z_en_gakufu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gakufu.c
+ * Overlay: ovl_En_Gakufu
+ * Description: Termina Field - 2D Song Buttons Appearing on Wall
+ */
+
 #include "z_en_gakufu.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.c
+++ b/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gamelupy.c
+ * Overlay: ovl_En_Gamelupy
+ * Description: Deku Scrub Playground - Large Green Rupee
+ */
+
 #include "z_en_gamelupy.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
+++ b/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gb2.c
+ * Overlay: ovl_En_Gb2
+ * Description: Spirit House - Owner
+ */
+
 #include "z_en_gb2.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ge1.c
+ * Overlay: ovl_En_Ge1
+ * Description:
+ */
+
 #include "z_en_ge1.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ge2.c
+ * Overlay: ovl_En_Ge2
+ * Description: Patrolling Pirate
+ */
+
 #include "z_en_ge2.h"
 
 #define FLAGS 0x80000009

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ge3.c
+ * Overlay: ovl_En_Ge3
+ * Description:
+ */
+
 #include "z_en_ge3.h"
 
 #define FLAGS 0x80000019

--- a/src/overlays/actors/ovl_En_Geg/z_en_geg.c
+++ b/src/overlays/actors/ovl_En_Geg/z_en_geg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_geg.c
+ * Overlay: ovl_En_Geg
+ * Description: Goron With Don Gero's Mask
+ */
+
 #include "z_en_geg.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Gg/z_en_gg.c
+++ b/src/overlays/actors/ovl_En_Gg/z_en_gg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gg.c
+ * Overlay: ovl_En_Gg
+ * Description: Darmani's Ghost
+ */
+
 #include "z_en_gg.h"
 
 #define FLAGS 0x00000089

--- a/src/overlays/actors/ovl_En_Gg2/z_en_gg2.c
+++ b/src/overlays/actors/ovl_En_Gg2/z_en_gg2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gg2.c
+ * Overlay: ovl_En_Gg2
+ * Description: Darmani's Ghost (2)
+ */
+
 #include "z_en_gg2.h"
 
 #define FLAGS 0x00000089

--- a/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
+++ b/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ginko_man.c
+ * Overlay: ovl_En_Ginko_Man
+ * Description: Bank Teller
+ */
+
 #include "z_en_ginko_man.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Gk/z_en_gk.c
+++ b/src/overlays/actors/ovl_En_Gk/z_en_gk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gk.c
+ * Overlay: ovl_En_Gk
+ * Description: Goron Elder's Son
+ */
+
 #include "z_en_gk.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gm.c
+ * Overlay: ovl_En_Gm
+ * Description: Gorman
+ */
+
 #include "z_en_gm.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_go.c
+ * Overlay: ovl_En_Go
+ * Description: Goron
+ */
+
 #include "z_en_go.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_goroiwa.c
+ * Overlay: ovl_En_Goroiwa
+ * Description: Rolling boulder
+ */
+
 #include "z_en_goroiwa.h"
 
 #define FLAGS 0x80000010

--- a/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.c
+++ b/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_grasshopper.c
+ * Overlay: ovl_En_Grasshopper
+ * Description: Dragonfly
+ */
+
 #include "z_en_grasshopper.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_gs.c
+ * Overlay: ovl_En_Gs
+ * Description: Gossip stone
+ */
+
 #include "z_en_gs.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.c
+++ b/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_guard_nuts.c
+ * Overlay: ovl_En_Guard_Nuts
+ * Description: Deku Palace - Entrance Guard
+ */
+
 #include "z_en_guard_nuts.h"
 
 #define FLAGS 0x80100009

--- a/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.c
+++ b/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hakurock.c
+ * Overlay: ovl_En_Hakurock
+ * Description: Rocks Kicked Up by Goht
+ */
+
 #include "z_en_hakurock.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Hanabi/z_en_hanabi.c
+++ b/src/overlays/actors/ovl_En_Hanabi/z_en_hanabi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hanabi.c
+ * Overlay: ovl_En_Hanabi
+ * Description: Fireworks
+ */
+
 #include "z_en_hanabi.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Hata/z_en_hata.c
+++ b/src/overlays/actors/ovl_En_Hata/z_en_hata.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hata.c
+ * Overlay: ovl_En_Hata
+ * Description: Red Flag on Post
+ */
+
 #include "z_en_hata.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Heishi/z_en_heishi.c
+++ b/src/overlays/actors/ovl_En_Heishi/z_en_heishi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_heishi.c
+ * Overlay: ovl_En_Heishi
+ * Description: Soldier
+ */
+
 #include "z_en_heishi.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Hg/z_en_hg.c
+++ b/src/overlays/actors/ovl_En_Hg/z_en_hg.c
@@ -1,6 +1,6 @@
 /*
  * File: z_en_hg.c
- * Overlay: En_Hg
+ * Overlay: ovl_En_Hg
  * Description: Pamela's Father (Human)
  */
 

--- a/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
+++ b/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hgo.c
+ * Overlay: ovl_En_Hgo
+ * Description: Pamela's Father As a Gibdo
+ */
+
 #include "z_en_hgo.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.c
+++ b/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hidden_nuts.c
+ * Overlay: ovl_En_Hidden_Nuts
+ * Description: Swamp Spider House - Sleeping Deku Scrub
+ */
+
 #include "z_en_hidden_nuts.h"
 
 #define FLAGS 0x02000009

--- a/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.c
+++ b/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hint_skb.c
+ * Overlay: ovl_En_Hint_Skb
+ * Description: Stalchild that gives hints in Oceanside Spider House
+ */
+
 #include "z_en_hint_skb.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Hit_Tag/z_en_hit_tag.c
+++ b/src/overlays/actors/ovl_En_Hit_Tag/z_en_hit_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hit_tag.c
+ * Overlay: ovl_En_Hit_Tag
+ * Description: Invisible hitbox that can spawn rupees
+ */
+
 #include "z_en_hit_tag.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
+++ b/src/overlays/actors/ovl_En_Honotrap/z_en_honotrap.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_honotrap.c
+ * Overlay: ovl_En_Honotrap
+ * Description: Eye switch that shoots fire
+ */
+
 #include "z_en_honotrap.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_horse.c
+ * Overlay: ovl_En_Horse
+ * Description: Epona
+ */
+
 #include "z_en_horse.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_horse_game_check.c
+ * Overlay: ovl_En_Horse_Game_Check
+ * Description:
+ */
+
 #include "z_en_horse_game_check.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
+++ b/src/overlays/actors/ovl_En_Horse_Link_Child/z_en_horse_link_child.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_horse_link_child.c
+ * Overlay: ovl_En_Horse_Link_Child
+ * Description: Child Epona
+ */
+
 #include "z_en_horse_link_child.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hs.c
+ * Overlay: ovl_En_Hs
+ * Description: Grog
+ */
+
 #include "z_en_hs.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_hs2.c
+ * Overlay: ovl_En_Hs2
+ * Description: Blue Target Spot
+ */
+
 #include "z_en_hs2.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Ig/z_en_ig.c
+++ b/src/overlays/actors/ovl_En_Ig/z_en_ig.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ig.c
+ * Overlay: ovl_En_Ig
+ * Description: The Goron named the same as the player
+ */
+
 #include "z_en_ig.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Ik/z_en_ik.c
+++ b/src/overlays/actors/ovl_En_Ik/z_en_ik.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ik.c
+ * Overlay: ovl_En_Ik
+ * Description: Iron Knuckle
+ */
+
 #include "z_en_ik.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Insect/z_en_insect.c
+++ b/src/overlays/actors/ovl_En_Insect/z_en_insect.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_insect.c
+ * Overlay: ovl_En_Insect
+ * Description: Single freestanding bug that doesn't burrow
+ */
+
 #include "z_en_insect.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Invadepoh_Demo/z_en_invadepoh_demo.c
+++ b/src/overlays/actors/ovl_En_Invadepoh_Demo/z_en_invadepoh_demo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_invadepoh_demo.c
+ * Overlay: ovl_En_Invadepoh_Demo
+ * Description:
+ */
+
 #include "z_en_invadepoh_demo.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Invisible_Ruppe/z_en_invisible_ruppe.c
+++ b/src/overlays/actors/ovl_En_Invisible_Ruppe/z_en_invisible_ruppe.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_invisible_ruppe.c
+ * Overlay: ovl_En_Invisible_Ruppe
+ * Description: Invisible Rupee
+ */
+
 #include "z_en_invisible_ruppe.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ishi.c
+ * Overlay: ovl_En_Ishi
+ * Description: Rock
+ */
+
 #include "z_en_ishi.h"
 
 #define FLAGS 0x00800010

--- a/src/overlays/actors/ovl_En_Ja/z_en_ja.c
+++ b/src/overlays/actors/ovl_En_Ja/z_en_ja.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ja.c
+ * Overlay: ovl_En_Ja
+ * Description: Juggler
+ */
+
 #include "z_en_ja.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Jg/z_en_jg.c
+++ b/src/overlays/actors/ovl_En_Jg/z_en_jg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_jg.c
+ * Overlay: ovl_En_Jg
+ * Description: Goron Elder
+ */
+
 #include "z_en_jg.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
+++ b/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_jgame_tsn.c
+ * Overlay: ovl_En_Jgame_Tsn
+ * Description: Fisherman's Jumping Game - Fisherman
+ */
+
 #include "z_en_jgame_tsn.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_js.c
+ * Overlay: ovl_En_Js
+ * Description: Moon Child
+ */
+
 #include "z_en_js.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Jso/z_en_jso.c
+++ b/src/overlays/actors/ovl_En_Jso/z_en_jso.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_jso.c
+ * Overlay: ovl_En_Jso
+ * Description: Garo
+ */
+
 #include "z_en_jso.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Jso2/z_en_jso2.c
+++ b/src/overlays/actors/ovl_En_Jso2/z_en_jso2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_jso2.c
+ * Overlay: ovl_En_Jso2
+ * Description: Garo Master
+ */
+
 #include "z_en_jso2.h"
 
 #define FLAGS 0x80100035

--- a/src/overlays/actors/ovl_En_Kaizoku/z_en_kaizoku.c
+++ b/src/overlays/actors/ovl_En_Kaizoku/z_en_kaizoku.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kaizoku.c
+ * Overlay: ovl_En_Kaizoku
+ * Description: Fighter pirate
+ */
+
 #include "z_en_kaizoku.h"
 
 #define FLAGS 0x00100015

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kakasi.c
+ * Overlay: ovl_En_Kakasi
+ * Description: Pierre
+ */
+
 #include "z_en_kakasi.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Kame/z_en_kame.c
+++ b/src/overlays/actors/ovl_En_Kame/z_en_kame.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kame.c
+ * Overlay: ovl_En_Kame
+ * Description: Snapper Turtle
+ */
+
 #include "z_en_kame.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kanban.c
+ * Overlay: ovl_En_Kanban
+ * Description: Square signpost
+ */
+
 #include "z_en_kanban.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
+++ b/src/overlays/actors/ovl_En_Karebaba/z_en_karebaba.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_karebaba.c
+ * Overlay: ovl_En_Karebaba
+ * Description: Wilted Deku Baba
+ */
+
 #include "z_en_karebaba.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Kbt/z_en_kbt.c
+++ b/src/overlays/actors/ovl_En_Kbt/z_en_kbt.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kbt.c
+ * Overlay: ovl_En_Kbt
+ * Description: Zubora
+ */
+
 #include "z_en_kbt.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.c
+++ b/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kendo_js.c
+ * Overlay: ovl_En_Kendo_Js
+ * Description: Swordsman
+ */
+
 #include "z_en_kendo_js.h"
 
 #define FLAGS 0x0A000019

--- a/src/overlays/actors/ovl_En_Kitan/z_en_kitan.c
+++ b/src/overlays/actors/ovl_En_Kitan/z_en_kitan.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kitan.c
+ * Overlay: ovl_En_Kitan
+ * Description:
+ */
+
 #include "z_en_kitan.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Knight/z_en_knight.c
+++ b/src/overlays/actors/ovl_En_Knight/z_en_knight.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_knight.c
+ * Overlay: ovl_En_Knight
+ * Description: Igos du Ikana and his lackeys
+ */
+
 #include "z_en_knight.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.c
+++ b/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kujiya.c
+ * Overlay: ovl_En_Kujiya
+ * Description: Clock Town - Lottery Shop
+ */
+
 #include "z_en_kujiya.h"
 
 #define FLAGS 0x08000009

--- a/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
+++ b/src/overlays/actors/ovl_En_Kusa/z_en_kusa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kusa.c
+ * Overlay: ovl_En_Kusa
+ * Description: Grass / Bush
+ */
+
 #include "z_en_kusa.h"
 
 #define FLAGS 0x00800010

--- a/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
+++ b/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_kusa2.c
+ * Overlay: ovl_En_Kusa2
+ * Description: Keaton grass?
+ */
+
 #include "z_en_kusa2.h"
 
 #define FLAGS 0x00800010

--- a/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.c
+++ b/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_lift_nuts.c
+ * Overlay: ovl_En_Lift_Nuts
+ * Description: Deku Scrub Playground - Employee
+ */
+
 #include "z_en_lift_nuts.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Light/z_en_light.c
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_light.c
+ * Overlay: ovl_En_Light
+ * Description: Deku Shrine - Flames of Varying Colours
+ */
+
 #include "z_en_light.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Look_Nuts/z_en_look_nuts.c
+++ b/src/overlays/actors/ovl_En_Look_Nuts/z_en_look_nuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_look_nuts.c
+ * Overlay: ovl_En_Look_Nuts
+ * Description: Deku Palace - Patrolling Deku Guard
+ */
+
 #include "z_en_look_nuts.h"
 
 #define FLAGS 0x80000000

--- a/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
+++ b/src/overlays/actors/ovl_En_M_Fire1/z_en_m_fire1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_m_fire1.c
+ * Overlay: ovl_En_M_Fire1
+ * Description: Deku Nut Effect
+ */
+
 #include "z_en_m_fire1.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_m_thunder.c
+ * Overlay: ovl_En_M_Thunder
+ * Description: Spin attack effect
+ */
+
 #include "z_en_m_thunder.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mag.c
+ * Overlay: ovl_En_Mag
+ * Description: Title Logo
+ */
+
 #include "z_en_mag.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Maruta/z_en_maruta.c
+++ b/src/overlays/actors/ovl_En_Maruta/z_en_maruta.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_maruta.c
+ * Overlay: ovl_En_Maruta
+ * Description: Swordsman's School - Practice Log
+ */
+
 #include "z_en_maruta.h"
 
 #define FLAGS 0x00000011

--- a/src/overlays/actors/ovl_En_Minideath/z_en_minideath.c
+++ b/src/overlays/actors/ovl_En_Minideath/z_en_minideath.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_minideath.c
+ * Overlay: ovl_En_Minideath
+ * Description: Bats Surrounding Gomess?
+ */
+
 #include "z_en_minideath.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mk.c
+ * Overlay: ovl_En_Mk
+ * Description: Marine Researcher
+ */
+
 #include "z_en_mk.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Mkk/z_en_mkk.c
+++ b/src/overlays/actors/ovl_En_Mkk/z_en_mkk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mkk.c
+ * Overlay: ovl_En_Mkk
+ * Description: Makkurokurosuke / Black and White Boe
+ */
+
 #include "z_en_mkk.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Mm/z_en_mm.c
+++ b/src/overlays/actors/ovl_En_Mm/z_en_mm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mm.c
+ * Overlay: ovl_En_Mm
+ * Description: Rock Sirloin
+ */
+
 #include "z_en_mm.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mm2.c
+ * Overlay: ovl_En_Mm2
+ * Description: Postman's Letter to Himself
+ */
+
 #include "z_en_mm2.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
+++ b/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mm3.c
+ * Overlay: ovl_En_Mm3
+ * Description: Counting Game Postman
+ */
+
 #include "z_en_mm3.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
+++ b/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mnk.c
+ * Overlay: ovl_En_Mnk
+ * Description: Monkey
+ */
+
 #include "z_en_mnk.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ms.c
+ * Overlay: ovl_En_Ms
+ * Description: Bean salesman
+ */
+
 #include "z_en_ms.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_mt_tag.c
+ * Overlay: ovl_En_Mt_tag
+ * Description:
+ */
+
 #include "z_en_mt_tag.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_mushi2.c
  * Overlay: ovl_En_Mushi2
- * Description: Burrowing Bugs
+ * Description: Group of three bugs that burrow underground
  */
 
 #include "overlays/actors/ovl_Obj_Bean/z_obj_bean.h"

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_nb.c
+ * Overlay: ovl_En_Nb
+ * Description: Anju's Grandma
+ */
+
 #include "z_en_nb.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.c
+++ b/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_neo_reeba.c
+ * Overlay: ovl_En_Neo_Reeba
+ * Description: Leevers
+ */
+
 #include "z_en_neo_reeba.h"
 
 #define FLAGS 0x00000205

--- a/src/overlays/actors/ovl_En_Nimotsu/z_en_nimotsu.c
+++ b/src/overlays/actors/ovl_En_Nimotsu/z_en_nimotsu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_nimotsu.c
+ * Overlay: ovl_En_Nimotsu
+ * Description: Bomb Shop Bag Stolen by Sakon
+ */
+
 #include "z_en_nimotsu.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Nnh/z_en_nnh.c
+++ b/src/overlays/actors/ovl_En_Nnh/z_en_nnh.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_nnh.c
+ * Overlay: ovl_En_Nnh
+ * Description: Twisted Corpse of Deku Butler's Son
+ */
+
 #include "z_en_nnh.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_nutsball.c
+ * Overlay: ovl_En_Nutsball
+ * Description: Deku nut Projectile
+ */
+
 #include "z_en_nutsball.h"
 #include "overlays/effects/ovl_Effect_Ss_Hahen/z_eff_ss_hahen.h"
 

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_nwc.c
+ * Overlay: ovl_En_Nwc
+ * Description: Cucco chick
+ */
+
 #include "z_en_nwc.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_okarina_effect.c
+ * Overlay: ovl_En_Okarina_Effect
+ * Description:
+ */
+
 #include "z_en_okarina_effect.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
+++ b/src/overlays/actors/ovl_En_Okarina_Tag/z_en_okarina_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_okarina_tag.c
+ * Overlay: ovl_En_Okarina_Tag
+ * Description:
+ */
+
 #include "z_en_okarina_tag.h"
 
 #define FLAGS 0x0A000010

--- a/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
+++ b/src/overlays/actors/ovl_En_Okuta/z_en_okuta.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_okuta.c
+ * Overlay: ovl_En_Okuta
+ * Description: Octorok
+ */
+
 #include "z_en_okuta.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
+++ b/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_onpuman.c
+ * Overlay: ovl_En_Onpuman
+ * Description: Monkey Instrument Prompt
+ */
+
 #include "z_en_onpuman.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Osk/z_en_osk.c
+++ b/src/overlays/actors/ovl_En_Osk/z_en_osk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_osk.c
+ * Overlay: ovl_En_Osk
+ * Description: Igos du Ikana's and his lackey's floating heads
+ */
+
 #include "z_en_osk.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Osn/z_en_osn.c
+++ b/src/overlays/actors/ovl_En_Osn/z_en_osn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_osn.c
+ * Overlay: ovl_En_Osn
+ * Description: Happy Mask Salesman
+ */
+
 #include "z_en_osn.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Pamera/z_en_pamera.c
+++ b/src/overlays/actors/ovl_En_Pamera/z_en_pamera.c
@@ -1,6 +1,6 @@
 /*
  * File: z_en_pamera.c
- * Overlay: En_Pamera
+ * Overlay: ovl_En_Pamera
  * Description: Pamela
  */
 

--- a/src/overlays/actors/ovl_En_Pametfrog/z_en_pametfrog.c
+++ b/src/overlays/actors/ovl_En_Pametfrog/z_en_pametfrog.c
@@ -1,6 +1,6 @@
 /*
  * File: z_en_pametfrog.c
- * Overlay: En_Pametfrog
+ * Overlay: ovl_En_Pametfrog
  * Description: Gekko & Snapper Miniboss: Gekko
  */
 

--- a/src/overlays/actors/ovl_En_Paper/z_en_paper.c
+++ b/src/overlays/actors/ovl_En_Paper/z_en_paper.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_paper.c
+ * Overlay: ovl_En_Paper
+ * Description: Tingle Confetti
+ */
+
 #include "z_en_paper.h"
 
 #define FLAGS 0x02100010

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_part.c
+ * Overlay: ovl_En_Part
+ * Description:
+ */
+
 #include "z_en_part.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_peehat.c
+ * Overlay: ovl_En_Peehat
+ * Description: Peahat
+ */
+
 #include "z_en_peehat.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Pm/z_en_pm.c
+++ b/src/overlays/actors/ovl_En_Pm/z_en_pm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_pm.c
+ * Overlay: ovl_En_Pm
+ * Description: Postman delivering letters
+ */
+
 #include "z_en_pm.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Po_Composer/z_en_po_composer.c
+++ b/src/overlays/actors/ovl_En_Po_Composer/z_en_po_composer.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_po_composer.c
+ * Overlay: ovl_En_Po_Composer
+ * Description: Poe Composers
+ */
+
 #include "z_en_po_composer.h"
 
 #define FLAGS 0x02100019

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.c
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_pp.c
+ * Overlay: ovl_En_Pp
+ * Description: Hiploop
+ */
+
 #include "z_en_pp.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Pr/z_en_pr.c
+++ b/src/overlays/actors/ovl_En_Pr/z_en_pr.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_pr.c
+ * Overlay: ovl_En_Pr
+ * Description: Desbreko
+ */
+
 #include "z_en_pr.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Pr2/z_en_pr2.c
+++ b/src/overlays/actors/ovl_En_Pr2/z_en_pr2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_pr2.c
+ * Overlay: ovl_En_Pr2
+ * Description: Skullfish
+ */
+
 #include "z_en_pr2.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Prz/z_en_prz.c
+++ b/src/overlays/actors/ovl_En_Prz/z_en_prz.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_prz.c
+ * Overlay: ovl_En_Prz
+ * Description: Skullfish - Defeated
+ */
+
 #include "z_en_prz.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Pst/z_en_pst.c
+++ b/src/overlays/actors/ovl_En_Pst/z_en_pst.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_pst.c
+ * Overlay: ovl_En_Pst
+ * Description: Postbox
+ */
+
 #include "z_en_pst.h"
 
 #define FLAGS 0x00000001

--- a/src/overlays/actors/ovl_En_Racedog/z_en_racedog.c
+++ b/src/overlays/actors/ovl_En_Racedog/z_en_racedog.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_racedog.c
+ * Overlay: ovl_En_Racedog
+ * Description: Racetrack Dog
+ */
+
 #include "z_en_racedog.h"
 
 #define FLAGS 0x80000010

--- a/src/overlays/actors/ovl_En_Raf/z_en_raf.c
+++ b/src/overlays/actors/ovl_En_Raf/z_en_raf.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_raf.c
+ * Overlay: ovl_En_Raf
+ * Description: Carnivorous Lilypad
+ */
+
 #include "z_en_raf.h"
 
 #define FLAGS 0x08000000

--- a/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
+++ b/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rail_skb.c
+ * Overlay: ovl_En_Rail_Skb
+ * Description: Ikana Graveyard - Circle of Stalchildren
+ */
+
 #include "z_en_rail_skb.h"
 
 #define FLAGS 0x00000015

--- a/src/overlays/actors/ovl_En_Rat/z_en_rat.c
+++ b/src/overlays/actors/ovl_En_Rat/z_en_rat.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rat.c
+ * Overlay: ovl_En_Rat
+ * Description: Real Bombchu
+ */
+
 #include "z_en_rat.h"
 
 #define FLAGS 0x00000205

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_rd.c
  * Overlay: ovl_En_Rd
- * Description: Redead / Gibdo
+ * Description: Dancing Redead/Gibdo
  */
 
 #include "z_en_rd.h"

--- a/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.c
+++ b/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_recepgirl.c
+ * Overlay: ovl_En_Recepgirl
+ * Description: Mayor's receptionist
+ */
+
 #include "z_en_recepgirl.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Rg/z_en_rg.c
+++ b/src/overlays/actors/ovl_En_Rg/z_en_rg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rg.c
+ * Overlay: ovl_En_Rg
+ * Description: Racetrack Goron
+ */
+
 #include "z_en_rg.h"
 
 #define FLAGS 0x80000010

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_river_sound.c
+ * Overlay: ovl_En_River_Sound
+ * Description:
+ */
+
 #include "z_en_river_sound.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rr.c
+ * Overlay: ovl_En_Rr
+ * Description: Like Like
+ */
+
 #include "z_en_rr.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
+++ b/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rsn.c
+ * Overlay: ovl_En_Rsn
+ * Description: Bomb Shop Man in the credits?
+ */
+
 #include "z_en_rsn.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Ru/z_en_ru.c
+++ b/src/overlays/actors/ovl_En_Ru/z_en_ru.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ru.c
+ * Overlay: ovl_En_Ru
+ * Description: Ruto
+ */
+
 #include "z_en_ru.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.c
+++ b/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ruppecrow.c
+ * Overlay: ovl_En_Ruppecrow
+ * Description: Guay Circling Clock Town
+ */
+
 #include "z_en_ruppecrow.h"
 
 #define FLAGS 0x00004030

--- a/src/overlays/actors/ovl_En_Rz/z_en_rz.c
+++ b/src/overlays/actors/ovl_En_Rz/z_en_rz.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_rz.c
+ * Overlay: ovl_En_Rz
+ * Description: Rosa Sister
+ */
+
 #include "z_en_rz.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_s_goro.c
+ * Overlay: ovl_En_S_Goro
+ * Description: Goron Complaining About Crying / Bomb Shop Goron
+ */
+
 #include "z_en_s_goro.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Sc_Ruppe/z_en_sc_ruppe.c
+++ b/src/overlays/actors/ovl_En_Sc_Ruppe/z_en_sc_ruppe.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_sc_ruppe.c
+ * Overlay: ovl_En_Sc_Ruppe
+ * Description: Giant Rupee
+ */
+
 #include "z_en_sc_ruppe.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Scopecoin/z_en_scopecoin.c
+++ b/src/overlays/actors/ovl_En_Scopecoin/z_en_scopecoin.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_scopecoin.c
+ * Overlay: ovl_En_Scopecoin
+ * Description: Telescope Coin
+ */
+
 #include "z_en_scopecoin.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Scopecrow/z_en_scopecrow.c
+++ b/src/overlays/actors/ovl_En_Scopecrow/z_en_scopecrow.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_scopecrow.c
+ * Overlay: ovl_En_Scopecrow
+ * Description: Astral Observatory - Guay in Telescope
+ */
+
 #include "z_en_scopecrow.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
+++ b/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_scopenuts.c
+ * Overlay: ovl_En_Scopenuts
+ * Description: Astral Observatory - Business Scrub in Telescope
+ */
+
 #include "z_en_scopenuts.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_sda.c
+ * Overlay: ovl_En_Sda
+ * Description:
+ */
+
 #include "z_en_sda.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.c
+++ b/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_sekihi.c
+ * Overlay: ovl_En_Sekihi
+ * Description: Mikau's Grave & Song Pedestals
+ */
+
 #include "z_en_sekihi.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Shn/z_en_shn.c
+++ b/src/overlays/actors/ovl_En_Shn/z_en_shn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_shn.c
+ * Overlay: ovl_En_Shn
+ * Description: Swamp Tourist Center Guide
+ */
+
 #include "z_en_shn.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Si/z_en_si.c
+++ b/src/overlays/actors/ovl_En_Si/z_en_si.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_si.c
+ * Overlay: ovl_En_Si
+ * Description: Golden Skulltula Token
+ */
+
 #include "z_en_si.h"
 
 #define FLAGS 0x00000201

--- a/src/overlays/actors/ovl_En_Slime/z_en_slime.c
+++ b/src/overlays/actors/ovl_En_Slime/z_en_slime.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_slime.c
+ * Overlay: ovl_En_Slime
+ * Description: Chuchu
+ */
+
 #include "z_en_slime.h"
 
 #define FLAGS 0x00000215

--- a/src/overlays/actors/ovl_En_Snowman/z_en_snowman.c
+++ b/src/overlays/actors/ovl_En_Snowman/z_en_snowman.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_snowman.c
+ * Overlay: ovl_En_Snowman
+ * Description: Enos
+ */
+
 #include "z_en_snowman.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Snowwd/z_en_snowwd.c
+++ b/src/overlays/actors/ovl_En_Snowwd/z_en_snowwd.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_snowwd.c
+ * Overlay: ovl_En_Snowwd
+ * Description: Snow-Covered Tree
+ */
+
 #include "z_en_snowwd.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_ssh.c
+ * Overlay: ovl_En_Ssh
+ * Description: Cursed Man
+ */
+
 #include "z_en_ssh.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_st.c
+ * Overlay: ovl_En_St
+ * Description: Skulltula
+ */
+
 #include "z_en_st.h"
 
 #define FLAGS 0x01004035

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_sth.c
+ * Overlay: ovl_En_Sth
+ * Description: Guy looking at moon in South Clock Town
+ */
+
 #include "z_en_sth.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Sth2/z_en_sth2.c
+++ b/src/overlays/actors/ovl_En_Sth2/z_en_sth2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_sth2.c
+ * Overlay: ovl_En_Sth2
+ * Description:
+ */
+
 #include "z_en_sth2.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.c
+++ b/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_stone_heishi.c
+ * Overlay: ovl_En_Stone_heishi
+ * Description: Shiro
+ */
+
 #include "z_en_stone_heishi.h"
 
 #define FLAGS 0x00000089

--- a/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
+++ b/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_stop_heishi.c
+ * Overlay: ovl_En_Stop_heishi
+ * Description: Clock Town - Gate-Blocking Soldier
+ */
+
 #include "z_en_stop_heishi.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.c
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_stream.c
+ * Overlay: ovl_En_Stream
+ * Description:
+ */
+
 #include "z_en_stream.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Syateki_Crow/z_en_syateki_crow.c
+++ b/src/overlays/actors/ovl_En_Syateki_Crow/z_en_syateki_crow.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_syateki_crow.c
+ * Overlay: ovl_En_Syateki_Crow
+ * Description: Shooting Gallery Guay
+ */
+
 #include "z_en_syateki_crow.h"
 
 #define FLAGS 0x08000030

--- a/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.c
+++ b/src/overlays/actors/ovl_En_Syateki_Dekunuts/z_en_syateki_dekunuts.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_syateki_dekunuts.c
+ * Overlay: ovl_En_Syateki_Dekunuts
+ * Description: Shooting Gallery Deku Scrub
+ */
+
 #include "z_en_syateki_dekunuts.h"
 
 #define FLAGS 0x08000030

--- a/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
+++ b/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_syateki_okuta.c
+ * Overlay: ovl_En_Syateki_Okuta
+ * Description: Shooting Gallery Octorok
+ */
+
 #include "z_en_syateki_okuta.h"
 
 #define FLAGS 0x08000030

--- a/src/overlays/actors/ovl_En_Syateki_Wf/z_en_syateki_wf.c
+++ b/src/overlays/actors/ovl_En_Syateki_Wf/z_en_syateki_wf.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_syateki_wf.c
+ * Overlay: ovl_En_Syateki_Wf
+ * Description: Shooting Gallery Wolfos
+ */
+
 #include "z_en_syateki_wf.h"
 
 #define FLAGS 0x08000030

--- a/src/overlays/actors/ovl_En_Tab/z_en_tab.c
+++ b/src/overlays/actors/ovl_En_Tab/z_en_tab.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tab.c
+ * Overlay: ovl_En_Tab
+ * Description: Talon B - Mr. Barten
+ */
+
 #include "z_en_tab.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Tag_Obj/z_en_tag_obj.c
+++ b/src/overlays/actors/ovl_En_Tag_Obj/z_en_tag_obj.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tag_obj.c
+ * Overlay: ovl_En_Tag_Obj
+ * Description:
+ */
+
 #include "z_en_tag_obj.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.c
+++ b/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_takaraya.c
+ * Overlay: ovl_En_Takaraya
+ * Description: Treasure Chest Shop Gal
+ */
+
 #include "z_en_takaraya.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_talk.c
+ * Overlay: ovl_En_Talk
+ * Description: Green Target Spot (e.g., Indigo-Go's Poster)
+ */
+
 #include "z_en_talk.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
+++ b/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_talk_gibud.c
+ * Overlay: ovl_En_Talk_Gibud
+ * Description: Gibdos requesting items Beneath the Well
+ */
+
 #include "z_en_talk_gibud.h"
 
 #define FLAGS 0x00000415

--- a/src/overlays/actors/ovl_En_Tanron1/z_en_tanron1.c
+++ b/src/overlays/actors/ovl_En_Tanron1/z_en_tanron1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron1.c
+ * Overlay: ovl_En_Tanron1
+ * Description: Swarm of Moths in Woodfall Temple
+ */
+
 #include "z_en_tanron1.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Tanron2/z_en_tanron2.c
+++ b/src/overlays/actors/ovl_En_Tanron2/z_en_tanron2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron2.c
+ * Overlay: ovl_En_Tanron2
+ * Description: Wart's Bubbles
+ */
+
 #include "z_en_tanron2.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Tanron3/z_en_tanron3.c
+++ b/src/overlays/actors/ovl_En_Tanron3/z_en_tanron3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron3.c
+ * Overlay: ovl_En_Tanron3
+ * Description: Small Fish summoned by Gyorg
+ */
+
 #include "z_en_tanron3.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Tanron4/z_en_tanron4.c
+++ b/src/overlays/actors/ovl_En_Tanron4/z_en_tanron4.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron4.c
+ * Overlay: ovl_En_Tanron4
+ * Description: Flock of Seagulls
+ */
+
 #include "z_en_tanron4.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.c
+++ b/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron5.c
+ * Overlay: ovl_En_Tanron5
+ * Description: Destructible props in Twinmold's arena
+ */
+
 #include "z_en_tanron5.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Tanron6/z_en_tanron6.c
+++ b/src/overlays/actors/ovl_En_Tanron6/z_en_tanron6.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tanron6.c
+ * Overlay: ovl_En_Tanron6
+ * Description: Swarm of Giant Bees
+ */
+
 #include "z_en_tanron6.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test.c
+ * Overlay: ovl_En_Test
+ * Description:
+ */
+
 #include "z_en_test.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Test2/z_en_test2.c
+++ b/src/overlays/actors/ovl_En_Test2/z_en_test2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test2.c
+ * Overlay: ovl_En_Test2
+ * Description: Objects affected by the Lens of Truth
+ */
+
 #include "z_en_test2.h"
 
 #define FLAGS 0x00000090

--- a/src/overlays/actors/ovl_En_Test3/z_en_test3.c
+++ b/src/overlays/actors/ovl_En_Test3/z_en_test3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test3.c
+ * Overlay: ovl_En_Test3
+ * Description: Kafei
+ */
+
 #include "z_en_test3.h"
 
 #define FLAGS 0x04000030

--- a/src/overlays/actors/ovl_En_Test5/z_en_test5.c
+++ b/src/overlays/actors/ovl_En_Test5/z_en_test5.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test5.c
+ * Overlay: ovl_En_Test5
+ * Description: Spring Water
+ */
+
 #include "z_en_test5.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Test6/z_en_test6.c
+++ b/src/overlays/actors/ovl_En_Test6/z_en_test6.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test6.c
+ * Overlay: ovl_En_Test6
+ * Description:
+ */
+
 #include "z_en_test6.h"
 
 #define FLAGS 0x02200030

--- a/src/overlays/actors/ovl_En_Test7/z_en_test7.c
+++ b/src/overlays/actors/ovl_En_Test7/z_en_test7.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_test7.c
+ * Overlay: ovl_En_Test7
+ * Description:
+ */
+
 #include "z_en_test7.h"
 
 #define FLAGS 0x02300030

--- a/src/overlays/actors/ovl_En_Tg/z_en_tg.c
+++ b/src/overlays/actors/ovl_En_Tg/z_en_tg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tg.c
+ * Overlay: ovl_En_Tg
+ * Description: Target Game (Honey & Darling)
+ */
+
 #include "z_en_tg.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
+++ b/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_time_tag.c
+ * Overlay: ovl_En_Time_Tag
+ * Description:
+ */
+
 #include "z_en_time_tag.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tk.c
+ * Overlay: ovl_En_Tk
+ * Description: Dampé
+ */
+
 #include "z_en_tk.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Torch/z_en_torch.c
+++ b/src/overlays/actors/ovl_En_Torch/z_en_torch.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_torch.c
+ * Overlay: ovl_En_Torch
+ * Description: Treasure chest (grotto)
+ */
+
 #include "z_en_torch.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
+++ b/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_trt2.c
+ * Overlay: ovl_En_Trt2
+ * Description:
+ */
+
 #include "z_en_trt2.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Tru/z_en_tru.c
+++ b/src/overlays/actors/ovl_En_Tru/z_en_tru.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tru.c
+ * Overlay: ovl_En_Tru
+ * Description: Koume in Woods of Mystery
+ */
+
 #include "z_en_tru.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Tru_Mt/z_en_tru_mt.c
+++ b/src/overlays/actors/ovl_En_Tru_Mt/z_en_tru_mt.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tru_mt.c
+ * Overlay: ovl_En_Tru_Mt
+ * Description: Koume's Target Game - Koume on Broom
+ */
+
 #include "z_en_tru_mt.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
+++ b/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tsn.c
+ * Overlay: ovl_En_Tsn
+ * Description: Great Bay - Fisherman
+ */
+
 #include "z_en_tsn.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
+++ b/src/overlays/actors/ovl_En_Tubo_Trap/z_en_tubo_trap.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_tubo_trap.c
+ * Overlay: ovl_En_Tubo_Trap
+ * Description: Flying Pot Trap Enemy
+ */
+
 #include "z_en_tubo_trap.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Twig/z_en_twig.c
+++ b/src/overlays/actors/ovl_En_Twig/z_en_twig.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_twig.c
+ * Overlay: ovl_En_Twig
+ * Description: Beaver Race Ring
+ */
+
 #include "z_en_twig.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_viewer.c
+ * Overlay: ovl_En_Viewer
+ * Description: Cutscene Actors?
+ */
+
 #include "z_en_viewer.h"
 
 #define FLAGS 0x00200030

--- a/src/overlays/actors/ovl_En_Vm/z_en_vm.c
+++ b/src/overlays/actors/ovl_En_Vm/z_en_vm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_vm.c
+ * Overlay: ovl_En_Vm
+ * Description: Beamos
+ */
+
 #include "z_en_vm.h"
 
 #define FLAGS 0x00000405

--- a/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
+++ b/src/overlays/actors/ovl_En_Wallmas/z_en_wallmas.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wallmas.c
+ * Overlay: ovl_En_Wallmas
+ * Description: Wallmaster
+ */
+
 #include "z_en_wallmas.h"
 
 #define FLAGS 0x00000415

--- a/src/overlays/actors/ovl_En_Warp_tag/z_en_warp_tag.c
+++ b/src/overlays/actors/ovl_En_Warp_tag/z_en_warp_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_warp_tag.c
+ * Overlay: ovl_En_Warp_tag
+ * Description: Warp to Trial Entrance
+ */
+
 #include "z_en_warp_tag.h"
 
 #define FLAGS 0x0A000011

--- a/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
+++ b/src/overlays/actors/ovl_En_Water_Effect/z_en_water_effect.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_water_effect.c
+ * Overlay: ovl_En_Water_Effect
+ * Description: Water splashing effect (used for Gyorg)
+ */
+
 #include "z_en_water_effect.h"
 
 #define FLAGS 0x00000035

--- a/src/overlays/actors/ovl_En_Wdhand/z_en_wdhand.c
+++ b/src/overlays/actors/ovl_En_Wdhand/z_en_wdhand.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wdhand.c
+ * Overlay: ovl_En_Wdhand
+ * Description: Dexihand
+ */
+
 #include "z_en_wdhand.h"
 
 #define FLAGS 0x00000005

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_weather_tag.c
+ * Overlay: ovl_En_Weather_Tag
+ * Description: Local weather changes
+ */
+
 #include "z_en_weather_tag.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Wiz/z_en_wiz.c
+++ b/src/overlays/actors/ovl_En_Wiz/z_en_wiz.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wiz.c
+ * Overlay: ovl_En_Wiz
+ * Description: Wizzrobe
+ */
+
 #include "z_en_wiz.h"
 
 #define FLAGS 0x88101035

--- a/src/overlays/actors/ovl_En_Wiz_Brock/z_en_wiz_brock.c
+++ b/src/overlays/actors/ovl_En_Wiz_Brock/z_en_wiz_brock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wiz_brock.c
+ * Overlay: ovl_En_Wiz_Brock
+ * Description: Wizzrobe Warp Platform
+ */
+
 #include "z_en_wiz_brock.h"
 
 #define FLAGS 0x08000010

--- a/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.c
+++ b/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wiz_fire.c
+ * Overlay: ovl_En_Wiz_Fire
+ * Description: Wizzrobe Fire/Ice Attack
+ */
+
 #include "z_en_wiz_fire.h"
 
 #define FLAGS 0x08000015

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_wood02.c
+ * Overlay: ovl_En_Wood02
+ * Description: Trees, shrubs
+ */
+
 #include "z_en_wood02.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_En_Yb/z_en_yb.c
+++ b/src/overlays/actors/ovl_En_Yb/z_en_yb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_yb.c
+ * Overlay: ovl_En_Yb
+ * Description: Kamaro the Dancing Ghost
+ */
+
 #include "z_en_yb.h"
 
 #define FLAGS 0x02000019

--- a/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
+++ b/src/overlays/actors/ovl_En_Zl1/z_en_zl1.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zl1.c
+ * Overlay: ovl_En_Zl1
+ * Description: [Empty]
+ */
+
 #include "z_en_zl1.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zl4.c
+ * Overlay: ovl_En_Zl4
+ * Description:
+ */
+
 #include "z_en_zl4.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_En_Zo/z_en_zo.c
+++ b/src/overlays/actors/ovl_En_Zo/z_en_zo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zo.c
+ * Overlay: ovl_En_Zo
+ * Description: Zoras
+ */
+
 #include "z_en_zo.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_En_Zob/z_en_zob.c
+++ b/src/overlays/actors/ovl_En_Zob/z_en_zob.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zob.c
+ * Overlay: ovl_En_Zob
+ * Description: Zora Bassist Japas
+ */
+
 #include "z_en_zob.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Zod/z_en_zod.c
+++ b/src/overlays/actors/ovl_En_Zod/z_en_zod.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zod.c
+ * Overlay: ovl_En_Zod
+ * Description: Zora Drummer Tijo
+ */
+
 #include "z_en_zod.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Zog/z_en_zog.c
+++ b/src/overlays/actors/ovl_En_Zog/z_en_zog.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zog.c
+ * Overlay: ovl_En_Zog
+ * Description: Mikau
+ */
+
 #include "z_en_zog.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.c
+++ b/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zoraegg.c
+ * Overlay: ovl_En_Zoraegg
+ * Description: Zora Egg
+ */
+
 #include "z_en_zoraegg.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.c
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zos.c
+ * Overlay: ovl_En_Zos
+ * Description: Zora Synthesizer - Evan
+ */
+
 #include "z_en_zos.h"
 
 #define FLAGS 0x02000009

--- a/src/overlays/actors/ovl_En_Zot/z_en_zot.c
+++ b/src/overlays/actors/ovl_En_Zot/z_en_zot.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_zot.c
  * Overlay: ovl_En_Zot
- * Description: Great Bay - Zora With Directions to Zora Hall
+ * Description: Great Bay - Zora With Directions to Zora Hall / Pot Game Zora
  */
 
 #include "z_en_zot.h"

--- a/src/overlays/actors/ovl_En_Zov/z_en_zov.c
+++ b/src/overlays/actors/ovl_En_Zov/z_en_zov.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zov.c
+ * Overlay: ovl_En_Zov
+ * Description: Zora Vocalist - Lulu
+ */
+
 #include "z_en_zov.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_En_Zow/z_en_zow.c
+++ b/src/overlays/actors/ovl_En_Zow/z_en_zow.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_en_zow.c
+ * Overlay: ovl_En_Zow
+ * Description: Great Bay - Zora Complaining About Water
+ */
+
 #include "z_en_zow.h"
 
 #define FLAGS 0x00000019

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_item_etcetera.c
+ * Overlay: ovl_Item_Etcetera
+ * Description:
+ */
+
 #include "z_item_etcetera.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
+++ b/src/overlays/actors/ovl_Item_Inbox/z_item_inbox.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_item_inbox.c
+ * Overlay: ovl_Item_Inbox
+ * Description:
+ */
+
 #include "z_item_inbox.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_mir_ray.c
+ * Overlay: ovl_Mir_Ray
+ * Description: Mirror Shield Face & Light Ray
+ */
+
 #include "z_mir_ray.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Mir_Ray2/z_mir_ray2.c
+++ b/src/overlays/actors/ovl_Mir_Ray2/z_mir_ray2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_mir_ray2.c
+ * Overlay: ovl_Mir_Ray2
+ * Description:
+ */
+
 #include "z_mir_ray2.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Mir_Ray3/z_mir_ray3.c
+++ b/src/overlays/actors/ovl_Mir_Ray3/z_mir_ray3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_mir_ray3.c
+ * Overlay: ovl_Mir_Ray3
+ * Description:
+ */
+
 #include "z_mir_ray3.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Armos/z_obj_armos.c
+++ b/src/overlays/actors/ovl_Obj_Armos/z_obj_armos.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_armos.c
+ * Overlay: ovl_Obj_Armos
+ * Description: Non-hostile Armos statues
+ */
+
 #include "z_obj_armos.h"
 
 #define FLAGS 0x04000010

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_bean.c
+ * Overlay: ovl_Obj_Bean
+ * Description: Floating Bean Plant / Dirt Patch
+ */
+
 #include "z_obj_bean.h"
 
 #define FLAGS 0x00400000

--- a/src/overlays/actors/ovl_Obj_Bigicicle/z_obj_bigicicle.c
+++ b/src/overlays/actors/ovl_Obj_Bigicicle/z_obj_bigicicle.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_bigicicle.c
+ * Overlay: ovl_Obj_Bigicicle
+ * Description: Large icicles
+ */
+
 #include "z_obj_bigicicle.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_blockstop.c
+ * Overlay: ovl_Obj_Blockstop
+ * Description:
+ */
+
 #include "z_obj_blockstop.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Boat/z_obj_boat.c
+++ b/src/overlays/actors/ovl_Obj_Boat/z_obj_boat.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_boat.c
+ * Overlay: ovl_Obj_Boat
+ * Description: Pirate Boat
+ */
+
 #include "z_obj_boat.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Bombiwa/z_obj_bombiwa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_bombiwa.c
+ * Overlay: ovl_Obj_Bombiwa
+ * Description: Bombable boulder
+ */
+
 #include "z_obj_bombiwa.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.c
+++ b/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_chan.c
+ * Overlay: ovl_Obj_Chan
+ * Description: Goron Shrine chandelier
+ */
+
 #include "z_obj_chan.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
+++ b/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_chikuwa.c
+ * Overlay: ovl_Obj_Chikuwa
+ * Description: Falling Block Row
+ */
+
 #include "z_obj_chikuwa.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_comb.c
+ * Overlay: ovl_Obj_Comb
+ * Description: Honeycomb
+ */
+
 #include "z_obj_comb.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.c
+++ b/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_danpeilift.c
+ * Overlay: ovl_Obj_Danpeilift
+ * Description: Deku Shrine & Snowhead Temple Elevator
+ */
+
 #include "z_obj_danpeilift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Demo/z_obj_demo.c
+++ b/src/overlays/actors/ovl_Obj_Demo/z_obj_demo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_demo.c
+ * Overlay: ovl_Obj_Demo
+ * Description:
+ */
+
 #include "z_obj_demo.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.c
+++ b/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_dhouse.c
+ * Overlay: ovl_Obj_Dhouse
+ * Description: Dinner plate Prop
+ */
+
 #include "z_obj_dhouse.h"
 
 #define FLAGS 0x00400010

--- a/src/overlays/actors/ovl_Obj_Dinner/z_obj_dinner.c
+++ b/src/overlays/actors/ovl_Obj_Dinner/z_obj_dinner.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_dinner.c
+ * Overlay: ovl_Obj_Dinner
+ * Description: Cremia and Romani's dinner
+ */
+
 #include "z_obj_dinner.h"
 
 #define FLAGS 0x00000020

--- a/src/overlays/actors/ovl_Obj_Dora/z_obj_dora.c
+++ b/src/overlays/actors/ovl_Obj_Dora/z_obj_dora.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_dora.c
+ * Overlay: ovl_Obj_Dora
+ * Description: Swordsman's School - Gong
+ */
+
 #include "z_obj_dora.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Dowsing/z_obj_dowsing.c
+++ b/src/overlays/actors/ovl_Obj_Dowsing/z_obj_dowsing.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_dowsing.c
+ * Overlay: ovl_Obj_Dowsing
+ * Description:
+ */
+
 #include "z_obj_dowsing.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.c
+++ b/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_driftice.c
+ * Overlay: ovl_Obj_Driftice
+ * Description: Floating Ice Platforms in Mountain Village
+ */
+
 #include "z_obj_driftice.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
+++ b/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_entotu.c
+ * Overlay: ovl_Obj_Entotu
+ * Description: Clock tower chimney Expelling Smoke
+ */
+
 #include "z_obj_entotu.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.c
+++ b/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_fireshield.c
+ * Overlay: ovl_Obj_Fireshield
+ * Description: Ring of fire
+ */
+
 #include "z_obj_fireshield.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
+++ b/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_flowerpot.c
+ * Overlay: ovl_Obj_Flowerpot
+ * Description: Breakable Pot With Grass
+ */
+
 #include "z_obj_flowerpot.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
+++ b/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_funen.c
+ * Overlay: ovl_Obj_Funen
+ * Description:
+ */
+
 #include "z_obj_funen.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
+++ b/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_grass.c
+ * Overlay: ovl_Obj_Grass
+ * Description:
+ */
+
 #include "z_obj_grass.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
+++ b/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_grass_carry.c
+ * Overlay: ovl_Obj_Grass_Carry
+ * Description:
+ */
+
 #include "z_obj_grass_carry.h"
 
 #define FLAGS 0x00800030

--- a/src/overlays/actors/ovl_Obj_Grass_Unit/z_obj_grass_unit.c
+++ b/src/overlays/actors/ovl_Obj_Grass_Unit/z_obj_grass_unit.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_grass_unit.c
+ * Overlay: ovl_Obj_Grass_Unit
+ * Description:
+ */
+
 #include "z_obj_grass_unit.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.c
+++ b/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hakaisi.c
+ * Overlay: ovl_Obj_Hakaisi
+ * Description: Gravestone
+ */
+
 #include "z_obj_hakaisi.h"
 
 #define FLAGS 0x00000029

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hamishi.c
+ * Overlay: ovl_Obj_Hamishi
+ * Description: Hammer Stone
+ */
+
 #include "z_obj_hamishi.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Hariko/z_obj_hariko.c
+++ b/src/overlays/actors/ovl_Obj_Hariko/z_obj_hariko.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hariko.c
+ * Overlay: ovl_Obj_Hariko
+ * Description: Little Cow Statue Head
+ */
+
 #include "z_obj_hariko.h"
 
 #define FLAGS 0x02000020

--- a/src/overlays/actors/ovl_Obj_Hgdoor/z_obj_hgdoor.c
+++ b/src/overlays/actors/ovl_Obj_Hgdoor/z_obj_hgdoor.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hgdoor.c
+ * Overlay: ovl_Obj_Hgdoor
+ * Description: Music Box House - Closet Door
+ */
+
 #include "z_obj_hgdoor.h"
 
 #define FLAGS 0x00100000

--- a/src/overlays/actors/ovl_Obj_HsStump/z_obj_hsstump.c
+++ b/src/overlays/actors/ovl_Obj_HsStump/z_obj_hsstump.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hsstump.c
+ * Overlay: ovl_Obj_HsStump
+ * Description: Ikana Canyon - Hookshotable Tree
+ */
+
 #include "z_obj_hsstump.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
+++ b/src/overlays/actors/ovl_Obj_Hsblock/z_obj_hsblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hsblock.c
+ * Overlay: ovl_Obj_Hsblock
+ * Description: Hookshot Block
+ */
+
 #include "z_obj_hsblock.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hugebombiwa.c
+ * Overlay: ovl_Obj_Hugebombiwa
+ * Description: Boulder Blocking Goron Racetrack
+ */
+
 #include "z_obj_hugebombiwa.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Hunsui/z_obj_hunsui.c
+++ b/src/overlays/actors/ovl_Obj_Hunsui/z_obj_hunsui.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_hunsui.c
+ * Overlay: ovl_Obj_Hunsui
+ * Description: Switch-Activated Geyser
+ */
+
 #include "z_obj_hunsui.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
+++ b/src/overlays/actors/ovl_Obj_Ice_Poly/z_obj_ice_poly.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_ice_poly.c
+ * Overlay: ovl_Obj_Ice_Poly
+ * Description: Large Block of Meltable Ice
+ */
+
 #include "z_obj_ice_poly.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.c
+++ b/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_iceblock.c
+ * Overlay: ovl_Obj_Iceblock
+ * Description: Ice Block That Appears After Freezing Enemy
+ */
+
 #include "z_obj_iceblock.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Jg_Gakki/z_obj_jg_gakki.c
+++ b/src/overlays/actors/ovl_Obj_Jg_Gakki/z_obj_jg_gakki.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_jg_gakki.c
+ * Overlay: ovl_Obj_Jg_Gakki
+ * Description: Goron Elder's Drum
+ */
+
 #include "z_obj_jg_gakki.h"
 
 #define FLAGS 0x00000020

--- a/src/overlays/actors/ovl_Obj_Jgame_Light/z_obj_jgame_light.c
+++ b/src/overlays/actors/ovl_Obj_Jgame_Light/z_obj_jgame_light.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_jgame_light.c
+ * Overlay: ovl_Obj_Jgame_Light
+ * Description: Fisherman's Jumping Game - Torch
+ */
+
 #include "z_obj_jgame_light.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Kendo_Kanban/z_obj_kendo_kanban.c
+++ b/src/overlays/actors/ovl_Obj_Kendo_Kanban/z_obj_kendo_kanban.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_kendo_kanban.c
+ * Overlay: ovl_Obj_Kendo_Kanban
+ * Description: Swordsman's School - Cuttable Board
+ */
+
 #include "z_obj_kendo_kanban.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Kepn_Koya/z_obj_kepn_koya.c
+++ b/src/overlays/actors/ovl_Obj_Kepn_Koya/z_obj_kepn_koya.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_kepn_koya.c
+ * Overlay: ovl_Obj_Kepn_Koya
+ * Description: Gorman Bros. Buildings
+ */
+
 #include "z_obj_kepn_koya.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Kinoko/z_obj_kinoko.c
+++ b/src/overlays/actors/ovl_Obj_Kinoko/z_obj_kinoko.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_kinoko.c
+ * Overlay: ovl_Obj_Kinoko
+ * Description: Mushroom
+ */
+
 #include "z_obj_kinoko.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Kzsaku/z_obj_kzsaku.c
+++ b/src/overlays/actors/ovl_Obj_Kzsaku/z_obj_kzsaku.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_kzsaku.c
+ * Overlay: ovl_Obj_Kzsaku
+ * Description: Underwater grate
+ */
+
 #include "z_obj_kzsaku.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
+++ b/src/overlays/actors/ovl_Obj_Lift/z_obj_lift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_lift.c
+ * Overlay: ovl_Obj_Lift
+ * Description: Dampé's Grave - Brown Elevator
+ */
+
 #include "z_obj_lift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
+++ b/src/overlays/actors/ovl_Obj_Lightswitch/z_obj_lightswitch.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_lightswitch.c
+ * Overlay: ovl_Obj_Lightswitch
+ * Description: Sun Switch / STT Flip switch
+ */
+
 #include "z_obj_lightswitch.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Lupygamelift/z_obj_lupygamelift.c
+++ b/src/overlays/actors/ovl_Obj_Lupygamelift/z_obj_lupygamelift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_lupygamelift.c
+ * Overlay: ovl_Obj_Lupygamelift
+ * Description: Deku Scrub Playground - Rupee Elevator
+ */
+
 #include "z_obj_lupygamelift.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_makekinsuta.c
+ * Overlay: ovl_Obj_Makekinsuta
+ * Description: Dirt Patch with Skulltula hiding in it
+ */
+
 #include "z_obj_makekinsuta.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Mine/z_obj_mine.c
+++ b/src/overlays/actors/ovl_Obj_Mine/z_obj_mine.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_mine.c
+ * Overlay: ovl_Obj_Mine
+ * Description: Spike metal Mine
+ */
+
 #include "z_obj_mine.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
+++ b/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_mu_pict.c
+ * Overlay: ovl_Obj_Mu_Pict
+ * Description:
+ */
+
 #include "z_obj_mu_pict.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_mure.c
+ * Overlay: ovl_Obj_Mure
+ * Description: Bugs, Insects, Butterfly spawner and behavior
+ */
+
 #include "z_obj_mure.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
+++ b/src/overlays/actors/ovl_Obj_Mure2/z_obj_mure2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_mure2.c
+ * Overlay: ovl_Obj_Mure2
+ * Description: Circle of rocks spawner
+ */
+
 #include "z_obj_mure2.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
+++ b/src/overlays/actors/ovl_Obj_Mure3/z_obj_mure3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_mure3.c
+ * Overlay: ovl_Obj_Mure3
+ * Description: Group Rupee spawner
+ */
+
 #include "z_obj_mure3.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.c
+++ b/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_nozoki.c
+ * Overlay: ovl_Obj_Nozoki
+ * Description: Sakon's Hideout Objects (Sun's Mask, doors, etc)
+ */
+
 #include "z_obj_nozoki.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.c
+++ b/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_ocarinalift.c
+ * Overlay: ovl_Obj_Ocarinalift
+ * Description: Elevator With Triforce Texture
+ */
+
 #include "z_obj_ocarinalift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
+++ b/src/overlays/actors/ovl_Obj_Oshihiki/z_obj_oshihiki.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_oshihiki.c
+ * Overlay: ovl_Obj_Oshihiki
+ * Description: Pushable Block
+ */
+
 #include "z_obj_oshihiki.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Purify/z_obj_purify.c
+++ b/src/overlays/actors/ovl_Obj_Purify/z_obj_purify.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_purify.c
+ * Overlay: ovl_Obj_Purify
+ * Description: Poisoned/Purified Water Elements
+ */
+
 #include "z_obj_purify.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Pzlblock/z_obj_pzlblock.c
+++ b/src/overlays/actors/ovl_Obj_Pzlblock/z_obj_pzlblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_pzlblock.c
+ * Overlay: ovl_Obj_Pzlblock
+ * Description: Puzzle Block
+ */
+
 #include "z_obj_pzlblock.h"
 
 #define FLAGS 0x04000010

--- a/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
+++ b/src/overlays/actors/ovl_Obj_Roomtimer/z_obj_roomtimer.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_roomtimer.c
+ * Overlay: ovl_Obj_Roomtimer
+ * Description:
+ */
+
 #include "z_obj_roomtimer.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Rotlift/z_obj_rotlift.c
+++ b/src/overlays/actors/ovl_Obj_Rotlift/z_obj_rotlift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_rotlift.c
+ * Overlay: ovl_Obj_Rotlift
+ * Description: Deku Moon Dungeon - Spiked Rotating Platforms
+ */
+
 #include "z_obj_rotlift.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Shutter/z_obj_shutter.c
+++ b/src/overlays/actors/ovl_Obj_Shutter/z_obj_shutter.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_shutter.c
+ * Overlay: ovl_Obj_Shutter
+ * Description:
+ */
+
 #include "z_obj_shutter.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.c
+++ b/src/overlays/actors/ovl_Obj_Skateblock/z_obj_skateblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_skateblock.c
+ * Overlay: ovl_Obj_Skateblock
+ * Description: Pushable block that slides on ice
+ */
+
 #include "z_obj_skateblock.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
+++ b/src/overlays/actors/ovl_Obj_Smork/z_obj_smork.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_smork.c
+ * Overlay: ovl_Obj_Smork
+ * Description: Romani Ranch Chimney Smoke
+ */
+
 #include "z_obj_smork.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.c
+++ b/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_snowball.c
+ * Overlay: ovl_Obj_Snowball
+ * Description: Large Snowball
+ */
+
 #include "z_obj_snowball.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Snowball2/z_obj_snowball2.c
+++ b/src/overlays/actors/ovl_Obj_Snowball2/z_obj_snowball2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_snowball2.c
+ * Overlay: ovl_Obj_Snowball2
+ * Description: Small Snowball
+ */
+
 #include "z_obj_snowball2.h"
 
 #define FLAGS 0x00800000

--- a/src/overlays/actors/ovl_Obj_Sound/z_obj_sound.c
+++ b/src/overlays/actors/ovl_Obj_Sound/z_obj_sound.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_sound.c
+ * Overlay: ovl_Obj_Sound
+ * Description: Plays certain sounds (e.g., swamp waterfall noise)
+ */
+
 #include "z_obj_sound.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.c
+++ b/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_spidertent.c
+ * Overlay: ovl_Obj_Spidertent
+ * Description: Tent-Shaped Spider Web
+ */
+
 #include "z_obj_spidertent.h"
 
 #define FLAGS 0x10000000

--- a/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.c
+++ b/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_spinyroll.c
+ * Overlay: ovl_Obj_Spinyroll
+ * Description: Spike-Covered Log
+ */
+
 #include "z_obj_spinyroll.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_switch.c
+ * Overlay: ovl_Obj_Switch
+ * Description: Floor and Eye Switches
+ */
+
 #include "z_obj_switch.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.c
+++ b/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_swprize.c
+ * Overlay: ovl_Obj_Swprize
+ * Description: Spawner for dirt square prize?
+ */
+
 #include "z_obj_swprize.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Takaraya_Wall/z_obj_takaraya_wall.c
+++ b/src/overlays/actors/ovl_Obj_Takaraya_Wall/z_obj_takaraya_wall.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_takaraya_wall.c
+ * Overlay: ovl_Obj_Takaraya_Wall
+ * Description: Treasure Chest Shop rising wall
+ */
+
 #include "z_obj_takaraya_wall.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Taru/z_obj_taru.c
+++ b/src/overlays/actors/ovl_Obj_Taru/z_obj_taru.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_taru.c
+ * Overlay: ovl_Obj_Taru
+ * Description: Wooden Barrel
+ */
+
 #include "z_obj_taru.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Toge/z_obj_toge.c
+++ b/src/overlays/actors/ovl_Obj_Toge/z_obj_toge.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_toge.c
+ * Overlay: ovl_Obj_Toge
+ * Description: Blade Trap
+ */
+
 #include "z_obj_toge.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Tokei_Tobira/z_obj_tokei_tobira.c
+++ b/src/overlays/actors/ovl_Obj_Tokei_Tobira/z_obj_tokei_tobira.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_tokei_tobira.c
+ * Overlay: ovl_Obj_Tokei_Tobira
+ * Description: Clock Tower - Swinging Doors
+ */
+
 #include "z_obj_tokei_tobira.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Tokei_Turret/z_obj_tokei_turret.c
+++ b/src/overlays/actors/ovl_Obj_Tokei_Turret/z_obj_tokei_turret.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_tokei_turret.c
+ * Overlay: ovl_Obj_Tokei_Turret
+ * Description: South Clock Town - Flags & Carnival Platform
+ */
+
 #include "z_obj_tokei_turret.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_tokeidai.c
+ * Overlay: ovl_Obj_Tokeidai
+ * Description: Clock Face
+ */
+
 #include "z_obj_tokeidai.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
+++ b/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_toudai.c
+ * Overlay: ovl_Obj_Toudai
+ * Description: Clock Tower Spotlight
+ */
+
 #include "z_obj_toudai.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Tree/z_obj_tree.c
+++ b/src/overlays/actors/ovl_Obj_Tree/z_obj_tree.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_tree.c
+ * Overlay: ovl_Obj_Tree
+ * Description: Single tree (e.g. North Clock Town)
+ */
+
 #include "z_obj_tree.h"
 
 #define FLAGS 0x02000000

--- a/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
+++ b/src/overlays/actors/ovl_Obj_Tsubo/z_obj_tsubo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_tsubo.c
+ * Overlay: ovl_Obj_Tsubo
+ * Description: Pots
+ */
+
 #include "z_obj_tsubo.h"
 
 #define FLAGS 0x04800010

--- a/src/overlays/actors/ovl_Obj_Um/z_obj_um.c
+++ b/src/overlays/actors/ovl_Obj_Um/z_obj_um.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_um.c
+ * Overlay: ovl_Obj_Um
+ * Description: Cremia's cart and milk run quest
+ */
+
 #include "z_obj_um.h"
 
 #define FLAGS 0x00000039

--- a/src/overlays/actors/ovl_Obj_Usiyane/z_obj_usiyane.c
+++ b/src/overlays/actors/ovl_Obj_Usiyane/z_obj_usiyane.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_usiyane.c
+ * Overlay: ovl_Obj_Usiyane
+ * Description: Roof of Cow Barn
+ */
+
 #include "z_obj_usiyane.h"
 
 #define FLAGS 0x00000020

--- a/src/overlays/actors/ovl_Obj_Visiblock/z_obj_visiblock.c
+++ b/src/overlays/actors/ovl_Obj_Visiblock/z_obj_visiblock.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_visiblock.c
+ * Overlay: ovl_Obj_Visiblock
+ * Description: Lens of Truth Platform
+ */
+
 #include "z_obj_visiblock.h"
 
 #define FLAGS 0x00000080

--- a/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
+++ b/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_vspinyroll.c
+ * Overlay: ovl_Obj_Vspinyroll
+ * Description: Spiked rollers
+ */
+
 #include "z_obj_vspinyroll.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Wind/z_obj_wind.c
+++ b/src/overlays/actors/ovl_Obj_Wind/z_obj_wind.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_wind.c
+ * Overlay: ovl_Obj_Wind
+ * Description: Updraft Current (STT) and Water Current (PFInterior)
+ */
+
 #include "z_obj_wind.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Wturn/z_obj_wturn.c
+++ b/src/overlays/actors/ovl_Obj_Wturn/z_obj_wturn.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_wturn.c
+ * Overlay: ovl_Obj_Wturn
+ * Description: Stone Tower Temple Inverter
+ */
+
 #include "z_obj_wturn.h"
 
 #define FLAGS 0x02100010

--- a/src/overlays/actors/ovl_Obj_Y2lift/z_obj_y2lift.c
+++ b/src/overlays/actors/ovl_Obj_Y2lift/z_obj_y2lift.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_y2lift.c
+ * Overlay: ovl_Obj_Y2lift
+ * Description:
+ */
+
 #include "z_obj_y2lift.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Y2shutter/z_obj_y2shutter.c
+++ b/src/overlays/actors/ovl_Obj_Y2shutter/z_obj_y2shutter.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_y2shutter.c
+ * Overlay: ovl_Obj_Y2shutter
+ * Description:
+ */
+
 #include "z_obj_y2shutter.h"
 
 #define FLAGS 0x00000010

--- a/src/overlays/actors/ovl_Obj_Yado/z_obj_yado.c
+++ b/src/overlays/actors/ovl_Obj_Yado/z_obj_yado.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_yado.c
+ * Overlay: ovl_Obj_Yado
+ * Description: Stockpot Inn - 2nd Floor Window
+ */
+
 #include "z_obj_yado.h"
 
 #define FLAGS 0x00000030

--- a/src/overlays/actors/ovl_Obj_Yasi/z_obj_yasi.c
+++ b/src/overlays/actors/ovl_Obj_Yasi/z_obj_yasi.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_yasi.c
  * Overlay: ovl_Obj_Yasi
- * Description: Palm Tree 
+ * Description: Palm Tree
  */
 
 #include "z_obj_yasi.h"

--- a/src/overlays/actors/ovl_Obj_Yasi/z_obj_yasi.c
+++ b/src/overlays/actors/ovl_Obj_Yasi/z_obj_yasi.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_obj_yasi.c
+ * Overlay: ovl_Obj_Yasi
+ * Description: Palm Tree 
+ */
+
 #include "z_obj_yasi.h"
 
 #define FLAGS 0x00000000

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_object_kankyo.c
+ * Overlay: ovl_Object_Kankyo
+ * Description:
+ */
+
 #include "z_object_kankyo.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_spot.c
+ * Overlay: ovl_Oceff_Spot
+ * Description:
+ */
+
 #include "z_oceff_spot.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_storm.c
+ * Overlay: ovl_Oceff_Storm
+ * Description:
+ */
+
 #include "z_oceff_storm.h"
 
 #define FLAGS 0x02000030

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe.c
+ * Overlay: ovl_Oceff_Wipe
+ * Description:
+ */
+
 #include "z_oceff_wipe.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe2.c
+ * Overlay: ovl_Oceff_Wipe2
+ * Description:
+ */
+
 #include "z_oceff_wipe2.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe3.c
+ * Overlay: ovl_Oceff_Wipe3
+ * Description:
+ */
+
 #include "z_oceff_wipe3.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe4.c
+ * Overlay: ovl_Oceff_Wipe4
+ * Description:
+ */
+
 #include "z_oceff_wipe4.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe5.c
+ * Overlay: ovl_Oceff_Wipe5
+ * Description:
+ */
+
 #include "z_oceff_wipe5.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe6.c
+ * Overlay: ovl_Oceff_Wipe6
+ * Description:
+ */
+
 #include "z_oceff_wipe6.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_oceff_wipe7.c
+ * Overlay: ovl_Oceff_Wipe7
+ * Description:
+ */
+
 #include "z_oceff_wipe7.h"
 
 #define FLAGS 0x02000010

--- a/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
+++ b/src/overlays/actors/ovl_Shot_Sun/z_shot_sun.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_shot_sun.c
+ * Overlay: ovl_Shot_Sun
+ * Description:
+ */
+
 #include "z_shot_sun.h"
 
 #define FLAGS 0x00000009

--- a/src/overlays/actors/ovl_TG_Sw/z_tg_sw.c
+++ b/src/overlays/actors/ovl_TG_Sw/z_tg_sw.c
@@ -1,3 +1,9 @@
+/*
+ * File: z_tg_sw.c
+ * Overlay: ovl_TG_Sw
+ * Description: Skulltula spider bonk detector
+ */
+
 #include "z_tg_sw.h"
 
 #define FLAGS 0x00000010


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Elliptic and I talked about doing this on discord, so I just decided to get it done. This adds an explanatory comment header for every single actor that does not currently have one. It uses the description for the actor that is currently present on the spreadsheet; some of these descriptions may be slightly inaccurate or just flat-out wrong, but it's better than nothing.