### PR TITLE
Three Makefile tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,10 @@ TEXTURE_FILES_OUT := $(foreach f,$(TEXTURE_FILES_PNG:.png=.inc.c),build/$f) \
 C_FILES       := $(foreach dir,$(SRC_DIRS) $(ASSET_BIN_DIRS),$(wildcard $(dir)/*.c))
 S_FILES       := $(shell grep -F "build/asm" spec | sed 's/.*build\/// ; s/\.o\".*/.s/') \
                  $(shell grep -F "build/data" spec | sed 's/.*build\/// ; s/\.o\".*/.s/')
+BASEROM_FILES := $(shell grep -F "build/baserom" spec | sed 's/.*build\/// ; s/\.o\".*//')
 O_FILES       := $(foreach f,$(S_FILES:.s=.o),build/$f) \
                  $(foreach f,$(C_FILES:.c=.o),build/$f) \
-                 $(foreach f,$(wildcard baserom/*),build/$f.o)
+                 $(foreach f,$(BASEROM_FILES),build/$f.o)
 
 # Automatic dependency files
 # (Only asm_processor dependencies are handled for now)
@@ -165,6 +166,8 @@ build/src/libultra/flash/%.o: OPTFLAGS := -g
 build/src/libultra/flash/%.o: MIPS_VERSION := -mips1
 
 build/src/code/audio/%.o: OPTFLAGS := -O2
+
+build/assets/%.o: OPTFLAGS := 
 
 # file flags
 build/src/boot_O2_g3/fault.o: CFLAGS += -trapuv
@@ -283,7 +286,7 @@ build/baserom/%.o: baserom/%
 	$(OBJCOPY) -I binary -O elf32-big $< $@
 
 build/data/%.o: data/%.s
-	iconv --from UTF-8 --to EUC-JP $< | $(AS) $(ASFLAGS) -o $@
+	$(AS) $(ASFLAGS) $< -o $@
 
 build/src/overlays/%.o: src/overlays/%.c
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Made a few efficiency changes to the Makefile:
- Only copy the baserom files that are actually needed (58 instead of 1532).
- Remove use of `iconv` on the data before it's assembled: there is no data that needs this any more.
- Remove the optimisation flags from the assets: these won't do anything to data, but `-g3` at least will needlessly bloat the symbol tables in the files and increase linking time.

I found this saved approximately 40 seconds over building on master:

master:
```
real    11m42.878s
user    9m39.837s
sys     1m40.324s
```
With these three changes:
```
real    11m1.702s
user    9m4.837s
sys     1m31.141s
```
(tested under similar conditions, dropping caches between, so I think this effect is real.)