### PR TITLE
Add ability to warnings script to just check building (not setup or disasm)

### DIFF
--- a/tools/warnings_count/check_new_warnings.sh
+++ b/tools/warnings_count/check_new_warnings.sh
@@ -109,9 +109,6 @@ else
     make_warnings uncompressed build
 fi
 
-echo "
-$(tput ${TPUTTERM} setaf 3)(lots of make output ${TPUTTERM} here...) 
-$RST"
 
 if [[ $full ]]; then
     $COMPARE_WARNINGS setup

--- a/tools/warnings_count/check_new_warnings.sh
+++ b/tools/warnings_count/check_new_warnings.sh
@@ -32,17 +32,29 @@ Check for new warnings created.
 
 Optional arguments:
     -h    Display this message and exit.
+    -a    Run full build process
     -j N  use N jobs (does not support plain -j because you shouldn't use it anyway)
 "
 }
 
 jobs=1
+all=
+run="make clean
+    make uncompressed"
+
+
 
 while getopts "hj:" opt
 do
     case $opt in
     h)  show_help
         exit 0
+        ;;
+    a)  all="true"
+        run="make distclean
+            make setup
+            make disasm
+            make all"
         ;;
     j)  j_option_arg="$OPTARG"
         if [[ ! "${j_option_arg}" =~ ^[0-9]*$ ]]
@@ -61,10 +73,7 @@ shift $(($OPTIND - 1))
 
 # Confirm run with -j jobs
 echo "This will run
-    make distclean
-    make setup
-    make disasm
-    make all
+    $run
 using $jobs threads. This may take some time."
 read -r -p "Is this okay? [Y/n]" response
 response=${response,,} # tolower
@@ -90,16 +99,23 @@ make_warnings () {
     && rm tools/warnings_count/warnings_temp.txt
 }
 
-
-make distclean
-make_warnings setup setup
-make_warnings disasm disasm
-make_warnings all build
+if [[ $all ]]; then
+    make distclean
+    make_warnings setup setup
+    make_warnings disasm disasm
+    make_warnings all build
+else
+    make clean
+    make_warnings uncompressed build
+fi
 
 echo "
 $(tput ${TPUTTERM} setaf 3)(lots of make output ${TPUTTERM} here...) 
 $RST"
-$COMPARE_WARNINGS setup
-$COMPARE_WARNINGS disasm
+
+if [[ $all ]]; then
+    $COMPARE_WARNINGS setup
+    $COMPARE_WARNINGS disasm
+fi
 $COMPARE_WARNINGS build
 

--- a/tools/warnings_count/check_new_warnings.sh
+++ b/tools/warnings_count/check_new_warnings.sh
@@ -32,29 +32,29 @@ Check for new warnings created.
 
 Optional arguments:
     -h    Display this message and exit.
-    -a    Run full build process
+    -f    Run full build process
     -j N  use N jobs (does not support plain -j because you shouldn't use it anyway)
 "
 }
 
 jobs=1
-all=
+full=
 run="make clean
     make uncompressed"
 
 
 
-while getopts "hj:" opt
+while getopts "hfj:" opt
 do
     case $opt in
     h)  show_help
         exit 0
         ;;
-    a)  all="true"
+    f)  full="true"
         run="make distclean
-            make setup
-            make disasm
-            make all"
+    make setup
+    make disasm
+    make all"
         ;;
     j)  j_option_arg="$OPTARG"
         if [[ ! "${j_option_arg}" =~ ^[0-9]*$ ]]
@@ -99,7 +99,7 @@ make_warnings () {
     && rm tools/warnings_count/warnings_temp.txt
 }
 
-if [[ $all ]]; then
+if [[ $full ]]; then
     make distclean
     make_warnings setup setup
     make_warnings disasm disasm
@@ -113,7 +113,7 @@ echo "
 $(tput ${TPUTTERM} setaf 3)(lots of make output ${TPUTTERM} here...) 
 $RST"
 
-if [[ $all ]]; then
+if [[ $full ]]; then
     $COMPARE_WARNINGS setup
     $COMPARE_WARNINGS disasm
 fi


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Since I feel most warnings will show up in the actual build (not setup or disasm), changed the warnings script to just check for build warnings by default. I have also added an option to still check warnings from start to finish for those cases where it still matters.