### PR TITLE
pfsdeletefile OK

### DIFF
--- a/src/libultra/io/pfsdeletefile.c
+++ b/src/libultra/io/pfsdeletefile.c
@@ -1,5 +1,86 @@
+#include "PR/pfs.h"
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/pfsdeletefile/osPfsDeleteFile.s")
+s32 __osPfsReleasePages(OSPfs* pfs, __OSInode* inode, u8 initialPage, u8 bank, __OSInodeUnit* finalPage);
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/pfsdeletefile/__osPfsReleasePages.s")
+s32 osPfsDeleteFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8* extName) {
+    s32 file_no;
+    s32 ret;
+    __OSInode inode;
+    __OSDir dir;
+    __OSInodeUnit last_page;
+    u8 startpage;
+    u8 bank;
+
+    if ((companyCode == 0) || (gameCode == 0)) {
+        return PFS_ERR_INVALID;
+    }
+
+    ret = osPfsFindFile(pfs, companyCode, gameCode, gameName, extName, &file_no);
+    if (ret != 0) {
+        return ret;
+    }
+    if (pfs->activebank != 0) {
+        ret = __osPfsSelectBank(pfs, 0);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+
+    ret = __osContRamRead(pfs->queue, pfs->channel, pfs->dir_table + file_no, (u8*)&dir);
+    if (ret != 0) {
+        return ret;
+    }
+
+    startpage = dir.start_page.inode_t.page;
+    for (bank = dir.start_page.inode_t.bank; bank < pfs->banks;) {
+        ret = __osPfsRWInode(pfs, &inode, PFS_READ, bank);
+        if (ret != 0) {
+            return ret;
+        }
+
+        ret = __osPfsReleasePages(pfs, &inode, startpage, bank, &last_page);
+        if (ret != 0) {
+            return ret;
+        }
+
+        ret = __osPfsRWInode(pfs, &inode, PFS_WRITE, bank);
+        if (ret != 0) {
+            return ret;
+        }
+
+        if (last_page.ipage == PFS_EOF) {
+            break;
+        }
+
+        bank = last_page.inode_t.bank;
+        startpage = last_page.inode_t.page;
+    }
+
+    if (bank >= pfs->banks) {
+        return PFS_ERR_INCONSISTENT;
+    }
+    bzero(&dir, sizeof(__OSDir));
+
+    ret = __osContRamWrite(pfs->queue, pfs->channel, pfs->dir_table + file_no, (u8*)&dir, 0);
+
+    return ret;
+}
+
+s32 __osPfsReleasePages(OSPfs* pfs, __OSInode* inode, u8 initialPage, u8 bank, __OSInodeUnit* finalPage) {
+    __OSInodeUnit next;
+    __OSInodeUnit prev;
+    s32 ret = 0;
+
+    next.ipage = (u16)((bank << 8) + initialPage);
+
+    do {
+        prev = next;
+        next = inode->inodePage[next.inode_t.page];
+        inode->inodePage[prev.inode_t.page].ipage = PFS_PAGE_NOT_USED;
+    } while (next.ipage >= pfs->inodeStartPage && next.inode_t.bank == bank);
+
+    *finalPage = next;
+
+    return ret;
+}

--- a/src/libultra/io/pfsdeletefile.c
+++ b/src/libultra/io/pfsdeletefile.c
@@ -21,7 +21,7 @@ s32 osPfsDeleteFile(OSPfs* pfs, u16 companyCode, u32 gameCode, u8* gameName, u8*
         return ret;
     }
     if (pfs->activebank != 0) {
-        ret = __osPfsSelectBank(pfs, 0);
+        ret = __osPfsSelectBank(pfs, PFS_ID_BANK_256K);
         if (ret != 0) {
             return ret;
         }


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
As with #422 and #423 , rewrote the ifs to separate the assignments.