### PR TITLE
Do another round of improvement on actor comment headers

### DIFF
--- a/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.c
+++ b/src/overlays/actors/ovl_Bg_Dkjail_Ivy/z_bg_dkjail_ivy.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_dkjail_ivy.c
  * Overlay: ovl_Bg_Dkjail_Ivy
- * Description: Ivy in Deku Jail
+ * Description: Cuttable Ivy wall (beneath Woodfall Temple, Swamp Spider House)
  */
 
 #include "z_bg_dkjail_ivy.h"

--- a/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
+++ b/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_f40_swlift.c
  * Overlay: ovl_Bg_F40_Swlift
- * Description:
+ * Description: Unused oscillating platform
  */
 
 #include "z_bg_f40_swlift.h"

--- a/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
+++ b/src/overlays/actors/ovl_Bg_F40_Swlift/z_bg_f40_swlift.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_f40_swlift.c
  * Overlay: ovl_Bg_F40_Swlift
- * Description: Unused oscillating platform
+ * Description: Unused Stone Tower vertically-oscillating platform
  */
 
 #include "z_bg_f40_swlift.h"

--- a/src/overlays/actors/ovl_Bg_Fu_Mizu/z_bg_fu_mizu.c
+++ b/src/overlays/actors/ovl_Bg_Fu_Mizu/z_bg_fu_mizu.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_fu_mizu.c
  * Overlay: ovl_Bg_Fu_Mizu
- * Description:
+ * Description: Water in Honey and Darling's Second Day game
  */
 
 #include "z_bg_fu_mizu.h"

--- a/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.c
+++ b/src/overlays/actors/ovl_Bg_Ikana_Dharma/z_bg_ikana_dharma.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_ikana_dharma.c
  * Overlay: ovl_Bg_Ikana_Dharma
- * Description: Ikana Castle - Punchable Pillar Segments
+ * Description: Stone Tower Temple - Punchable Pillar Segments
  */
 
 #include "z_bg_ikana_dharma.h"

--- a/src/overlays/actors/ovl_Bg_Market_Step/z_bg_market_step.c
+++ b/src/overlays/actors/ovl_Bg_Market_Step/z_bg_market_step.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_market_step.c
  * Overlay: ovl_Bg_Market_Step
- * Description: West Clocktown - Stairs
+ * Description: West Clocktown - most scenery
  */
 
 #include "z_bg_market_step.h"

--- a/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.c
+++ b/src/overlays/actors/ovl_Bg_Open_Shutter/z_bg_open_shutter.c
@@ -1,7 +1,7 @@
 /*
  * File: z_bg_open_shutter.c
  * Overlay: ovl_Bg_Open_Shutter
- * Description:
+ * Description: Sliding doors in opening dungeon
  */
 
 #include "z_bg_open_shutter.h"

--- a/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
+++ b/src/overlays/actors/ovl_Demo_Effect/z_demo_effect.c
@@ -1,7 +1,7 @@
 /*
  * File: z_demo_effect.c
  * Overlay: ovl_Demo_Effect
- * Description: Obtaining Masks (?)
+ * Description: Various cutscene effects (blue warp in, Great Fairy vanish, etc.)
  */
 
 #include "z_demo_effect.h"

--- a/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.c
+++ b/src/overlays/actors/ovl_Demo_Getitem/z_demo_getitem.c
@@ -1,7 +1,7 @@
 /*
  * File: z_demo_getitem.c
  * Overlay: ovl_Demo_Getitem
- * Description:
+ * Description: Cutscene object for Great Fairy's Mask and Great Fairy's Sword
  */
 
 #include "z_demo_getitem.h"

--- a/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.c
+++ b/src/overlays/actors/ovl_Demo_Syoten/z_demo_syoten.c
@@ -1,7 +1,7 @@
 /*
  * File: z_demo_syoten.c
  * Overlay: ovl_Demo_Syoten
- * Description:
+ * Description: Ikana Canyon Cleansing Cutscene Effects
  */
 
 #include "z_demo_syoten.h"

--- a/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.c
+++ b/src/overlays/actors/ovl_Dm_Char00/z_dm_char00.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char00.c
  * Overlay: ovl_Dm_Char00
- * Description: Tatl (cutscene)
+ * Description: Tatl and Tael (cutscene)
  */
 
 #include "z_dm_char00.h"

--- a/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.c
+++ b/src/overlays/actors/ovl_Dm_Char01/z_dm_char01.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char01.c
  * Overlay: ovl_Dm_Char01
- * Description: Tatl and Tael (cutscene)
+ * Description: Woodfall scene objects (temple, water, walls, etc)
  */
 
 #include "z_dm_char01.h"

--- a/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.c
+++ b/src/overlays/actors/ovl_Dm_Char02/z_dm_char02.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char02.c
  * Overlay: ovl_Dm_Char02
