### PR TITLE
Match `SkelAnime_GetFrameDataLegacy`

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -2575,7 +2575,7 @@ Gfx* SkelAnime_DrawFlexLimb(GlobalContext* globalCtx, s32 limbIndex, void** skel
                            Mtx** mtx, Gfx* gfx);
 Gfx* SkelAnime_DrawFlex(GlobalContext* globalCtx, void** skeleton, Vec3s* jointTable, s32 dListCount,
                        OverrideLimbDraw overrideLimbDraw, PostLimbDraw postLimbDraw, Actor* actor, Gfx* gfx);
-s16 SkelAnime_GetFrameData2(LegacyAnimationHeader* animation, s32 frame, Vec3s* frameTable);
+s16 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Vec3s* frameTable);
 s16 Animation_GetLimbCount2(LegacyAnimationHeader* animation);
 s16 Animation_GetLength2(LegacyAnimationHeader* animation);
 s16 Animation_GetLastFrame2(LegacyAnimationHeader* animation);

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -869,8 +869,6 @@ Gfx* SkelAnime_DrawFlex(GlobalContext* globalCtx, void** skeleton, Vec3s* jointT
  * Unpacks frame data for the animation at the given frame into frameTable
  * Used by the legacy animation format
  */
-#ifdef NON_MATCHING
-// equivalent, minor reordering
 s16 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Vec3s* frameTable) {
     LegacyAnimationHeader* animHeader = Lib_SegmentedToVirtual(animation);
     s16 limbCount = animHeader->limbCount;
@@ -880,59 +878,21 @@ s16 SkelAnime_GetFrameDataLegacy(LegacyAnimationHeader* animation, s32 frame, Ve
     s16* dynamicData = &frameData[frame];
     s32 i;
 
-    /**
-     *Equivalent to the following, but the compiler optimizes the loop in a way I can't replicate
-     */
-    /*
-         for(i = 0, frameTable++, key++; i < limbCount + 1; i++, key++, frameTable++) {
-             frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-             frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-             frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-         }
-    */
     frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
     frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
     frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
 
-    i = 1;
     frameTable++;
     key++;
 
-    if (limbCount & 1) {}
-
-    if (limbCount > 0) {
-        if (limbCount & 1) {
-            i++;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-            if (limbCount + 1 == i) {
-                goto ret;
-            }
-        }
-        do {
-            i += 2;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-            frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
-            frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
-            frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
-            key++;
-            frameTable++;
-        } while (i != limbCount + 1);
+    for (i = 1; i <= limbCount; i++, key++, frameTable++) {
+        frameTable->x = frame < key->xMax ? dynamicData[key->x] : staticData[key->x];
+        frameTable->y = frame < key->yMax ? dynamicData[key->y] : staticData[key->y];
+        frameTable->z = frame < key->zMax ? dynamicData[key->z] : staticData[key->z];
     }
 
-ret:
     return limbCount;
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_skelanime/SkelAnime_GetFrameDataLegacy.s")
-#endif
 
 /**
  * Used by legacy animation format

--- a/src/code/z_skelanime.c
+++ b/src/code/z_skelanime.c
@@ -931,7 +931,7 @@ ret:
     return limbCount;
 }
 #else
-#pragma GLOBAL_ASM("asm/non_matchings/code/z_skelanime/SkelAnime_GetFrameData2.s")
+#pragma GLOBAL_ASM("asm/non_matchings/code/z_skelanime/SkelAnime_GetFrameDataLegacy.s")
 #endif
 
 /**

--- a/tools/disasm/functions.txt
+++ b/tools/disasm/functions.txt
@@ -2536,7 +2536,7 @@
     0x80134990:("SkelAnime_Draw",),
     0x80134B54:("SkelAnime_DrawFlexLimb",),
     0x80134DBC:("SkelAnime_DrawFlex",),
-    0x80134FFC:("SkelAnime_GetFrameData2",),
+    0x80134FFC:("SkelAnime_GetFrameDataLegacy",),
     0x801353D4:("Animation_GetLimbCount2",),
     0x801353F8:("Animation_GetLength2",),
     0x8013541C:("Animation_GetLastFrame2",),


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

This is the only non matching left in z_skelanime.
I matched this one in OoT, and I just noted Lucas didn't update this function when he did his skelanime PR, so here we are.
The function is completely unused. It goes back to the `object_human` era of OoT, which is the only OoT object which still uses this old format.

This looks like a fake match for a loop unroll. If anybody wants to try to do a less fake match here's a scratch: https://decomp.me/scratch/KHaTp