### PR TITLE
osspsetpc OK

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -477,7 +477,7 @@ float __ull_to_f(unsigned long long l);
 // void osVoiceControlGain(void);
 // void osVoiceStartReadData(void);
 void* osViGetCurrentFramebuffer(void);
-s32 __osSpSetPc(void* data);
+s32 __osSpSetPc(void* pc);
 // void __osVoiceContWrite4(void);
 void __osGetHWIntrRoutine(s32 idx, OSMesgQueue** outQueue, OSMesg* outMsg);
 void __osSetHWIntrRoutine(s32 idx, OSMesgQueue* queue, OSMesg msg);

--- a/src/libultra/io/spsetpc.c
+++ b/src/libultra/io/spsetpc.c
@@ -1,3 +1,13 @@
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/spsetpc/__osSpSetPc.s")
+s32 __osSpSetPc(void* pc) {
+    register u32 spStatus = HW_REG(SP_STATUS_REG, u32);
+
+    if (!(spStatus & SP_STATUS_HALT)) {
+        return -1;
+    } else {
+        HW_REG(SP_PC_REG, void*) = pc;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Another OoT copy/paste