- * Description:
+ * Description: Ocarina of Time (dropped from Skull Kid's hand)
  */
 
 #include "z_dm_char02.h"

--- a/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.c
+++ b/src/overlays/actors/ovl_Dm_Char04/z_dm_char04.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char04.c
  * Overlay: ovl_Dm_Char04
- * Description:
+ * Description: Unused(?) Tatl and Tael actors
  */
 
 #include "z_dm_char04.h"

--- a/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
+++ b/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char06.c
  * Overlay: ovl_Dm_Char06
- * Description: Some unseen Mountain Village cutscene actor?
+ * Description: Thawing landscape fadeout in Mountain Village
  */
 
 #include "z_dm_char06.h"

--- a/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
+++ b/src/overlays/actors/ovl_Dm_Char06/z_dm_char06.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_char06.c
  * Overlay: ovl_Dm_Char06
- * Description: Thawing landscape fadeout in Mountain Village
+ * Description: Mountain Village Snowy landscape fadeout in post-Snowhead thawing cutscene
  */
 
 #include "z_dm_char06.h"

--- a/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
+++ b/src/overlays/actors/ovl_Dm_Sa/z_dm_sa.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_sa.c
  * Overlay: ovl_Dm_Sa
- * Description:
+ * Description: Glitched early version of Skull Kid stuck in a T-pose
  */
 
 #include "z_dm_sa.h"

--- a/src/overlays/actors/ovl_Dm_Statue/z_dm_statue.c
+++ b/src/overlays/actors/ovl_Dm_Statue/z_dm_statue.c
@@ -1,7 +1,7 @@
 /*
  * File: z_dm_statue.c
  * Overlay: ovl_Dm_Statue
- * Description: Elegy of Emptiness - Beam of Light When Creating Statue
+ * Description: Pillars of water in Giant's Chamber
  */
 
 #include "z_dm_statue.h"

--- a/src/overlays/actors/ovl_Eff_Change/z_eff_change.c
+++ b/src/overlays/actors/ovl_Eff_Change/z_eff_change.c
@@ -1,7 +1,7 @@
 /*
  * File: z_eff_change.c
  * Overlay: ovl_Eff_Change
- * Description:
+ * Description: Elegy of Emptiness - Beam of Light When Creating Statue
  */
 
 #include "z_eff_change.h"

--- a/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
+++ b/src/overlays/actors/ovl_Eff_Dust/z_eff_dust.c
@@ -1,5 +1,5 @@
 /*
- * File z_eff_dust.c
+ * File: z_eff_dust.c
  * Overlay: ovl_Eff_Dust
  * Description: Dust effects
  */

--- a/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.c
+++ b/src/overlays/actors/ovl_Eff_Kamejima_Wave/z_eff_kamejima_wave.c
@@ -1,5 +1,5 @@
 /*
- * File z_eff_kamejima_wave.c
+ * File: z_eff_kamejima_wave.c
  * Overlay: ovl_Eff_Kamejima_Wave
  * Description: Wave Created by Turtle Awakening
  */

--- a/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.c
+++ b/src/overlays/actors/ovl_Eff_Lastday/z_eff_lastday.c
@@ -1,5 +1,5 @@
 /*
- * File z_eff_lastday.c
+ * File: z_eff_lastday.c
  * Overlay: ovl_Eff_Lastday
  * Description: Moon Crash Cutscene Fire Wall
  */

--- a/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.c
+++ b/src/overlays/actors/ovl_Eff_Stk/z_eff_stk.c
@@ -1,5 +1,5 @@
 /*
- * File z_eff_stk.c
+ * File: z_eff_stk.c
  * Overlay: ovl_Eff_Stk
  * Description: Skullkid Effects (calling down moon / cursing Link)
  */

--- a/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
+++ b/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
@@ -1,7 +1,7 @@
 /*
  * File z_eff_zoraband.c
  * Overlay: ovl_Eff_Zoraband
- * Description:
+ * Description: Indigo-Go's (Mikau's healing cutscene)
  */
 
 #include "z_eff_zoraband.h"

--- a/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
+++ b/src/overlays/actors/ovl_Eff_Zoraband/z_eff_zoraband.c
@@ -1,5 +1,5 @@
 /*
- * File z_eff_zoraband.c
+ * File: z_eff_zoraband.c
  * Overlay: ovl_Eff_Zoraband
  * Description: Indigo-Go's (Mikau's healing cutscene)
  */

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg.c
+ * File: z_elf_msg.c
  * Overlay: ovl_Elf_Msg
  * Description: Tatl Hint (proximity-activated C-up hint?)
  */

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg2.c
+ * File: z_elf_msg2.c
  * Overlay: ovl_Elf_Msg2
  * Description: Tatl Hint (Z-target-activated C-up hint?)
  */

--- a/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
+++ b/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg3.c
+ * File: z_elf_msg3.c
  * Overlay: ovl_Elf_Msg3
  * Description: Tatl Message (Proximity-activated dialogue?)
  */

--- a/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
+++ b/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg4.c
+ * File: z_elf_msg4.c
  * Overlay: ovl_Elf_Msg4
  * Description: Tatl Hint (another proximity-activated C-up hint?)
  */

--- a/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.c
+++ b/src/overlays/actors/ovl_Elf_Msg5/z_elf_msg5.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg5.c
+ * File: z_elf_msg5.c
  * Overlay: ovl_Elf_Msg5
  * Description: Tatl Message (Another proximity-activated dialogue?)
  */

--- a/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
+++ b/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
@@ -1,5 +1,5 @@
 /*
- * File z_elf_msg6.c
+ * File: z_elf_msg6.c
  * Overlay: ovl_Elf_Msg6
  * Description: Tatl Hint (another proximity-activated C-up hint?)
  */

--- a/src/overlays/actors/ovl_En_Ah/z_en_ah.c
+++ b/src/overlays/actors/ovl_En_Ah/z_en_ah.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_ah.c
+ * File: z_en_ah.c
  * Overlay: ovl_En_Ah
  * Description: Anju's Mother
  */

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_akindonuts.c
+ * File: z_en_akindonuts.c
  * Overlay: ovl_En_Akindonuts
  * Description: Woodfall - Business Scrub
  */

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_akindonuts.c
  * Overlay: ovl_En_Akindonuts
- * Description: Business Scrubs that are part of the Moon's Tear/Deed trade quest
+ * Description: Trade quest Business Scrubs
  */
 
 #include "z_en_akindonuts.h"

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_akindonuts.c
  * Overlay: ovl_En_Akindonuts
- * Description: Woodfall - Business Scrub
+ * Description: Business Scrubs that are part of the Moon's Tear/Deed trade quest
  */
 
 #include "z_en_akindonuts.h"

--- a/src/overlays/actors/ovl_En_Al/z_en_al.c
+++ b/src/overlays/actors/ovl_En_Al/z_en_al.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_al.c
+ * File: z_en_al.c
  * Overlay: ovl_En_Al
  * Description: Madame Aroma
  */

--- a/src/overlays/actors/ovl_En_Am/z_en_am.c
+++ b/src/overlays/actors/ovl_En_Am/z_en_am.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_am.c
+ * File: z_en_am.c
  * Overlay: ovl_En_Am
  * Description: Armos
  */

--- a/src/overlays/actors/ovl_En_An/z_en_an.c
+++ b/src/overlays/actors/ovl_En_An/z_en_an.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_an.c
+ * File: z_en_an.c
  * Overlay: ovl_En_An
  * Description: Anju
  */

--- a/src/overlays/actors/ovl_En_And/z_en_and.c
+++ b/src/overlays/actors/ovl_En_And/z_en_and.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_and.c
+ * File: z_en_and.c
  * Overlay: ovl_En_And
  * Description: Anju in Wedding Dress
  */

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_ani.c
+ * File: z_en_ani.c
  * Overlay: ovl_En_Ani
  * Description: Part-time worker
  */

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_ani.c
  * Overlay: ovl_En_Ani
- * Description: Part-Timer
+ * Description: Part-time worker
  */
 
 #include "z_en_ani.h"

--- a/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
+++ b/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_aob_01.c
+ * File: z_en_aob_01.c
  * Overlay: ovl_En_Aob_01
  * Description: Mamamu Yan
  */

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_arrow.c
+ * File: z_en_arrow.c
  * Overlay: ovl_En_Arrow
  * Description: Arrows and other projectiles
  */

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_attack_niw.c
+ * File: z_en_attack_niw.c
  * Overlay: ovl_En_Attack_Niw
  * Description: Attacking cucco
  */

--- a/src/overlays/actors/ovl_En_Az/z_en_az.c
+++ b/src/overlays/actors/ovl_En_Az/z_en_az.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_az.c
+ * File: z_en_az.c
  * Overlay: ovl_En_Az
  * Description: Beaver Bros
  */

--- a/src/overlays/actors/ovl_En_Baba/z_en_baba.c
+++ b/src/overlays/actors/ovl_En_Baba/z_en_baba.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_baba.c
+ * File: z_en_baba.c
  * Overlay: ovl_En_Baba
  * Description: Bomb Shop Lady
  */

--- a/src/overlays/actors/ovl_En_Bal/z_en_bal.c
+++ b/src/overlays/actors/ovl_En_Bal/z_en_bal.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bal.c
+ * File: z_en_bal.c
  * Overlay: ovl_En_Bal
  * Description: Tingle With Balloon
  */

--- a/src/overlays/actors/ovl_En_Bal/z_en_bal.c
+++ b/src/overlays/actors/ovl_En_Bal/z_en_bal.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_bal.c
  * Overlay: ovl_En_Bal
- * Description: Tingle With Balloon
+ * Description: Tingle with Balloon
  */
 
 #include "z_en_bal.h"

--- a/src/overlays/actors/ovl_En_Bat/z_en_bat.c
+++ b/src/overlays/actors/ovl_En_Bat/z_en_bat.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bat.c
+ * File: z_en_bat.c
  * Overlay: ovl_En_Bat
  * Description: Bad Bat
  */

--- a/src/overlays/actors/ovl_En_Bb/z_en_bb.c
+++ b/src/overlays/actors/ovl_En_Bb/z_en_bb.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bb.c
+ * File: z_en_bb.c
  * Overlay: ovl_En_Bb
  * Description: Blue Bubble
  */

--- a/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
+++ b/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_bba_01.c
  * Overlay: ovl_En_Bba_01
- * Description:
+ * Description: Unused Bomb Shop Lady NPC
  */
 
 #include "z_en_bba_01.h"

--- a/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
+++ b/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bba_01.c
+ * File: z_en_bba_01.c
  * Overlay: ovl_En_Bba_01
  * Description: Unused Bomb Shop Lady NPC
  */

--- a/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.c
+++ b/src/overlays/actors/ovl_En_Bbfall/z_en_bbfall.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bbfall.c
+ * File: z_en_bbfall.c
  * Overlay: ovl_En_Bbfall
  * Description: Red Bubble
  */

--- a/src/overlays/actors/ovl_En_Bee/z_en_bee.c
+++ b/src/overlays/actors/ovl_En_Bee/z_en_bee.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bee.c
+ * File: z_en_bee.c
  * Overlay: ovl_En_Bee
  * Description: Giant Bee
  */

--- a/src/overlays/actors/ovl_En_Bh/z_en_bh.c
+++ b/src/overlays/actors/ovl_En_Bh/z_en_bh.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bh.c
+ * File: z_en_bh.c
  * Overlay: ovl_En_Bh
  * Description: Brown Bird (on the Moon)
  */

--- a/src/overlays/actors/ovl_En_Bh/z_en_bh.c
+++ b/src/overlays/actors/ovl_En_Bh/z_en_bh.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_bh.c
  * Overlay: ovl_En_Bh
- * Description: Brown Bird
+ * Description: Brown Bird (on the Moon)
  */
 
 #include "z_en_bh.h"

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bigokuta.c
+ * File: z_en_bigokuta.c
  * Overlay: ovl_En_Bigokuta
  * Description: Big Octo
  */

--- a/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.c
+++ b/src/overlays/actors/ovl_En_Bigpamet/z_en_bigpamet.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bigpamet.c
+ * File: z_en_bigpamet.c
  * Overlay: ovl_En_Bigpamet
  * Description: Gekko & Snapper Miniboss - Snapper
  */

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bigpo.c
+ * File: z_en_bigpo.c
  * Overlay: ovl_En_Bigpi
  * Description: Big Poe. Leader of the Poes, found under Dampe's house and in Beneath the Well
  */

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_bigpo.c
  * Overlay: ovl_En_Bigpi
- * Description: Big Poe. Leader of the Poes, found under Dampe's house and in Beneath the Well
+ * Description: Big Poe. Found under Dampe's house and in Beneath the Well
  */
 
 #include "z_en_bigpo.h"

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -1,6 +1,6 @@
 /*
  * File: z_en_bigpo.c
- * Overlay: ovl_En_Bigpi
+ * Overlay: ovl_En_Bigpo
  * Description: Big Poe. Found under Dampe's house and in Beneath the Well
  */
 

--- a/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bigslime.c
+ * File: z_en_bigslime.c
  * Overlay: ovl_En_Bigslime
  * Description: Mad Jelly (miniboss)
  */

--- a/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
+++ b/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bjt.c
+ * File: z_en_bjt.c
  * Overlay: ovl_En_Bjt
  * Description: ??? (Hand in toilet)
  */

--- a/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
+++ b/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_bjt.c
  * Overlay: ovl_En_Bjt
- * Description: Hand in Toilet
+ * Description: ??? (Hand in toilet)
  */
 
 #include "z_en_bjt.h"

--- a/src/overlays/actors/ovl_En_Boj_01/z_en_boj_01.c
+++ b/src/overlays/actors/ovl_En_Boj_01/z_en_boj_01.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boj_01.c
+ * File: z_en_boj_01.c
  * Overlay: ovl_En_Boj_01
  * Description: [Empty]
  */

--- a/src/overlays/actors/ovl_En_Boj_02/z_en_boj_02.c
+++ b/src/overlays/actors/ovl_En_Boj_02/z_en_boj_02.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boj_02.c
+ * File: z_en_boj_02.c
  * Overlay: ovl_En_Boj_02
  * Description: [Empty]
  */

--- a/src/overlays/actors/ovl_En_Boj_03/z_en_boj_03.c
+++ b/src/overlays/actors/ovl_En_Boj_03/z_en_boj_03.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boj_03.c
+ * File: z_en_boj_03.c
  * Overlay: ovl_En_Boj_03
  * Description: [Empty]
  */

--- a/src/overlays/actors/ovl_En_Boj_04/z_en_boj_04.c
+++ b/src/overlays/actors/ovl_En_Boj_04/z_en_boj_04.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boj_04.c
+ * File: z_en_boj_04.c
  * Overlay: ovl_En_Boj_04
  * Description: [Empty]
  */

--- a/src/overlays/actors/ovl_En_Boj_05/z_en_boj_05.c
+++ b/src/overlays/actors/ovl_En_Boj_05/z_en_boj_05.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boj_05.c
+ * File: z_en_boj_05.c
  * Overlay: ovl_En_Boj_05
  * Description: [Empty]
  */

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bom.c
+ * File: z_en_bom.c
  * Overlay: ovl_En_Bom
  * Description: Bomb / Powder Keg
  */

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bom_bowl_man.c
+ * File: z_en_bom_bowl_man.c
  * Overlay: ovl_En_Bom_Bowl_Man
  * Description: Line of Bombers when they teach you the password
  */

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_bom_bowl_man.c
  * Overlay: ovl_En_Bom_Bowl_Man
- * Description: Line of Bombers?
+ * Description: Line of Bombers when they teach you the password
  */
 
 #include "z_en_bom_bowl_man.h"

--- a/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
+++ b/src/overlays/actors/ovl_En_Bom_Chu/z_en_bom_chu.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bom_chu.c
+ * File: z_en_bom_chu.c
  * Overlay: ovl_En_Bom_Chu
  * Description: Bombchus
  */

--- a/src/overlays/actors/ovl_En_Bombal/z_en_bombal.c
+++ b/src/overlays/actors/ovl_En_Bombal/z_en_bombal.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bombal.c
+ * File: z_en_bombal.c
  * Overlay: ovl_En_Bombal
  * Description: Bombers - Majora Balloon
  */

--- a/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
+++ b/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bombers.c
+ * File: z_en_bombers.c
  * Overlay: ovl_En_Bombers
  * Description: Bombers - Blue-Hatted Bomber
  */

--- a/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
+++ b/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bombers2.c
+ * File: z_en_bombers2.c
  * Overlay: ovl_En_Bombers2
  * Description: Bombers - Hideout Guard
  */

--- a/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
+++ b/src/overlays/actors/ovl_En_Bombf/z_en_bombf.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bombf.c
+ * File: z_en_bombf.c
  * Overlay: ovl_En_Bombf
  * Description: Bomb flower
  */

--- a/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
+++ b/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bomjima.c
+ * File: z_en_bomjima.c
  * Overlay: ovl_En_Bomjima
  * Description: Bombers - Jim
  */

--- a/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
+++ b/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bomjimb.c
+ * File: z_en_bomjimb.c
  * Overlay: ovl_En_Bomjimb
  * Description: Bombers when chasing them
  */

--- a/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
+++ b/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_bomjimb.c
  * Overlay: ovl_En_Bomjimb
- * Description: Bomber Jim B
+ * Description: Bombers when chasing them
  */
 
 #include "z_en_bomjimb.h"

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_boom.c
+ * File: z_en_boom.c
  * Overlay: ovl_En_Boom
  * Description: Zora boomerangs
  */

--- a/src/overlays/actors/ovl_En_Box/z_en_box.c
+++ b/src/overlays/actors/ovl_En_Box/z_en_box.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_box.c
+ * File: z_en_box.c
  * Overlay: ovl_En_Box
  * Description: Chest
  */

--- a/src/overlays/actors/ovl_En_Bsb/z_en_bsb.c
+++ b/src/overlays/actors/ovl_En_Bsb/z_en_bsb.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bsb.c
+ * File: z_en_bsb.c
  * Overlay: ovl_En_Bsb
  * Description: Captain Keeta
  */

--- a/src/overlays/actors/ovl_En_Bu/z_en_bu.c
+++ b/src/overlays/actors/ovl_En_Bu/z_en_bu.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bu.c
+ * File: z_en_bu.c
  * Overlay: ovl_En_Bu
  * Description: Unused dummied-out enemy
  */

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_bubble.c
  * Overlay: ovl_En_Bubble
- * Description: Bubble (flying skull enemy)
+ * Description: Shabom (unused)
  */
 
 #include "z_en_bubble.h"

--- a/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
+++ b/src/overlays/actors/ovl_En_Bubble/z_en_bubble.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_bubble.c
+ * File: z_en_bubble.c
  * Overlay: ovl_En_Bubble
  * Description: Bubble (flying skull enemy)
  */

--- a/src/overlays/actors/ovl_En_Butte/z_en_butte.c
+++ b/src/overlays/actors/ovl_En_Butte/z_en_butte.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_butte.c
+ * File: z_en_butte.c
  * Overlay: ovl_En_Butte
  * Description: Butterflies
  */

--- a/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
+++ b/src/overlays/actors/ovl_En_Clear_Tag/z_en_clear_tag.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_clear_tag.c
+ * File: z_en_clear_tag.c
  * Overlay: ovl_En_Clear_Tag
  * Description: Various effects: explosions and pops, splashes, light rays
  */

--- a/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
+++ b/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_cne_01.c
  * Overlay: ovl_En_Cne_01
- * Description:
+ * Description: Unused Market NPC
  */
 
 #include "z_en_cne_01.h"

--- a/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
+++ b/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_cne_01.c
+ * File: z_en_cne_01.c
  * Overlay: ovl_En_Cne_01
  * Description: Unused Market NPC
  */

--- a/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
+++ b/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_col_man.c
+ * File: z_en_col_man.c
  * Overlay: ovl_En_Col_Man
  * Description: Piece of Heart spawned by Fish2
  */

--- a/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
+++ b/src/overlays/actors/ovl_En_Col_Man/z_en_col_man.c
@@ -1,7 +1,7 @@
 /*
  * File z_en_col_man.c
  * Overlay: ovl_En_Col_Man
- * Description: Gives you a Piece of Heart when you touch it?
+ * Description: Piece of Heart spawned by Fish2
  */
 
 #include "z_en_col_man.h"

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_cow.c
+ * File: z_en_cow.c
  * Overlay: ovl_En_Cow
  * Description: Cow
  */

--- a/src/overlays/actors/ovl_En_Crow/z_en_crow.c
+++ b/src/overlays/actors/ovl_En_Crow/z_en_crow.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_crow.c
+ * File: z_en_crow.c
  * Overlay: ovl_En_Crow
  * Description: Guay
  */

--- a/src/overlays/actors/ovl_En_Death/z_en_death.c
+++ b/src/overlays/actors/ovl_En_Death/z_en_death.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_death.c
+ * File: z_en_death.c
  * Overlay: ovl_En_Death
  * Description: Gomess
  */

--- a/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
+++ b/src/overlays/actors/ovl_En_Dekubaba/z_en_dekubaba.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_dekubaba.c
+ * File: z_en_dekubaba.c
  * Overlay: ovl_En_Dekubaba
  * Description: Deku Baba
  */

--- a/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
+++ b/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_demo_heishi.c
+ * File: z_en_demo_heishi.c
  * Overlay: ovl_En_Demo_heishi
  * Description: Unused(?) version of Shiro
  */

--- a/src/overlays/actors/ovl_En_Dnb/z_en_dnb.c
+++ b/src/overlays/actors/ovl_En_Dnb/z_en_dnb.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_dnb.c
  * Overlay: ovl_En_Dnb
- * Description:
+ * Description: Unused invisible snowy mountain that explodes?
  */
 
 #include "z_en_dnb.h"

--- a/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
+++ b/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ds2n.c
  * Overlay: ovl_En_Ds2n
- * Description:
+ * Description: Medicine Shop Owner from OoT (unused)
  */
 
 #include "z_en_ds2n.h"

--- a/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
+++ b/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ds2n.c
  * Overlay: ovl_En_Ds2n
- * Description: Medicine Shop Owner from OoT (unused)
+ * Description: Potion Shop Owner from OoT (unused)
  */
 
 #include "z_en_ds2n.h"

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_encount1.c
  * Overlay: ovl_En_Encount1
- * Description:
+ * Description: Spawner for Dragonflies, Skullfish, and Wallmasters
  */
 
 #include "z_en_encount1.h"

--- a/src/overlays/actors/ovl_En_Encount3/z_en_encount3.c
+++ b/src/overlays/actors/ovl_En_Encount3/z_en_encount3.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_encount3.c
  * Overlay: ovl_En_Encount3
- * Description:
+ * Description: Garo spawner
  */
 
 #include "z_en_encount3.h"

--- a/src/overlays/actors/ovl_En_Encount4/z_en_encount4.c
+++ b/src/overlays/actors/ovl_En_Encount4/z_en_encount4.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_encount4.c
  * Overlay: ovl_En_Encount4
- * Description:
+ * Description: Spawner for Stalchild and Fire Wall in Keeta chase
  */
 
 #include "z_en_encount4.h"

--- a/src/overlays/actors/ovl_En_Ending_Hero/z_en_ending_hero.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero/z_en_ending_hero.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ending_hero.c
  * Overlay: ovl_En_Ending_Hero
- * Description:
+ * Description: Mayor Dotour at wedding during the credits
  */
 
 #include "z_en_ending_hero.h"

--- a/src/overlays/actors/ovl_En_Ending_Hero2/z_en_ending_hero2.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero2/z_en_ending_hero2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ending_hero2.c
  * Overlay: ovl_En_Ending_Hero2
- * Description:
+ * Description: Viscen watching moon disappearance and wedding
  */
 
 #include "z_en_ending_hero2.h"

--- a/src/overlays/actors/ovl_En_Ending_Hero3/z_en_ending_hero3.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero3/z_en_ending_hero3.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ending_hero3.c
  * Overlay: ovl_En_Ending_Hero3
- * Description:
+ * Description: Mutoh watching moon disappearance and wedding
  */
 
 #include "z_en_ending_hero3.h"

--- a/src/overlays/actors/ovl_En_Ending_Hero4/z_en_ending_hero4.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero4/z_en_ending_hero4.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ending_hero4.c
  * Overlay: ovl_En_Ending_Hero4
- * Description:
+ * Description: Soldiers watching moon disappearance and Indigo-Go's
  */
 
 #include "z_en_ending_hero4.h"

--- a/src/overlays/actors/ovl_En_Ending_Hero5/z_en_ending_hero5.c
+++ b/src/overlays/actors/ovl_En_Ending_Hero5/z_en_ending_hero5.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ending_hero5.c
  * Overlay: ovl_En_Ending_Hero5
- * Description:
+ * Description: Carpenters watching moon disappearance and Indigo-Go's
  */
 
 #include "z_en_ending_hero5.h"

--- a/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.c
+++ b/src/overlays/actors/ovl_En_Gamelupy/z_en_gamelupy.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_gamelupy.c
  * Overlay: ovl_En_Gamelupy
- * Description: Deku Scrub Playground - Large Green Rupee
+ * Description: Deku Scrub Playground Rupees
  */
 
 #include "z_en_gamelupy.h"

--- a/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
+++ b/src/overlays/actors/ovl_En_Ge1/z_en_ge1.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ge1.c
  * Overlay: ovl_En_Ge1
- * Description:
+ * Description: White-clad Gerudo Pirate
  */
 
 #include "z_en_ge1.h"

--- a/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
+++ b/src/overlays/actors/ovl_En_Ge2/z_en_ge2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ge2.c
  * Overlay: ovl_En_Ge2
- * Description: Patrolling Pirate
+ * Description: Purple-clad Gerudo Pirate
  */
 
 #include "z_en_ge2.h"

--- a/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
+++ b/src/overlays/actors/ovl_En_Ge3/z_en_ge3.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ge3.c
  * Overlay: ovl_En_Ge3
- * Description:
+ * Description: Aviel
  */
 
 #include "z_en_ge3.h"

--- a/src/overlays/actors/ovl_En_Heishi/z_en_heishi.c
+++ b/src/overlays/actors/ovl_En_Heishi/z_en_heishi.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_heishi.c
  * Overlay: ovl_En_Heishi
- * Description: Soldier
+ * Description: Soldier (Mayor's Residence only)
  */
 
 #include "z_en_heishi.h"

--- a/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
+++ b/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_hgo.c
  * Overlay: ovl_En_Hgo
- * Description: Pamela's Father As a Gibdo
+ * Description: Pamela's Father (Gibdo)
  */
 
 #include "z_en_hgo.h"

--- a/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
+++ b/src/overlays/actors/ovl_En_Horse_Game_Check/z_en_horse_game_check.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_horse_game_check.c
  * Overlay: ovl_En_Horse_Game_Check
- * Description:
+ * Description: Dirt patches you can jump over on Gorman Race Track
  */
 
 #include "z_en_horse_game_check.h"

--- a/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
+++ b/src/overlays/actors/ovl_En_Hs2/z_en_hs2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_hs2.c
  * Overlay: ovl_En_Hs2
- * Description: Blue Target Spot
+ * Description: Blue Target Spot (?)
  */
 
 #include "z_en_hs2.h"

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_in.c
+ * File: z_en_in.c
  * Overlay: ovl_En_In
  * Description: Gorman Bros
  */

--- a/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
+++ b/src/overlays/actors/ovl_En_Invadepoh/z_en_invadepoh.c
@@ -1,5 +1,5 @@
 /*
- * File z_en_invadepoh.c
+ * File: z_en_invadepoh.c
  * Overlay: ovl_En_Invadepoh
  * Description: Ranch nighttime actors
  */

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ishi.c
  * Overlay: ovl_En_Ishi
- * Description: Rock
+ * Description: Liftable rocks and silver boulders
  */
 
 #include "z_en_ishi.h"

--- a/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
+++ b/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_kusa2.c
  * Overlay: ovl_En_Kusa2
- * Description: Keaton grass?
+ * Description: Keaton grass
  */
 
 #include "z_en_kusa2.h"

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_m_thunder.c
  * Overlay: ovl_En_M_Thunder
- * Description: Spin attack effect
+ * Description: Spin attack and sword beams
  */
 
 #include "z_en_m_thunder.h"

--- a/src/overlays/actors/ovl_En_Minideath/z_en_minideath.c
+++ b/src/overlays/actors/ovl_En_Minideath/z_en_minideath.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_minideath.c
  * Overlay: ovl_En_Minideath
- * Description: Bats Surrounding Gomess?
+ * Description: Gomess's bats
  */
 
 #include "z_en_minideath.h"

--- a/src/overlays/actors/ovl_En_Mkk/z_en_mkk.c
+++ b/src/overlays/actors/ovl_En_Mkk/z_en_mkk.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_mkk.c
  * Overlay: ovl_En_Mkk
- * Description: Makkurokurosuke / Black and White Boe
+ * Description: Black and White Boe (Name origin: Makkurokurosuke)
  */
 
 #include "z_en_mkk.h"

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_mt_tag.c
  * Overlay: ovl_En_Mt_tag
- * Description:
+ * Description: Controls the Goron Race minigame
  */
 
 #include "z_en_mt_tag.h"

--- a/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.c
+++ b/src/overlays/actors/ovl_En_Neo_Reeba/z_en_neo_reeba.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_neo_reeba.c
  * Overlay: ovl_En_Neo_Reeba
- * Description: Leevers
+ * Description: (New) Leevers
  */
 
 #include "z_en_neo_reeba.h"

--- a/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
+++ b/src/overlays/actors/ovl_En_Okarina_Effect/z_en_okarina_effect.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_okarina_effect.c
  * Overlay: ovl_En_Okarina_Effect
- * Description:
+ * Description: Manages the storm created when playing Song of Storms
  */
 
 #include "z_en_okarina_effect.h"

--- a/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
+++ b/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_onpuman.c
  * Overlay: ovl_En_Onpuman
- * Description: Monkey Instrument Prompt
+ * Description: Monkey Instrument Prompt (unused)
  */
 
 #include "z_en_onpuman.h"

--- a/src/overlays/actors/ovl_En_Part/z_en_part.c
+++ b/src/overlays/actors/ovl_En_Part/z_en_part.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_part.c
  * Overlay: ovl_En_Part
- * Description:
+ * Description: Enemy body parts (spawned when dying)
  */
 
 #include "z_en_part.h"

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_rd.c
  * Overlay: ovl_En_Rd
- * Description: Dancing Redead/Gibdo
+ * Description: Redead/Gibdo (able to dance)
  */
 
 #include "z_en_rd.h"

--- a/src/overlays/actors/ovl_En_Rg/z_en_rg.c
+++ b/src/overlays/actors/ovl_En_Rg/z_en_rg.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_rg.c
  * Overlay: ovl_En_Rg
- * Description: Racetrack Goron
+ * Description: Racing Goron
  */
 
 #include "z_en_rg.h"

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_river_sound.c
  * Overlay: ovl_En_River_Sound
- * Description:
+ * Description: Various environment SFX (e.g., ocean waves, gulls, waterfall, lava, etc)
  */
 
 #include "z_en_river_sound.h"

--- a/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
+++ b/src/overlays/actors/ovl_En_River_Sound/z_en_river_sound.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_river_sound.c
  * Overlay: ovl_En_River_Sound
- * Description: Various environment SFX (e.g., ocean waves, gulls, waterfall, lava, etc)
+ * Description: Various environment Sfx (e.g., ocean waves, gulls, waterfall, lava, etc)
  */
 
 #include "z_en_river_sound.h"

--- a/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
+++ b/src/overlays/actors/ovl_En_Rsn/z_en_rsn.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_rsn.c
  * Overlay: ovl_En_Rsn
- * Description: Bomb Shop Man in the credits?
+ * Description: Bomb Shop Man in the credits
  */
 
 #include "z_en_rsn.h"

--- a/src/overlays/actors/ovl_En_Ru/z_en_ru.c
+++ b/src/overlays/actors/ovl_En_Ru/z_en_ru.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ru.c
  * Overlay: ovl_En_Ru
- * Description: Ruto
+ * Description: (OoT's Adult) Ruto (unused)
  */
 
 #include "z_en_ru.h"

--- a/src/overlays/actors/ovl_En_Ru/z_en_ru.c
+++ b/src/overlays/actors/ovl_En_Ru/z_en_ru.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ru.c
  * Overlay: ovl_En_Ru
- * Description: (OoT's Adult) Ruto (unused)
+ * Description: OoT's Adult Ruto (unused)
  */
 
 #include "z_en_ru.h"

--- a/src/overlays/actors/ovl_En_Rz/z_en_rz.c
+++ b/src/overlays/actors/ovl_En_Rz/z_en_rz.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_rz.c
  * Overlay: ovl_En_Rz
- * Description: Rosa Sister
+ * Description: Rosa Sisters, Judo (red) and Marilla (blue)
  */
 
 #include "z_en_rz.h"

--- a/src/overlays/actors/ovl_En_Scopecoin/z_en_scopecoin.c
+++ b/src/overlays/actors/ovl_En_Scopecoin/z_en_scopecoin.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_scopecoin.c
  * Overlay: ovl_En_Scopecoin
- * Description: Telescope Coin
+ * Description: Termina Field rupees visible from the telescope
  */
 
 #include "z_en_scopecoin.h"

--- a/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
+++ b/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_scopenuts.c
  * Overlay: ovl_En_Scopenuts
- * Description: Astral Observatory - Business Scrub in Telescope
+ * Description: Business Scrub that sells you a Heart Piece (viewable from Telescope)
  */
 
 #include "z_en_scopenuts.h"

--- a/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
+++ b/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_scopenuts.c
  * Overlay: ovl_En_Scopenuts
- * Description: Business Scrub that sells you a Heart Piece (viewable from Telescope)
+ * Description: Business Scrub that sells you a Heart Piece
  */
 
 #include "z_en_scopenuts.h"

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_sda.c
  * Overlay: ovl_En_Sda
- * Description:
+ * Description: Dynamic Shadow for Link
  */
 
 #include "z_en_sda.h"

--- a/src/overlays/actors/ovl_En_Sda/z_en_sda.c
+++ b/src/overlays/actors/ovl_En_Sda/z_en_sda.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_sda.c
  * Overlay: ovl_En_Sda
- * Description: Dynamic Shadow for Link
+ * Description: Dynamic Shadow for Player
  */
 
 #include "z_en_sda.h"

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_ssh.c
  * Overlay: ovl_En_Ssh
- * Description: Cursed Man
+ * Description: Cursed Man (Swamp Spider House)
  */
 
 #include "z_en_ssh.h"

--- a/src/overlays/actors/ovl_En_St/z_en_st.c
+++ b/src/overlays/actors/ovl_En_St/z_en_st.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_st.c
  * Overlay: ovl_En_St
- * Description: Skulltula
+ * Description: Skulltula (large suspended one)
  */
 
 #include "z_en_st.h"

--- a/src/overlays/actors/ovl_En_Sth2/z_en_sth2.c
+++ b/src/overlays/actors/ovl_En_Sth2/z_en_sth2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_sth2.c
  * Overlay: ovl_En_Sth2
- * Description:
+ * Description: Guy waving at the telescope in Termina Field
  */
 
 #include "z_en_sth2.h"

--- a/src/overlays/actors/ovl_En_Stream/z_en_stream.c
+++ b/src/overlays/actors/ovl_En_Stream/z_en_stream.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_stream.c
  * Overlay: ovl_En_Stream
- * Description:
+ * Description: Unused water vortex from OoT
  */
 
 #include "z_en_stream.h"

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test.c
  * Overlay: ovl_En_Test
- * Description:
+ * Description: Goron crater mark
  */
 
 #include "z_en_test.h"

--- a/src/overlays/actors/ovl_En_Test/z_en_test.c
+++ b/src/overlays/actors/ovl_En_Test/z_en_test.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test.c
  * Overlay: ovl_En_Test
- * Description: Goron crater mark
+ * Description: Various crater marks (e.g., Goron Link punch/pound, Moon's Tear crash, etc.)
  */
 
 #include "z_en_test.h"

--- a/src/overlays/actors/ovl_En_Test4/z_en_test4.c
+++ b/src/overlays/actors/ovl_En_Test4/z_en_test4.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test4.c
  * Overlay: ovl_En_Test4
- * Description: Day transition effects
+ * Description: Three-Day Timer
  */
 
 #include "z_en_test4.h"

--- a/src/overlays/actors/ovl_En_Test6/z_en_test6.c
+++ b/src/overlays/actors/ovl_En_Test6/z_en_test6.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test6.c
  * Overlay: ovl_En_Test6
- * Description:
+ * Description: Song of Time effects (Return to DoTFD, invert, skip forward)
  */
 
 #include "z_en_test6.h"

--- a/src/overlays/actors/ovl_En_Test6/z_en_test6.c
+++ b/src/overlays/actors/ovl_En_Test6/z_en_test6.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test6.c
  * Overlay: ovl_En_Test6
- * Description: Song of Time effects (Return to DoTFD, invert, skip forward)
+ * Description: Song of Time effects (Return to DotFD, invert, skip forward)
  */
 
 #include "z_en_test6.h"

--- a/src/overlays/actors/ovl_En_Test7/z_en_test7.c
+++ b/src/overlays/actors/ovl_En_Test7/z_en_test7.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_test7.c
  * Overlay: ovl_En_Test7
- * Description:
+ * Description: Soaring effects (wings, sphere, etc)
  */
 
 #include "z_en_test7.h"

--- a/src/overlays/actors/ovl_En_Torch/z_en_torch.c
+++ b/src/overlays/actors/ovl_En_Torch/z_en_torch.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_torch.c
  * Overlay: ovl_En_Torch
- * Description: Treasure chest (grotto)
+ * Description: Grotto chest spawner
  */
 
 #include "z_en_torch.h"

--- a/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
+++ b/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_trt2.c
  * Overlay: ovl_En_Trt2
- * Description:
+ * Description: Kotake outside of her shop
  */
 
 #include "z_en_trt2.h"

--- a/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
+++ b/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_trt2.c
  * Overlay: ovl_En_Trt2
- * Description: Kotake outside of her shop
+ * Description: Kotake in Southern Swamp and Woods of Mystery
  */
 
 #include "z_en_trt2.h"

--- a/src/overlays/actors/ovl_En_Wf/z_en_wf.c
+++ b/src/overlays/actors/ovl_En_Wf/z_en_wf.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_wf.c
  * Overlay: ovl_En_Wf
- * Description: Wolfos
+ * Description: Wolfos and White Wolfos
  */
 
 #include "z_en_wf.h"

--- a/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
+++ b/src/overlays/actors/ovl_En_Zl4/z_en_zl4.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_zl4.c
  * Overlay: ovl_En_Zl4
- * Description:
+ * Description: Glitched early version of Skull Kid stuck in a T-pose
  */
 
 #include "z_en_zl4.h"

--- a/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
+++ b/src/overlays/actors/ovl_Item_Etcetera/z_item_etcetera.c
@@ -1,7 +1,7 @@
 /*
  * File: z_item_etcetera.c
  * Overlay: ovl_Item_Etcetera
- * Description:
+ * Description: Leftover OoT Collectible Items (bottle, key, Fire Arrow, etc.)
  */
 
 #include "z_item_etcetera.h"

--- a/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
+++ b/src/overlays/actors/ovl_Mir_Ray/z_mir_ray.c
@@ -1,7 +1,7 @@
 /*
  * File: z_mir_ray.c
  * Overlay: ovl_Mir_Ray
- * Description: Mirror Shield Face & Light Ray
+ * Description: Reflectible light ray (unused, somewhat broken)
  */
 
 #include "z_mir_ray.h"

--- a/src/overlays/actors/ovl_Mir_Ray2/z_mir_ray2.c
+++ b/src/overlays/actors/ovl_Mir_Ray2/z_mir_ray2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_mir_ray2.c
  * Overlay: ovl_Mir_Ray2
- * Description:
+ * Description: Reflectable light ray (static beam)
  */
 
 #include "z_mir_ray2.h"

--- a/src/overlays/actors/ovl_Mir_Ray3/z_mir_ray3.c
+++ b/src/overlays/actors/ovl_Mir_Ray3/z_mir_ray3.c
@@ -1,7 +1,7 @@
 /*
  * File: z_mir_ray3.c
  * Overlay: ovl_Mir_Ray3
- * Description:
+ * Description: Mirror shield reflection and glow
  */
 
 #include "z_mir_ray3.h"

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_bean.c
  * Overlay: ovl_Obj_Bean
- * Description: Floating Bean Plant / Dirt Patch
+ * Description: Floating Bean Plant / Soft Soil
  */
 
 #include "z_obj_bean.h"

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_blockstop.c
  * Overlay: ovl_Obj_Blockstop
- * Description:
+ * Description: Signals that a block has fallen in a hole and can't be moved
  */
 
 #include "z_obj_blockstop.h"

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_blockstop.c
  * Overlay: ovl_Obj_Blockstop
- * Description: Signals that a block has fallen in a hole and can't be moved
+ * Description: Snowhead Temple - plays a cutscene when a block falls into a hole
  */
 
 #include "z_obj_blockstop.h"

--- a/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
+++ b/src/overlays/actors/ovl_Obj_Blockstop/z_obj_blockstop.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_blockstop.c
  * Overlay: ovl_Obj_Blockstop
- * Description: Snowhead Temple - plays a cutscene when a block falls into a hole
+ * Description: Push Block Trigger - Blockstop switch triggered by pushblock (Snowhead)
  */
 
 #include "z_obj_blockstop.h"

--- a/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
+++ b/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_chikuwa.c
  * Overlay: ovl_Obj_Chikuwa
- * Description: Falling Block Row
+ * Description: Falling row of blocks
  */
 
 #include "z_obj_chikuwa.h"

--- a/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
+++ b/src/overlays/actors/ovl_Obj_Chikuwa/z_obj_chikuwa.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_chikuwa.c
  * Overlay: ovl_Obj_Chikuwa
- * Description: Falling row of blocks
+ * Description: Falling row of blocks (unused)
  */
 
 #include "z_obj_chikuwa.h"

--- a/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
+++ b/src/overlays/actors/ovl_Obj_Comb/z_obj_comb.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_comb.c
  * Overlay: ovl_Obj_Comb
- * Description: Honeycomb
+ * Description: Beehive
  */
 
 #include "z_obj_comb.h"

--- a/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.c
+++ b/src/overlays/actors/ovl_Obj_Danpeilift/z_obj_danpeilift.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_danpeilift.c
  * Overlay: ovl_Obj_Danpeilift
- * Description: Deku Shrine & Snowhead Temple Elevator
+ * Description: Deku Shrine & Snowhead Temple floating blocks
  */
 
 #include "z_obj_danpeilift.h"

--- a/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
+++ b/src/overlays/actors/ovl_Obj_Entotu/z_obj_entotu.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_entotu.c
  * Overlay: ovl_Obj_Entotu
- * Description: Clock tower chimney Expelling Smoke
+ * Description: Clock Town Smoking Chimney
  */
 
 #include "z_obj_entotu.h"

--- a/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
+++ b/src/overlays/actors/ovl_Obj_Funen/z_obj_funen.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_funen.c
  * Overlay: ovl_Obj_Funen
- * Description:
+ * Description: Unused(?) Stone Tower smoke
  */
 
 #include "z_obj_funen.h"

--- a/src/overlays/actors/ovl_Obj_Ghaka/z_obj_ghaka.c
+++ b/src/overlays/actors/ovl_Obj_Ghaka/z_obj_ghaka.c
@@ -1,5 +1,5 @@
 /*
- * File z_obj_ghaka.c
+ * File: z_obj_ghaka.c
  * Overlay: ovl_Obj_Ghaka
  * Description: Darmani's Gravestone
  */

--- a/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
+++ b/src/overlays/actors/ovl_Obj_Grass/z_obj_grass.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_grass.c
  * Overlay: ovl_Obj_Grass
- * Description:
+ * Description: "Master" instance of grass for unit spawned by Obj_Grass_Unit
  */
 
 #include "z_obj_grass.h"

--- a/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
+++ b/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_grass_carry.c
  * Overlay: ovl_Obj_Grass_Carry
- * Description:
+ * Description: Grass that the player is holding (spawned by Obj_Grass_Unit)
  */
 
 #include "z_obj_grass_carry.h"

--- a/src/overlays/actors/ovl_Obj_Grass_Unit/z_obj_grass_unit.c
+++ b/src/overlays/actors/ovl_Obj_Grass_Unit/z_obj_grass_unit.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_grass_unit.c
  * Overlay: ovl_Obj_Grass_Unit
- * Description:
+ * Description: Spawner for circular patch of grass
  */
 
 #include "z_obj_grass_unit.h"

--- a/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
+++ b/src/overlays/actors/ovl_Obj_Hamishi/z_obj_hamishi.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_hamishi.c
  * Overlay: ovl_Obj_Hamishi
- * Description: Hammer Stone
+ * Description: Bronze boulder
  */
 
 #include "z_obj_hamishi.h"

--- a/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_hugebombiwa.c
  * Overlay: ovl_Obj_Hugebombiwa
- * Description: Boulder Blocking Goron Racetrack
+ * Description: Boulder Blocking Goron Racetrack/Milk Road
  */
 
 #include "z_obj_hugebombiwa.h"

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_makekinsuta.c
  * Overlay: ovl_Obj_Makekinsuta
- * Description: Dirt Patch with Skulltula hiding in it
+ * Description: Soft soil with Skulltula hiding in it
  */
 
 #include "z_obj_makekinsuta.h"

--- a/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
+++ b/src/overlays/actors/ovl_Obj_Makekinsuta/z_obj_makekinsuta.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_makekinsuta.c
  * Overlay: ovl_Obj_Makekinsuta
- * Description: Soft soil with Skulltula hiding in it
+ * Description: Swamp Spider House - Soft soil with Skulltula hiding in it
  */
 
 #include "z_obj_makekinsuta.h"

--- a/src/overlays/actors/ovl_Obj_Moon_Stone/z_obj_moon_stone.c
+++ b/src/overlays/actors/ovl_Obj_Moon_Stone/z_obj_moon_stone.c
@@ -1,5 +1,5 @@
 /*
- * File z_obj_moon_stone.c
+ * File: z_obj_moon_stone.c
  * Overlay: ovl_Obj_Moon_Stone
  * Description: Moon's Tear
  */

--- a/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
+++ b/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_mu_pict.c
  * Overlay: ovl_Obj_Mu_Pict
- * Description:
+ * Description: Garo/Gibdo poster in the Music Box House
  */
 
 #include "z_obj_mu_pict.h"

--- a/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
+++ b/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_mu_pict.c
  * Overlay: ovl_Obj_Mu_Pict
- * Description: Garo/Gibdo poster in the Music Box House
+ * Description: Handles dialogue for checking the Garo/Gibdo poster in the Music Box House
  */
 
 #include "z_obj_mu_pict.h"

--- a/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.c
+++ b/src/overlays/actors/ovl_Obj_Ocarinalift/z_obj_ocarinalift.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_ocarinalift.c
  * Overlay: ovl_Obj_Ocarinalift
- * Description: Elevator With Triforce Texture
+ * Description: Elevator With Triforce Texture (unused?)
  */
 
 #include "z_obj_ocarinalift.h"

--- a/src/overlays/actors/ovl_Obj_Shutter/z_obj_shutter.c
+++ b/src/overlays/actors/ovl_Obj_Shutter/z_obj_shutter.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_shutter.c
  * Overlay: ovl_Obj_Shutter
- * Description:
+ * Description: Unused West Clock Town bank closing shutter
  */
 
 #include "z_obj_shutter.h"

--- a/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.c
+++ b/src/overlays/actors/ovl_Obj_Spinyroll/z_obj_spinyroll.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_spinyroll.c
  * Overlay: ovl_Obj_Spinyroll
- * Description: Spike-Covered Log
+ * Description: Horizontal Spike-Covered Log
  */
 
 #include "z_obj_spinyroll.h"

--- a/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.c
+++ b/src/overlays/actors/ovl_Obj_Swprize/z_obj_swprize.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_swprize.c
  * Overlay: ovl_Obj_Swprize
- * Description: Spawner for dirt square prize?
+ * Description: Spawns item drop from soft soil
  */
 
 #include "z_obj_swprize.h"

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_tokeidai.c
  * Overlay: ovl_Obj_Tokeidai
- * Description: Clock Face
+ * Description: Components of the Clock Tower (gears, clock face, counterweight, etc).
  */
 
 #include "z_obj_tokeidai.h"

--- a/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
+++ b/src/overlays/actors/ovl_Obj_Toudai/z_obj_toudai.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_toudai.c
  * Overlay: ovl_Obj_Toudai
- * Description: Clock Tower Spotlight
+ * Description: Unused early Clock Tower Spotlight
  */
 
 #include "z_obj_toudai.h"

--- a/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
+++ b/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_vspinyroll.c
  * Overlay: ovl_Obj_Vspinyroll
- * Description: Spiked rollers
+ * Description: Vertical Spiked rollers
  */
 
 #include "z_obj_vspinyroll.h"

--- a/src/overlays/actors/ovl_Obj_Y2lift/z_obj_y2lift.c
+++ b/src/overlays/actors/ovl_Obj_Y2lift/z_obj_y2lift.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_y2lift.c
  * Overlay: ovl_Obj_Y2lift
- * Description:
+ * Description: Unused elevator platform
  */
 
 #include "z_obj_y2lift.h"

--- a/src/overlays/actors/ovl_Obj_Y2shutter/z_obj_y2shutter.c
+++ b/src/overlays/actors/ovl_Obj_Y2shutter/z_obj_y2shutter.c
@@ -1,7 +1,7 @@
 /*
  * File: z_obj_y2shutter.c
  * Overlay: ovl_Obj_Y2shutter
- * Description:
+ * Description: Pirates' Fortress sliding grate
  */
 
 #include "z_obj_y2shutter.h"

--- a/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
+++ b/src/overlays/actors/ovl_Object_Kankyo/z_object_kankyo.c
@@ -1,7 +1,7 @@
 /*
  * File: z_object_kankyo.c
  * Overlay: ovl_Object_Kankyo
- * Description:
+ * Description: Snow, rain in Skull Kid backstory cutscene, and bubbles deep in Pinnacle Rock
  */
 
 #include "z_object_kankyo.h"

--- a/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
+++ b/src/overlays/actors/ovl_Oceff_Spot/z_oceff_spot.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_spot.c
  * Overlay: ovl_Oceff_Spot
- * Description:
+ * Description: Sun's Song Ocarina Effect
  */
 
 #include "z_oceff_spot.h"

--- a/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
+++ b/src/overlays/actors/ovl_Oceff_Storm/z_oceff_storm.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_storm.c
  * Overlay: ovl_Oceff_Storm
- * Description:
+ * Description: Song of Storms Ocarina Effect
  */
 
 #include "z_oceff_storm.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe.c
  * Overlay: ovl_Oceff_Wipe
- * Description:
+ * Description: Song of Time Ocarina Effect
  */
 
 #include "z_oceff_wipe.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe2.c
  * Overlay: ovl_Oceff_Wipe2
- * Description:
+ * Description: Epona's Song Ocarina Effect
  */
 
 #include "z_oceff_wipe2.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe3.c
  * Overlay: ovl_Oceff_Wipe3
- * Description:
+ * Description: Unused OoT Saria's Song Ocarina Effect
  */
 
 #include "z_oceff_wipe3.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe4/z_oceff_wipe4.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe4.c
  * Overlay: ovl_Oceff_Wipe4
- * Description:
+ * Description: Scarecrow's Song Ocarina Effect
  */
 
 #include "z_oceff_wipe4.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe5/z_oceff_wipe5.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe5.c
  * Overlay: ovl_Oceff_Wipe5
- * Description:
+ * Description: Sonata/Lullaby/Bossa Nova/Elegy/Oath Ocarina Effect
  */
 
 #include "z_oceff_wipe5.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe6/z_oceff_wipe6.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe6.c
  * Overlay: ovl_Oceff_Wipe6
- * Description:
+ * Description: Song of Soaring Ocarina Effect
  */
 
 #include "z_oceff_wipe6.h"

--- a/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
+++ b/src/overlays/actors/ovl_Oceff_Wipe7/z_oceff_wipe7.c
@@ -1,7 +1,7 @@
 /*
  * File: z_oceff_wipe7.c
  * Overlay: ovl_Oceff_Wipe7
- * Description:
+ * Description: Song of Healing Ocarina Effect
  */
 
 #include "z_oceff_wipe7.h"


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
This PR does two things:
1. Updates actor descriptions to match what is currently on the spreadsheet; we've done a lot of research since my first PR got merged.
2. Fix an issue where a few actors were missing a colon in their comment

Note to maintainers: don't merge this until @EllipticEllipsis approves.