### PR TITLE
ovl_En_Talk OK

### DIFF
--- a/spec
+++ b/spec
@@ -4911,8 +4911,7 @@ beginseg
     name "ovl_En_Talk"
     compress
     include "build/src/overlays/actors/ovl_En_Talk/z_en_talk.o"
-    include "build/data/ovl_En_Talk/ovl_En_Talk.data.o"
-    include "build/data/ovl_En_Talk/ovl_En_Talk.reloc.o"
+    include "build/src/overlays/actors/ovl_En_Talk/ovl_En_Talk_reloc.o"
 endseg
 
 beginseg

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -47,7 +47,9 @@ void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
     this->actor.textId = (this->actor.params & 0x3F) + 0x1C00;
 }
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/EnTalk_Destroy.s")
+void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {
+    EnTalk* this = THIS;
+}
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/func_80BDE058.s")
 

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -44,17 +44,16 @@ void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    EnTalk* this = THIS;
 }
 
 void func_80BDE058(EnTalk* this, GlobalContext* globalCtx) {
-    if (func_800B867C(&this->actor, globalCtx) != 0) {
+    if (func_800B867C(&this->actor, globalCtx)) {
         this->actionFunc = func_80BDE090;
     }
 }
 
 void func_80BDE090(EnTalk* this, GlobalContext* globalCtx) {
-    if (func_800B84D0(&this->actor, globalCtx) != 0) {
+    if (func_800B84D0(&this->actor, globalCtx)) {
         this->actionFunc = func_80BDE058;
         return;
     }
@@ -67,5 +66,6 @@ void func_80BDE090(EnTalk* this, GlobalContext* globalCtx) {
 
 void EnTalk_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;
+    
     this->actionFunc(this, globalCtx);
 }

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -51,8 +51,15 @@ void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;
 }
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/func_80BDE058.s")
+void func_80BDE058(EnTalk* this, GlobalContext* globalCtx) {
+    if (func_800B867C(&this->actor, globalCtx) != 0) {
+        this->actionFunc = func_80BDE090;
+    }
+}
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/func_80BDE090.s")
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/EnTalk_Update.s")
+void EnTalk_Update(Actor* thisx, GlobalContext* globalCtx) {
+    EnTalk* this = THIS;
+    this->actionFunc(this, globalCtx);
+}

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -57,7 +57,17 @@ void func_80BDE058(EnTalk* this, GlobalContext* globalCtx) {
     }
 }
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/func_80BDE090.s")
+void func_80BDE090(EnTalk* this, GlobalContext* globalCtx) {
+    if (func_800B84D0(&this->actor, globalCtx) != 0) {
+        this->actionFunc = func_80BDE058;
+        return;
+    }
+
+    if ((this->actor.xzDistToPlayer < 40.0f && Actor_IsLinkFacingActor(&this->actor, 0x3000, globalCtx) != 0) ||
+        this->actor.isTargeted) {
+        func_800B8614(&this->actor, globalCtx, 120.0f);
+    }
+}
 
 void EnTalk_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -66,6 +66,6 @@ void func_80BDE090(EnTalk* this, GlobalContext* globalCtx) {
 
 void EnTalk_Update(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;
-    
+
     this->actionFunc(this, globalCtx);
 }

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -13,11 +13,9 @@
 void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx);
 void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx);
 void EnTalk_Update(Actor* thisx, GlobalContext* globalCtx);
-
 void func_80BDE058(EnTalk* this, GlobalContext* globalCtx);
 void func_80BDE090(EnTalk* this, GlobalContext* globalCtx);
 
