### PR TITLE
Use ITEM_MASK_GIBDO enum in En_Hg

### DIFF
--- a/src/overlays/actors/ovl_En_Hg/z_en_hg.c
+++ b/src/overlays/actors/ovl_En_Hg/z_en_hg.c
@@ -364,7 +364,7 @@ void func_80BCFC0C(EnHg* this, GlobalContext* globalCtx) {
         }
         if (globalCtx->msgCtx.unk1202A == 3) {
             if (globalCtx->msgCtx.unk1202E == 7 && gSaveContext.playerForm == PLAYER_FORM_HUMAN) {
-                if (INV_CONTENT(0x41) == 0x41) {
+                if (INV_CONTENT(ITEM_MASK_GIBDO) == ITEM_MASK_GIBDO) {
                     this->unk218 = 3;
                 } else {
                     this->unk218 = 1;


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
After the enum PR was merged, I went and updated my existing PRs to use it. In the process of doing so, I noticed there was exactly one place in the codebase that used `INV_CONTENT` *without* using an appropriate item enum, which was En_Hg. So this PR just changes the 0x41 to `ITEM_MASK_GIBDO` to match all other uses of `INV_CONTENT`.