### PR TITLE
Match EnItem00_Update

### DIFF
--- a/src/code/z_en_item00.c
+++ b/src/code/z_en_item00.c
@@ -434,15 +434,13 @@ void func_800A6A40(EnItem00* this, GlobalContext* globalCtx) {
     }
 }
 
-#ifdef NON_MATCHING
-// Minor regalloc issue where it uses v1 instead of v0
 void EnItem00_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnItem00* this = THIS;
     s32 pad;
     Player* player = GET_PLAYER(globalCtx);
     s32 sp38 = player->stateFlags3 & 0x1000;
     s32 getItemId = GI_NONE;
-    s32 pad2;
+    s32 params;
 
     if (this->unk152 > 0) {
         this->unk152--;
@@ -471,8 +469,8 @@ void EnItem00_Update(Actor* thisx, GlobalContext* globalCtx) {
     Collider_UpdateCylinder(&this->actor, &this->collider);
     CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
 
-    if ((this->actor.params == ITEM00_SHIELD_HERO) || (this->actor.params == ITEM00_MAP) ||
-        (this->actor.params == ITEM00_COMPASS)) {
+    params = this->actor.params;
+    if ((params == ITEM00_SHIELD_HERO) || (params == ITEM00_MAP) || (params == ITEM00_COMPASS)) {
         this->actor.shape.yOffset = fabsf(Math_CosS(this->actor.shape.rot.x) * 37.0f);
     }
 
@@ -622,9 +620,6 @@ void EnItem00_Update(Actor* thisx, GlobalContext* globalCtx) {
     this->unk14A = 0;
     this->actionFunc = func_800A6A40;
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_en_item00/EnItem00_Update.s")
-#endif
 
 void EnItem00_DrawRupee(EnItem00* this, GlobalContext* globalCtx);
 void EnItem00_DrawSprite(EnItem00* this, GlobalContext* globalCtx);


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
This is a little awkward of a match, but it's the best I could find. I'm almost certain this function needs a `params` temp somewhere to match, and this seemed to be the best place it could be that still worked.