-#if 0
 const ActorInit En_Talk_InitVars = {
     ACTOR_EN_TALK,
     ACTORCAT_ITEMACTION,
@@ -30,21 +28,19 @@ const ActorInit En_Talk_InitVars = {
     (ActorFunc)NULL,
 };
 
-#endif
-
 void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;
-    s8 temp_v0;
+    s8 targetMode;
 
-    temp_v0 = this->actor.home.rot.x - 0x1;
+    targetMode = this->actor.home.rot.x - 0x1;
 
-    if (temp_v0 >= 0x0 && temp_v0 < 0x7) {
-        this->actor.targetMode = temp_v0;
+    if (targetMode >= 0x0 && targetMode < 0x7) {
+        this->actor.targetMode = targetMode;
     }
 
     Actor_SetScale(&this->actor, 1.0f);
     this->actionFunc = func_80BDE090;
-    this->actor.textId = (this->actor.params & 0x3F) + 0x1C00;
+    this->actor.textId = GET_TEXT_ID(this);
 }
 
 void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {
@@ -63,7 +59,7 @@ void func_80BDE090(EnTalk* this, GlobalContext* globalCtx) {
         return;
     }
 
-    if ((this->actor.xzDistToPlayer < 40.0f && Actor_IsLinkFacingActor(&this->actor, 0x3000, globalCtx) != 0) ||
+    if ((this->actor.xzDistToPlayer < 40.0f && Actor_IsLinkFacingActor(&this->actor, 0x3000, globalCtx)) ||
         this->actor.isTargeted) {
         func_800B8614(&this->actor, globalCtx, 120.0f);
     }

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -32,7 +32,20 @@ const ActorInit En_Talk_InitVars = {
 
 #endif
 
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/EnTalk_Init.s")
+void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
+    EnTalk* this = THIS;
+    s8 temp_v0;
+
+    temp_v0 = this->actor.home.rot.x - 0x1;
+
+    if (temp_v0 >= 0x0 && temp_v0 < 0x7) {
+        this->actor.targetMode = temp_v0;
+    }
+
+    Actor_SetScale(&this->actor, 1.0f);
+    this->actionFunc = func_80BDE090;
+    this->actor.textId = (this->actor.params & 0x3F) + 0x1C00;
+}
 
 #pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Talk/EnTalk_Destroy.s")
 

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -40,7 +40,7 @@ void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     Actor_SetScale(&this->actor, 1.0f);
     this->actionFunc = func_80BDE090;
-    this->actor.textId = GET_TEXT_ID(this);
+    this->actor.textId = EN_TALK_GET_TEXT_ID(this);
 }
 
 void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -30,17 +30,15 @@ const ActorInit En_Talk_InitVars = {
 
 void EnTalk_Init(Actor* thisx, GlobalContext* globalCtx) {
     EnTalk* this = THIS;
-    s8 targetMode;
+    s8 targetMode = this->actor.home.rot.x - 0x1;
 
-    targetMode = this->actor.home.rot.x - 0x1;
-
-    if (targetMode >= 0x0 && targetMode < 0x7) {
+    if (targetMode >= 0 && targetMode < 7) {
         this->actor.targetMode = targetMode;
     }
 
     Actor_SetScale(&this->actor, 1.0f);
     this->actionFunc = func_80BDE090;
-    this->actor.textId = EN_TALK_GET_TEXT_ID(this);
+    this->actor.textId = ENTALK_GET_TEXT_ID(&this->actor);
 }
 
 void EnTalk_Destroy(Actor* thisx, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.h
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.h
@@ -3,6 +3,8 @@
 
 #include "global.h"
 
+#define ENTALK_GET_TEXT_ID(thisx) (((thisx)->params & 0x3F) + 0x1C00)
+
 struct EnTalk;
 
 typedef void (*EnTalkActionFunc)(struct EnTalk*, GlobalContext*);
@@ -13,7 +15,5 @@ typedef struct EnTalk {
 } EnTalk; // size = 0x148
 
 extern const ActorInit En_Talk_InitVars;
-
-#define EN_TALK_GET_TEXT_ID(this) ((this->actor.params & 0x3F) + 0x1C00)
 
 #endif // Z_EN_TALK_H

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.h
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.h
@@ -14,4 +14,6 @@ typedef struct EnTalk {
 
 extern const ActorInit En_Talk_InitVars;
 
+#define GET_TEXT_ID(this) ((this->actor.params & 0x3F) + 0x1C00)
+
 #endif // Z_EN_TALK_H

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.h
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.h
@@ -14,6 +14,6 @@ typedef struct EnTalk {
 
 extern const ActorInit En_Talk_InitVars;
 
-#define GET_TEXT_ID(this) ((this->actor.params & 0x3F) + 0x1C00)
+#define EN_TALK_GET_TEXT_ID(this) ((this->actor.params & 0x3F) + 0x1C00)
 
 #endif // Z_EN_TALK_H


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
Not too much to go by for naming the two additional functions, I'm assuming `func_80BDE090` has to do with displaying the reticule but I'm not sure what the context is for switching between the two (maybe when you're reading the associated text?)
