### PR TITLE
Macro Clean up

### DIFF
--- a/src/boot_O2_g3/fault.c
+++ b/src/boot_O2_g3/fault.c
@@ -802,7 +802,7 @@ void Fault_ThreadEntry(void* arg) {
     osSetEventMesg(12, &sFaultContext->queue, (OSMesg)2);
     while (1) {
         do {
-            osRecvMesg(&sFaultContext->queue, &msg, 1);
+            osRecvMesg(&sFaultContext->queue, &msg, OS_MESG_BLOCK);
 
             if (msg == (OSMesg)1) {
                 sFaultContext->msgId = 1;
@@ -893,7 +893,7 @@ void Fault_Start(void) {
     sFaultContext->clients = NULL;
     sFaultContext->faultActive = 0;
     gFaultStruct.faultHandlerEnabled = 1;
-    osCreateMesgQueue(&sFaultContext->queue, sFaultContext->msg, 1);
+    osCreateMesgQueue(&sFaultContext->queue, sFaultContext->msg, ARRAY_COUNT(sFaultContext->msg));
     StackCheck_Init(&sFaultThreadInfo, sFaultStack, sFaultStack + sizeof(sFaultStack), 0, 0x100, "fault");
     osCreateThread(&sFaultContext->thread, 2, Fault_ThreadEntry, NULL, sFaultStack + sizeof(sFaultStack), 0x7F);
     osStartThread(&sFaultContext->thread);

--- a/src/boot_O2_g3/idle.c
+++ b/src/boot_O2_g3/idle.c
@@ -63,7 +63,7 @@ void Idle_InitCodeAndMemory(void) {
                            SEGMENT_ROM_END(code) - SEGMENT_ROM_START(code), 0, &queue, 0);
     Idle_InitScreen();
     Idle_InitMemory();
-    osRecvMesg(&queue, NULL, 1);
+    osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
 
     sDmaMgrDmaBuffSize = oldSize;
 

--- a/src/boot_O2_g3/irqmgr.c
+++ b/src/boot_O2_g3/irqmgr.c
@@ -17,10 +17,10 @@ void IrqMgr_AddClient(IrqMgr* irqmgr, IrqMgrClient* param_2, OSMesgQueue* param_
     osSetIntMask(saveMask);
 
     if (irqmgr->prenmiStage > 0) {
-        osSendMesg(param_2->queue, &irqmgr->prenmiMsg.type, 0);
+        osSendMesg(param_2->queue, &irqmgr->prenmiMsg.type, OS_MESG_NOBLOCK);
     }
     if (irqmgr->prenmiStage > 1) {
-        osSendMesg(param_2->queue, &irqmgr->nmiMsg.type, 0);
+        osSendMesg(param_2->queue, &irqmgr->nmiMsg.type, OS_MESG_NOBLOCK);
     }
 }
 
@@ -54,7 +54,7 @@ void IrqMgr_SendMesgForClient(IrqMgr* irqmgr, OSMesg msg) {
     IrqMgrClient* iter = irqmgr->callbacks;
 
     while (iter != NULL) {
-        osSendMesg(iter->queue, msg, 0);
+        osSendMesg(iter->queue, msg, OS_MESG_NOBLOCK);
         iter = iter->next;
     }
 }
@@ -64,7 +64,7 @@ void IrqMgr_JamMesgForClient(IrqMgr* irqmgr, OSMesg msg) {
 
     while (iter != NULL) {
         if (iter->queue->validCount < iter->queue->msgCount) {
-            osSendMesg(iter->queue, msg, 0);
+            osSendMesg(iter->queue, msg, OS_MESG_NOBLOCK);
         }
         iter = iter->next;
     }
@@ -130,7 +130,7 @@ void IrqMgr_ThreadEntry(IrqMgr* irqmgr) {
             ;
         }
 
-        osRecvMesg(&irqmgr->irqQueue, (OSMesg*)&interrupt, 1);
+        osRecvMesg(&irqmgr->irqQueue, (OSMesg*)&interrupt, OS_MESG_BLOCK);
         switch (interrupt) {
             case 0x29A:
                 IrqMgr_HandleRetrace(irqmgr);
@@ -159,7 +159,7 @@ void IrqMgr_Init(IrqMgr* irqmgr, void* stack, OSPri pri, u8 retraceCount) {
     irqmgr->prenmiStage = 0;
     irqmgr->lastPrenmiTime = 0;
 
-    osCreateMesgQueue(&irqmgr->irqQueue, (OSMesg*)irqmgr->irqBuffer, 8);
+    osCreateMesgQueue(&irqmgr->irqQueue, (OSMesg*)irqmgr->irqBuffer, ARRAY_COUNT(irqmgr->irqBuffer));
     osSetEventMesg(0xE, &irqmgr->irqQueue, (OSMesg)0x29D);
     osViSetEvent(&irqmgr->irqQueue, (OSMesg)0x29A, retraceCount);
 

--- a/src/boot_O2_g3/z_std_dma.c
+++ b/src/boot_O2_g3/z_std_dma.c
@@ -31,7 +31,7 @@ s32 DmaMgr_DMARomToRam(u32 rom, void* ram, size_t size) {
                 goto END;
             }
 
-            osRecvMesg(&queue, NULL, 1);
+            osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
             size -= buffSize;
             rom = rom + buffSize;
             ram = (u8*)ram + buffSize;
@@ -47,7 +47,7 @@ s32 DmaMgr_DMARomToRam(u32 rom, void* ram, size_t size) {
         goto END;
     }
 
-    osRecvMesg(&queue, NULL, 1);
+    osRecvMesg(&queue, NULL, OS_MESG_BLOCK);
 
     osInvalDCache(ram, size);
 

--- a/src/code/z_debug_display.c
+++ b/src/code/z_debug_display.c
@@ -68,10 +68,10 @@ void DebugDisplay_DrawSpriteI8(DebugDispObject* dispObj, void* texture, GlobalCo
     func_8012C6FC(globalCtx->state.gfxCtx);
 
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, dispObj->color.r, dispObj->color.g, dispObj->color.b, dispObj->color.a);
-    Matrix_InsertTranslation(dispObj->pos.x, dispObj->pos.y, dispObj->pos.z, 0);
-    Matrix_Scale(dispObj->scale.x, dispObj->scale.y, dispObj->scale.z, 1);
-    Matrix_InsertMatrix(&globalCtx->mf_187FC, 1);
-    Matrix_InsertRotation(dispObj->rot.x, dispObj->rot.y, dispObj->rot.z, 1);
+    Matrix_InsertTranslation(dispObj->pos.x, dispObj->pos.y, dispObj->pos.z, MTXMODE_NEW);
+    Matrix_Scale(dispObj->scale.x, dispObj->scale.y, dispObj->scale.z, MTXMODE_APPLY);
+    Matrix_InsertMatrix(&globalCtx->mf_187FC, MTXMODE_APPLY);
+    Matrix_InsertRotation(dispObj->rot.x, dispObj->rot.y, dispObj->rot.z, MTXMODE_APPLY);
 
     gDPLoadTextureBlock(POLY_XLU_DISP++, texture, G_IM_FMT_I, G_IM_SIZ_8b, 16, 16, 0, G_TX_NOMIRROR | G_TX_WRAP,
                         G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
@@ -95,7 +95,7 @@ void DebugDisplay_DrawPolygon(DebugDispObject* dispObj, void* arg1, GlobalContex
     gSPSetLights1(POLY_XLU_DISP++, sDebugDisplayLight1);
 
     Matrix_SetStateRotationAndTranslation(dispObj->pos.x, dispObj->pos.y, dispObj->pos.z, &dispObj->rot);
-    Matrix_Scale(dispObj->scale.x, dispObj->scale.y, dispObj->scale.z, 1);
+    Matrix_Scale(dispObj->scale.x, dispObj->scale.y, dispObj->scale.z, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
     gSPDisplayList(POLY_XLU_DISP++, arg1);

--- a/src/code/z_view.c
+++ b/src/code/z_view.c
@@ -259,11 +259,11 @@ s32 View_StepQuake(View* view, Mtx* matrix) {
     Matrix_FromRSPMatrix(matrix, &mf);
     Matrix_SetCurrentState(&mf);
     Matrix_RotateStateAroundXAxis(view->currQuakeRot.x);
-    Matrix_InsertYRotation_f(view->currQuakeRot.y, 1);
-    Matrix_InsertZRotation_f(view->currQuakeRot.z, 1);
+    Matrix_InsertYRotation_f(view->currQuakeRot.y, MTXMODE_APPLY);
+    Matrix_InsertZRotation_f(view->currQuakeRot.z, MTXMODE_APPLY);
     Matrix_Scale(view->currQuakeScale.x, view->currQuakeScale.y, view->currQuakeScale.z, MTXMODE_APPLY);
-    Matrix_InsertZRotation_f(-view->currQuakeRot.z, 1);
-    Matrix_InsertYRotation_f(-view->currQuakeRot.y, 1);
+    Matrix_InsertZRotation_f(-view->currQuakeRot.z, MTXMODE_APPLY);
+    Matrix_InsertYRotation_f(-view->currQuakeRot.y, MTXMODE_APPLY);
     Matrix_RotateStateAroundXAxis(-view->currQuakeRot.x);
     Matrix_ToMtx(matrix);
 

--- a/src/code/z_vr_box.c
+++ b/src/code/z_vr_box.c
@@ -103,7 +103,7 @@ void func_80143324(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skyTy
                                    SEGMENT_ROM_START(d2_cloud_static), size, 0, &skyboxCtx->loadQueue, NULL);
         }
 
-        osRecvMesg(&skyboxCtx->loadQueue, NULL, 1);
+        osRecvMesg(&skyboxCtx->loadQueue, NULL, OS_MESG_BLOCK);
         osCreateMesgQueue(&skyboxCtx->loadQueue, &skyboxCtx->loadMsg, 1);
 
         if (globalCtx->envCtx.unk_11 == 0) {
@@ -120,7 +120,7 @@ void func_80143324(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skyTy
                                    SEGMENT_ROM_START(d2_cloud_static), size, 0, &skyboxCtx->loadQueue, NULL);
         }
 
-        osRecvMesg(&skyboxCtx->loadQueue, NULL, 1);
+        osRecvMesg(&skyboxCtx->loadQueue, NULL, OS_MESG_BLOCK);
         osCreateMesgQueue(&skyboxCtx->loadQueue, &skyboxCtx->loadMsg, 1);
 
         size = SEGMENT_ROM_SIZE(d2_fine_pal_static);
@@ -129,7 +129,7 @@ void func_80143324(GlobalContext* globalCtx, SkyboxContext* skyboxCtx, s16 skyTy
         DmaMgr_SendRequestImpl(&skyboxCtx->unk1C8, skyboxCtx->skyboxPaletteStaticSegment,
                                SEGMENT_ROM_START(d2_fine_pal_static), size, 0, &skyboxCtx->loadQueue, NULL);
 
-        osRecvMesg(&skyboxCtx->loadQueue, NULL, 1);
+        osRecvMesg(&skyboxCtx->loadQueue, NULL, OS_MESG_BLOCK);
     }
 }
 

--- a/src/libultra/io/contquery.c
+++ b/src/libultra/io/contquery.c
@@ -7,11 +7,11 @@ s32 osContStartQuery(OSMesgQueue* mq) {
 
     if (__osContLastPoll != 0) {
         __osPackRequestData(0);
-        __osSiRawStartDma(1, &__osContPifRam);
+        __osSiRawStartDma(OS_WRITE, &__osContPifRam);
         osRecvMesg(mq, NULL, OS_MESG_BLOCK);
     }
 
-    ret = __osSiRawStartDma(0, &__osContPifRam);
+    ret = __osSiRawStartDma(OS_READ, &__osContPifRam);
 
     __osContLastPoll = 0;
 

--- a/src/libultra/io/contreaddata.c
+++ b/src/libultra/io/contreaddata.c
@@ -8,11 +8,11 @@ s32 osContStartReadData(OSMesgQueue* mq) {
 
     if (__osContLastPoll != 1) {
         __osPackReadData();
-        __osSiRawStartDma(1, &__osContPifRam);
-        osRecvMesg(mq, NULL, 1);
+        __osSiRawStartDma(OS_WRITE, &__osContPifRam);
+        osRecvMesg(mq, NULL, OS_MESG_BLOCK);
     }
 
-    ret = __osSiRawStartDma(0, &__osContPifRam);
+    ret = __osSiRawStartDma(OS_READ, &__osContPifRam);
     __osContLastPoll = 1;
 
     __osSiRelAccess();

--- a/src/libultra/io/controller.c
+++ b/src/libultra/io/controller.c
@@ -34,16 +34,16 @@ s32 osContInit(OSMesgQueue* mq, u8* bitpattern, OSContStatus* data) {
 
     __osPackRequestData(0);
 
-    ret = __osSiRawStartDma(1, &__osContPifRam);
-    osRecvMesg(mq, &dummy, 1);
+    ret = __osSiRawStartDma(OS_WRITE, &__osContPifRam);
+    osRecvMesg(mq, &dummy, OS_MESG_BLOCK);
 
-    ret = __osSiRawStartDma(0, &__osContPifRam);
-    osRecvMesg(mq, &dummy, 1);
+    ret = __osSiRawStartDma(OS_READ, &__osContPifRam);
+    osRecvMesg(mq, &dummy, OS_MESG_BLOCK);
 
     __osContGetInitData(bitpattern, data);
     __osContLastPoll = 0;
     __osSiCreateAccessQueue();
-    osCreateMesgQueue(&D_8009CF38, D_8009CF50, 1);
+    osCreateMesgQueue(&D_8009CF38, D_8009CF50, ARRAY_COUNT(D_8009CF50));
 
     return ret;
 }

--- a/src/libultra/io/epidma.c
+++ b/src/libultra/io/epidma.c
@@ -16,9 +16,9 @@ s32 osEPiStartDma(OSPiHandle* pihandle, OSIoMesg* mb, s32 direction) {
     }
 
     if (mb->hdr.pri == 1) {
-        result = osJamMesg(osPiGetCmdQueue(), mb, 0);
+        result = osJamMesg(osPiGetCmdQueue(), mb, OS_MESG_NOBLOCK);
     } else {
-        result = osSendMesg(osPiGetCmdQueue(), mb, 0);
+        result = osSendMesg(osPiGetCmdQueue(), mb, OS_MESG_NOBLOCK);
     }
     return result;
 }

--- a/src/libultra/io/piacs.c
+++ b/src/libultra/io/piacs.c
@@ -7,8 +7,8 @@ OSMesgQueue __osPiAccessQueue;
 
 void __osPiCreateAccessQueue(void) {
     __osPiAccessQueueEnabled = 1;
-    osCreateMesgQueue(&__osPiAccessQueue, D_8009E3F0, 1);
-    osSendMesg(&__osPiAccessQueue, NULL, 0);
+    osCreateMesgQueue(&__osPiAccessQueue, D_8009E3F0, ARRAY_COUNT(D_8009E3F0));
+    osSendMesg(&__osPiAccessQueue, NULL, OS_MESG_NOBLOCK);
 }
 
 void __osPiGetAccess(void) {

--- a/src/libultra/io/pimgr.c
+++ b/src/libultra/io/pimgr.c
@@ -14,7 +14,7 @@ void osCreatePiManager(OSPri pri, OSMesgQueue* cmdQ, OSMesg* cmdBuf, s32 cmdMsgC
 
     if (!__osPiDevMgr.active) {
         osCreateMesgQueue(cmdQ, cmdBuf, cmdMsgCnt);
-        osCreateMesgQueue(&D_8009E3D0, D_8009E3E8, 1);
+        osCreateMesgQueue(&D_8009E3D0, D_8009E3E8, ARRAY_COUNT(D_8009E3E8));
         if (!__osPiAccessQueueEnabled) {
             __osPiCreateAccessQueue();
         }

--- a/src/libultra/io/siacs.c
+++ b/src/libultra/io/siacs.c
@@ -7,8 +7,8 @@ OSMesgQueue __osSiAccessQueue;
 
 void __osSiCreateAccessQueue() {
     __osSiAccessQueueEnabled = 1;
-    osCreateMesgQueue(&__osSiAccessQueue, siAccessBuf, 1);
-    osSendMesg(&__osSiAccessQueue, NULL, 0);
+    osCreateMesgQueue(&__osSiAccessQueue, siAccessBuf, ARRAY_COUNT(siAccessBuf));
+    osSendMesg(&__osSiAccessQueue, NULL, OS_MESG_NOBLOCK);
 }
 
 void __osSiGetAccess(void) {
@@ -16,9 +16,9 @@ void __osSiGetAccess(void) {
     if (!__osSiAccessQueueEnabled) {
         __osSiCreateAccessQueue();
     }
-    osRecvMesg(&__osSiAccessQueue, &dummyMesg, 1);
+    osRecvMesg(&__osSiAccessQueue, &dummyMesg, OS_MESG_BLOCK);
 }
 
 void __osSiRelAccess(void) {
-    osSendMesg(&__osSiAccessQueue, NULL, 0);
+    osSendMesg(&__osSiAccessQueue, NULL, OS_MESG_NOBLOCK);
 }

--- a/src/libultra/os/seteventmesg.c
+++ b/src/libultra/os/seteventmesg.c
@@ -17,7 +17,7 @@ void osSetEventMesg(OSEvent e, OSMesgQueue* mq, OSMesg m) {
 
     if (e == 14) {
         if (__osShutdown != 0 && D_80097F10 == 0) {
-            osSendMesg(mq, m, 0);
+            osSendMesg(mq, m, OS_MESG_NOBLOCK);
         }
         D_80097F10 = 1;
     }

--- a/src/libultra/os/timerintr.c
+++ b/src/libultra/os/timerintr.c
@@ -49,7 +49,7 @@ void __osTimerInterrupt(void) {
             t->next = NULL;
             t->prev = NULL;
             if (t->mq != NULL) {
-                osSendMesg(t->mq, t->msg, 0);
+                osSendMesg(t->mq, t->msg, OS_MESG_NOBLOCK);
             }
             if (t->interval != 0) {
                 t->value = t->interval;

--- a/src/overlays/actors/ovl_Bg_Ctower_Gear/z_bg_ctower_gear.c
+++ b/src/overlays/actors/ovl_Bg_Ctower_Gear/z_bg_ctower_gear.c
@@ -89,9 +89,9 @@ void BgCtowerGear_Splash(BgCtowerGear* this, GlobalContext* globalCtx) {
     flags = this->dyna.actor.flags & 0x40;
     rotZ = this->dyna.actor.shape.rot.z & 0x1FFF;
     if ((flags != 0) && (rotZ < 0x1B58) && (rotZ >= 0x1388)) {
-        Matrix_RotateY(this->dyna.actor.home.rot.y, 0);
-        Matrix_InsertXRotation_s(this->dyna.actor.home.rot.x, 1);
-        Matrix_InsertZRotation_s(this->dyna.actor.home.rot.z, 1);
+        Matrix_RotateY(this->dyna.actor.home.rot.y, MTXMODE_NEW);
+        Matrix_InsertXRotation_s(this->dyna.actor.home.rot.x, MTXMODE_APPLY);
+        Matrix_InsertZRotation_s(this->dyna.actor.home.rot.z, MTXMODE_APPLY);
         for (i = 0; i < 4; i++) {
             if ((u32)Rand_Next() >= 0x40000000) {
                 splashOffset.x = D_80AD3270[i].x - (Rand_ZeroOne() * 30.0f);
@@ -107,9 +107,9 @@ void BgCtowerGear_Splash(BgCtowerGear* this, GlobalContext* globalCtx) {
     }
     if ((rotZ < 0x1F4) && (rotZ >= 0)) {
         if (flags != 0) {
-            Matrix_RotateY(this->dyna.actor.home.rot.y, 0);
-            Matrix_InsertXRotation_s(this->dyna.actor.home.rot.x, 1);
-            Matrix_InsertZRotation_s(this->dyna.actor.home.rot.z, 1);
+            Matrix_RotateY(this->dyna.actor.home.rot.y, MTXMODE_NEW);
+            Matrix_InsertXRotation_s(this->dyna.actor.home.rot.x, MTXMODE_APPLY);
+            Matrix_InsertZRotation_s(this->dyna.actor.home.rot.z, MTXMODE_APPLY);
             for (i = 0; i < 3; i++) {
                 for (j = 0; j < 2; j++) {
                     splashOffset.x = D_80AD32A0[i].x + (Rand_ZeroOne() * 10.0f);

--- a/src/overlays/actors/ovl_En_Bu/z_en_bu.c
+++ b/src/overlays/actors/ovl_En_Bu/z_en_bu.c
@@ -54,9 +54,9 @@ void EnBu_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
     Matrix_InsertTranslation(this->actor.world.pos.x, this->actor.world.pos.y, this->actor.world.pos.z, MTXMODE_NEW);
-    Matrix_InsertZRotation_s(this->actor.shape.rot.z, 1);
-    Matrix_RotateY(this->actor.shape.rot.y, 1);
-    Matrix_InsertXRotation_s(this->actor.shape.rot.x, 1);
+    Matrix_InsertZRotation_s(this->actor.shape.rot.z, MTXMODE_APPLY);
+    Matrix_RotateY(this->actor.shape.rot.y, MTXMODE_APPLY);
+    Matrix_InsertXRotation_s(this->actor.shape.rot.x, MTXMODE_APPLY);
     Matrix_Scale(0.01f, 0.01f, 0.01f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, this->displayListPtr);

--- a/src/overlays/actors/ovl_En_Cha/z_en_cha.c
+++ b/src/overlays/actors/ovl_En_Cha/z_en_cha.c
@@ -119,6 +119,6 @@ void EnCha_Draw(Actor* thisx, GlobalContext* globalCtx) {
 
     func_800BDFC0(globalCtx, D_06000710);
     Matrix_InsertTranslation(-1094.0f, 4950.0f, 9.0f, MTXMODE_APPLY);
-    Matrix_InsertXRotation_s(this->actor.home.rot.x, 1);
+    Matrix_InsertXRotation_s(this->actor.home.rot.x, MTXMODE_APPLY);
     func_800BDFC0(globalCtx, D_06000958);
 }

--- a/src/overlays/actors/ovl_En_Dno/z_en_dno.c
+++ b/src/overlays/actors/ovl_En_Dno/z_en_dno.c
@@ -171,7 +171,7 @@ void func_80A715DC(EnDno* this, GlobalContext* globalCtx) {
                 if (func_8013E5CC(&crace->actor.home.pos, &crace->actor.home.rot, &D_80A73B2C, &this->actor.prevPos,
                                   &this->actor.world.pos, &sp88)) {
                     Math_Vec3f_Diff(&this->actor.world.pos, &crace->actor.home.pos, &sp7C);
-                    Matrix_RotateY(-crace->actor.home.rot.y, 0);
+                    Matrix_RotateY(-crace->actor.home.rot.y, MTXMODE_NEW);
                     Matrix_MultiplyVector3fByState(&sp7C, &sp70);
                     if ((fabsf(sp70.x) < 100.0f) && (sp70.y >= -10.0f) && (sp70.y <= 180.0f) && (sp70.z < 0.0f)) {
                         crace->unk_170 |= 1;
@@ -985,7 +985,7 @@ void EnDno_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Ve
         func_8012C28C(globalCtx->state.gfxCtx);
         if (limbIndex == 13) {
             Matrix_Scale(this->unk_454, this->unk_454, this->unk_454, MTXMODE_APPLY);
-            Matrix_InsertXRotation_s(this->unk_45C, 1);
+            Matrix_InsertXRotation_s(this->unk_45C, MTXMODE_APPLY);
         }
 
         gfxOpa = POLY_OPA_DISP;

--- a/src/overlays/actors/ovl_En_Elfbub/z_en_elfbub.c
+++ b/src/overlays/actors/ovl_En_Elfbub/z_en_elfbub.c
@@ -154,12 +154,12 @@ void EnElfbub_Draw(Actor* thisx, GlobalContext* globalCtx2) {
 
     func_8012C2DC(globalCtx->state.gfxCtx);
 
-    Matrix_InsertTranslation(0.0f, 0.0f, 1.0f, 1);
+    Matrix_InsertTranslation(0.0f, 0.0f, 1.0f, MTXMODE_APPLY);
     Matrix_NormalizeXYZ(&globalCtx->mf_187FC);
-    Matrix_Scale(this->xyScale + 1.0f, this->xyScale + 1.0f, 1.0f, 1);
-    Matrix_InsertZRotation_s(this->zRot, 1);
-    Matrix_Scale(this->xScale + 1.0f, 1.0f, 1.0f, 1);
-    Matrix_InsertZRotation_s(this->zRot * -1, 1);
+    Matrix_Scale(this->xyScale + 1.0f, this->xyScale + 1.0f, 1.0f, MTXMODE_APPLY);
+    Matrix_InsertZRotation_s(this->zRot, MTXMODE_APPLY);
+    Matrix_Scale(this->xScale + 1.0f, 1.0f, 1.0f, MTXMODE_APPLY);
+    Matrix_InsertZRotation_s(this->zRot * -1, MTXMODE_APPLY);
 
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_XLU_DISP++, D_06001000);

--- a/src/overlays/actors/ovl_En_Elforg/z_en_elforg.c
+++ b/src/overlays/actors/ovl_En_Elforg/z_en_elforg.c
@@ -607,7 +607,7 @@ void EnElforg_Draw(Actor* thisx, GlobalContext* globalCtx) {
             AnimatedMat_Draw(globalCtx, Lib_SegmentedToVirtual(&D_0402C818));
             break;
     }
-    Matrix_InsertMatrix(&globalCtx->mf_187FC, 1);
+    Matrix_InsertMatrix(&globalCtx->mf_187FC, MTXMODE_APPLY);
 
     POLY_XLU_DISP =
         SkelAnime_DrawFlex(globalCtx, this->skelAnime.skeleton, this->skelAnime.jointTable, this->skelAnime.dListCount,

--- a/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
+++ b/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
@@ -642,12 +642,12 @@ s32 EnGinkoMan_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** d
 
     if (limbIndex == 15) {
         Matrix_InsertTranslation(1500.0f, 0.0f, 0.0f, MTXMODE_APPLY);
-        Matrix_InsertXRotation_s(this->limb15Rot.y, 1);
-        Matrix_InsertZRotation_s(this->limb15Rot.x, 1);
+        Matrix_InsertXRotation_s(this->limb15Rot.y, MTXMODE_APPLY);
+        Matrix_InsertZRotation_s(this->limb15Rot.x, MTXMODE_APPLY);
         Matrix_InsertTranslation(-1500.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     } else if (limbIndex == 8) {
-        Matrix_InsertXRotation_s(-this->limb8Rot.y, 1);
-        Matrix_InsertZRotation_s(-this->limb8Rot.x, 1);
+        Matrix_InsertXRotation_s(-this->limb8Rot.y, MTXMODE_APPLY);
+        Matrix_InsertZRotation_s(-this->limb8Rot.x, MTXMODE_APPLY);
     }
 
     return 0;

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -1590,7 +1590,7 @@ void func_80942B1C(EnGoroiwa* this, GlobalContext* globalCtx) {
             sp80.z = ptr->unk_20;
 
             Matrix_SetStateRotationAndTranslation(ptr->unk_00.x, ptr->unk_00.y, ptr->unk_00.z, &sp80);
-            Matrix_Scale(this->actor.scale.x, this->actor.scale.y, this->actor.scale.z, 1);
+            Matrix_Scale(this->actor.scale.x, this->actor.scale.y, this->actor.scale.z, MTXMODE_APPLY);
             func_800BDFC0(globalCtx, phi_fp);
 
             if ((ptr->unk_28 != 0) && (ptr->unk_2C > 0)) {
@@ -1604,7 +1604,7 @@ void func_80942B1C(EnGoroiwa* this, GlobalContext* globalCtx) {
 
                 func_800C0094(ptr->unk_28, ptr->unk_00.x, ptr->unk_18, ptr->unk_00.z, &sp88);
                 Matrix_SetCurrentState(&sp88);
-                Matrix_Scale(this->actor.scale.x * 7.5f, 1.0f, this->actor.scale.z * 7.5f, 1);
+                Matrix_Scale(this->actor.scale.x * 7.5f, 1.0f, this->actor.scale.z * 7.5f, MTXMODE_APPLY);
 
                 gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx),
                           G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);

--- a/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.c
+++ b/src/overlays/actors/ovl_En_Hakurock/z_en_hakurock.c
@@ -351,7 +351,7 @@ void func_80B228F4(Actor* thisx, GlobalContext* globalCtx) {
 void EnHakurock_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
     func_8012C28C(globalCtx->state.gfxCtx);
-    Matrix_InsertTranslation(-100.0f, 0.0f, 0.0f, 1);
+    Matrix_InsertTranslation(-100.0f, 0.0f, 0.0f, MTXMODE_APPLY);
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_OPA_DISP++, D_06011100);
     gSPDisplayList(POLY_OPA_DISP++, D_06011178);

--- a/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -320,7 +320,7 @@ s32 func_80A68F9C(EnMushi2* this, s16 arg1) {
     matrix->mf[3][2] = 0.0f;
     matrix->mf[3][3] = 0.0f;
 
-    Matrix_RotateY(arg1, 1);
+    Matrix_RotateY(arg1, MTXMODE_APPLY);
 
     this->unk_310.x = matrix->mf[0][0];
     this->unk_310.y = matrix->mf[0][1];
@@ -367,7 +367,7 @@ s32 func_80A690C4(EnMushi2* this, s16 arg1) {
     matrix->mf[3][2] = 0.0f;
     matrix->mf[3][3] = 0.0f;
 
-    Matrix_InsertXRotation_s(arg1, 1);
+    Matrix_InsertXRotation_s(arg1, MTXMODE_APPLY);
 
     this->unk_310.x = matrix->mf[0][0];
     this->unk_310.y = matrix->mf[0][1];

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -1172,9 +1172,9 @@ void func_8095D074(Actor* thisx, GlobalContext* globalCtx) {
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
-    Matrix_InsertTranslation(0.0f, 500.0f, 0.0f, 1);
-    Matrix_InsertXRotation_s(this->unk_3D8 - 0x4000, 1);
-    Matrix_InsertTranslation(0.0f, 0.0f, -500.0f, 1);
+    Matrix_InsertTranslation(0.0f, 500.0f, 0.0f, MTXMODE_APPLY);
+    Matrix_InsertXRotation_s(this->unk_3D8 - 0x4000, MTXMODE_APPLY);
+    Matrix_InsertTranslation(0.0f, 0.0f, -500.0f, MTXMODE_APPLY);
     if (this->unk_3DC >= 0x20) {
         gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 

--- a/src/overlays/actors/ovl_En_Pm/z_en_pm.c
+++ b/src/overlays/actors/ovl_En_Pm/z_en_pm.c
@@ -861,7 +861,7 @@ void func_80AF8C68(EnPm* this, GlobalContext* globalCtx) {
         this->unk_360 = 0.0f;
     }
     Math_SmoothStepToF(&this->unk_364, this->unk_360, 0.8f, 40.0f, 10.0f);
-    Matrix_InsertTranslation(this->unk_364, 0.0f, 0.0f, 1);
+    Matrix_InsertTranslation(this->unk_364, 0.0f, 0.0f, MTXMODE_APPLY);
     this->unk_388 = sp28;
 }
 

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -893,7 +893,8 @@ void EnPoh_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Ve
 
     if (limbIndex == 18) {
         if ((this->actionFunc == func_80B2D300) && (this->unk_18E >= 19) && (this->actor.scale.x != 0.0f)) {
-            Matrix_Scale(0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, MTXMODE_APPLY);
+            Matrix_Scale(0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x,
+                         MTXMODE_APPLY);
         }
         Matrix_CopyCurrentState(&this->unk_3D8);
         func_80B2C910(&sp60, globalCtx);

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -893,7 +893,7 @@ void EnPoh_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Ve
 
     if (limbIndex == 18) {
         if ((this->actionFunc == func_80B2D300) && (this->unk_18E >= 19) && (this->actor.scale.x != 0.0f)) {
-            Matrix_Scale(0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, 1);
+            Matrix_Scale(0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, 0.01f / this->actor.scale.x, MTXMODE_APPLY);
         }
         Matrix_CopyCurrentState(&this->unk_3D8);
         func_80B2C910(&sp60, globalCtx);

--- a/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
+++ b/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
@@ -72,7 +72,7 @@ s32 EnRsn_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList,
     EnRsn* this = (EnRsn*)arg;
 
     if (limbIndex == 14) {
-        Matrix_InsertXRotation_s(this->unk1D8.y, 1);
+        Matrix_InsertXRotation_s(this->unk1D8.y, MTXMODE_APPLY);
     }
     return 0;
 }

--- a/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
+++ b/src/overlays/actors/ovl_Obj_Aqua/z_obj_aqua.c
@@ -285,12 +285,12 @@ void ObjAqua_Draw(Actor* thisx, GlobalContext* globalCtx) {
     if (actionFuncTemp) {
         s16 rotation = Math_SinS(this->unk_198) * 8000.0f;
 
-        Matrix_InsertZRotation_s(rotation, 1);
-        Matrix_Scale(1.3f, 1.0f, 1.0f, 1);
-        Matrix_InsertZRotation_s(rotation * -1, 1);
-        Matrix_Scale(10.0f / 13.0f, 1.0f, 1.0f, 1);
+        Matrix_InsertZRotation_s(rotation, MTXMODE_APPLY);
+        Matrix_Scale(1.3f, 1.0f, 1.0f, MTXMODE_APPLY);
+        Matrix_InsertZRotation_s(rotation * -1, MTXMODE_APPLY);
+        Matrix_Scale(10.0f / 13.0f, 1.0f, 1.0f, MTXMODE_APPLY);
     }
-    Matrix_RotateY(yaw, 1);
+    Matrix_RotateY(yaw, MTXMODE_APPLY);
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
     gSPDisplayList(POLY_XLU_DISP++, D_0407D590);
     CLOSE_DISPS(globalCtx->state.gfxCtx);

--- a/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
+++ b/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
@@ -36,7 +36,7 @@ void ObjFunen_Draw(Actor* thisx, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
 
     func_8012C2DC(globalCtx->state.gfxCtx);
-    Matrix_RotateY((s16)(func_800DFCDC(GET_ACTIVE_CAM(globalCtx)) - 0x8000), 1);
+    Matrix_RotateY((s16)(func_800DFCDC(GET_ACTIVE_CAM(globalCtx)) - 0x8000), MTXMODE_APPLY);
 
     gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_MODELVIEW | G_MTX_LOAD | G_MTX_NOPUSH);
 


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Just some macro's that were missing that I noticed in voice WIP. It doesn't introduce any new macros, only uses existing ones. Includes OS macros and MTXMODE macros