### PR TITLE
Name textures in object_mag

### DIFF
--- a/assets/xml/objects/object_mag.xml
+++ b/assets/xml/objects/object_mag.xml
@@ -1,28 +1,30 @@
 ﻿<Root>
     <File Name="object_mag" Segment="6">
-        <Texture Name="object_mag_Tex_000000" OutName="tex_000000" Format="rgba32" Width="144" Height="64" Offset="0x0" />
-        <Texture Name="object_mag_Tex_009000" OutName="tex_009000" Format="i8" Width="104" Height="16" Offset="0x9000" />
-        <Texture Name="object_mag_Tex_009680" OutName="tex_009680" Format="i8" Width="104" Height="16" Offset="0x9680" />
-        <Texture Name="object_mag_Tex_009D00" OutName="tex_009D00" Format="i8" Width="72" Height="8" Offset="0x9D00" />
-        <Texture Name="object_mag_Tex_009F40" OutName="tex_009F40" Format="i4" Width="64" Height="64" Offset="0x9F40" />
-        <Texture Name="object_mag_Tex_00A740" OutName="tex_00A740" Format="i4" Width="64" Height="64" Offset="0xA740" />
-        <Texture Name="object_mag_Tex_00AF40" OutName="tex_00AF40" Format="i4" Width="64" Height="64" Offset="0xAF40" />
-        <Texture Name="object_mag_Tex_00B740" OutName="tex_00B740" Format="i4" Width="64" Height="64" Offset="0xB740" />
-        <Texture Name="object_mag_Tex_00BF40" OutName="tex_00BF40" Format="i4" Width="64" Height="64" Offset="0xBF40" />
-        <Texture Name="object_mag_Tex_00C740" OutName="tex_00C740" Format="i4" Width="64" Height="64" Offset="0xC740" />
-        <Texture Name="object_mag_Tex_00CF40" OutName="tex_00CF40" Format="i4" Width="64" Height="64" Offset="0xCF40" />
-        <Texture Name="object_mag_Tex_00D740" OutName="tex_00D740" Format="i4" Width="64" Height="64" Offset="0xD740" />
-        <Texture Name="object_mag_Tex_00DF40" OutName="tex_00DF40" Format="i4" Width="64" Height="64" Offset="0xDF40" />
-        <Texture Name="object_mag_Tex_00E740" OutName="tex_00E740" Format="i4" Width="64" Height="64" Offset="0xE740" />
-        <Texture Name="object_mag_Tex_00EF40" OutName="tex_00EF40" Format="i4" Width="64" Height="64" Offset="0xEF40" />
-        <Texture Name="object_mag_Tex_00F740" OutName="tex_00F740" Format="i4" Width="64" Height="64" Offset="0xF740" />
-        <Texture Name="object_mag_Tex_00FF40" OutName="tex_00FF40" Format="i8" Width="32" Height="32" Offset="0xFF40" />
-        <Texture Name="object_mag_Tex_010340" OutName="tex_010340" Format="i8" Width="32" Height="32" Offset="0x10340" />
-        <Texture Name="object_mag_Tex_010740" OutName="tex_010740" Format="i8" Width="32" Height="32" Offset="0x10740" />
-        <Texture Name="object_mag_Tex_010B40" OutName="tex_010B40" Format="i8" Width="32" Height="32" Offset="0x10B40" />
-        <Texture Name="object_mag_Tex_010F40" OutName="tex_010F40" Format="ia8" Width="128" Height="16" Offset="0x10F40" />
-        <Texture Name="object_mag_Tex_011740" OutName="tex_011740" Format="i4" Width="256" Height="9" Offset="0x11740" />
-        <Texture Name="object_mag_Tex_011BC0" OutName="tex_011BC0" Format="i4" Width="144" Height="9" Offset="0x11BC0" />
-        <Texture Name="object_mag_Tex_011E48" OutName="tex_011E48" Format="rgba32" Width="128" Height="112" Offset="0x11E48" />
+		<Texture Name="gTitleScreenZeldaLogoTex" OutName="title_screen_zelda_logo" Format="rgba32" Width="144" Height="64" Offset="0x0"/>
+		<Texture Name="gTitleScreenMajorasMaskSubtitleTex" OutName="title_screen_majoras_mask_subtitle" Format="i8" Width="104" Height="16" Offset="0x9000"/>
+		<Texture Name="gTitleScreenMajorasMaskSubtitleMaskTex" OutName="title_screen_majoras_mask_subtitle_mask" Format="i8" Width="104" Height="16" Offset="0x9680"/><!-- Masking the flame effect -->
+		<Texture Name="gTitleScreenTheLegendOfTextTex" OutName="title_screen_the_legend_of_text" Format="i8" Width="72" Height="8" Offset="0x9D00"/>
+    
+		<Texture Name="gTitleScreenMaskGlowDim00Tex" OutName="title_screen_mask_glow_dim_0_0" Format="i4" Width="64" Height="64" Offset="0x9F40"/>
+		<Texture Name="gTitleScreenMaskGlowDim01Tex" OutName="title_screen_mask_glow_dim_0_1" Format="i4" Width="64" Height="64" Offset="0xA740"/>
+		<Texture Name="gTitleScreenMaskGlowDim10Tex" OutName="title_screen_mask_glow_dim_1_0" Format="i4" Width="64" Height="64" Offset="0xAF40"/>
+		<Texture Name="gTitleScreenMaskGlowDim11Tex" OutName="title_screen_mask_glow_dim_1_1" Format="i4" Width="64" Height="64" Offset="0xB740"/>
+		<Texture Name="gTitleScreenZeldaGlow0Tex" OutName="title_screen_zelda_glow_0" Format="i4" Width="64" Height="64" Offset="0xBF40"/>
+		<Texture Name="gTitleScreenZeldaGlow1Tex" OutName="title_screen_zelda_glow_1" Format="i4" Width="64" Height="64" Offset="0xC740"/>
+		<Texture Name="gTitleScreenMaskGlowBright00Tex" OutName="title_screen_mask_glow_bright_0_0" Format="i4" Width="64" Height="64" Offset="0xCF40"/>
+		<Texture Name="gTitleScreenMaskGlowBright01Tex" OutName="title_screen_mask_glow_bright_0_1" Format="i4" Width="64" Height="64" Offset="0xD740"/>
+		<Texture Name="gTitleScreenMaskGlowBright10Tex" OutName="title_screen_mask_glow_bright_1_0" Format="i4" Width="64" Height="64" Offset="0xDF40"/>
+		<Texture Name="gTitleScreenMaskGlowBright11Tex" OutName="title_screen_mask_glow_bright_1_1" Format="i4" Width="64" Height="64" Offset="0xE740"/>
+		<Texture Name="gTitleScreenGlowRight0Tex" OutName="title_screen_glow_right_0" Format="i4" Width="64" Height="128" Offset="0xEF40"/>
+		<Texture Name="gTitleScreenGlowRight1Tex" OutName="title_screen_glow_right_1" Format="i4" Width="64" Height="128" Offset="0xF740"/>
+		<Texture Name="gTitleScreenFlame0Tex" OutName="title_screen_flame_0" Format="i8" Width="32" Height="32" Offset="0xFF40"/>
+		<Texture Name="gTitleScreenFlame1Tex" OutName="title_screen_flame_1" Format="i8" Width="32" Height="32" Offset="0x10340"/>
+		<Texture Name="gTitleScreenFlame2Tex" OutName="title_screen_flame_2" Format="i8" Width="32" Height="32" Offset="0x10740"/>
+		<Texture Name="gTitleScreenFlame3Tex" OutName="title_screen_flame_3" Format="i8" Width="32" Height="32" Offset="0x10B40"/>
+
+		<Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="64" Height="64" Offset="0x10F40"/>
+		<Texture Name="gTitleScreenControllerNotConnectedTextTex" OutName="title_screen_controller_not_connected_text" Format="i4" Width="256" Height="9" Offset="0x11740"/>
+		<Texture Name="gTitleScreenInsertControllerTextTex" OutName="title_screen_insert_controller_text" Format="i4" Width="144" Height="9" Offset="0x11BC0"/>
+		<Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="256" Height="256" Offset="0x11E48"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_mag.xml
+++ b/assets/xml/objects/object_mag.xml
@@ -1,30 +1,30 @@
 ﻿<Root>
     <File Name="object_mag" Segment="6">
-		<Texture Name="gTitleScreenZeldaLogoTex" OutName="title_screen_zelda_logo" Format="rgba32" Width="144" Height="64" Offset="0x0"/>
-		<Texture Name="gTitleScreenMajorasMaskSubtitleTex" OutName="title_screen_majoras_mask_subtitle" Format="i8" Width="104" Height="16" Offset="0x9000"/>
-		<Texture Name="gTitleScreenMajorasMaskSubtitleMaskTex" OutName="title_screen_majoras_mask_subtitle_mask" Format="i8" Width="104" Height="16" Offset="0x9680"/><!-- Masking the flame effect -->
-		<Texture Name="gTitleScreenTheLegendOfTextTex" OutName="title_screen_the_legend_of_text" Format="i8" Width="72" Height="8" Offset="0x9D00"/>
+        <Texture Name="gTitleScreenZeldaLogoTex" OutName="title_screen_zelda_logo" Format="rgba32" Width="144" Height="64" Offset="0x0"/>
+        <Texture Name="gTitleScreenMajorasMaskSubtitleTex" OutName="title_screen_majoras_mask_subtitle" Format="i8" Width="104" Height="16" Offset="0x9000"/>
+        <Texture Name="gTitleScreenMajorasMaskSubtitleMaskTex" OutName="title_screen_majoras_mask_subtitle_mask" Format="i8" Width="104" Height="16" Offset="0x9680"/><!-- Masking the flame effect -->
+        <Texture Name="gTitleScreenTheLegendOfTextTex" OutName="title_screen_the_legend_of_text" Format="i8" Width="72" Height="8" Offset="0x9D00"/>
     
-		<Texture Name="gTitleScreenMaskGlowDim00Tex" OutName="title_screen_mask_glow_dim_0_0" Format="i4" Width="64" Height="64" Offset="0x9F40"/>
-		<Texture Name="gTitleScreenMaskGlowDim01Tex" OutName="title_screen_mask_glow_dim_0_1" Format="i4" Width="64" Height="64" Offset="0xA740"/>
-		<Texture Name="gTitleScreenMaskGlowDim10Tex" OutName="title_screen_mask_glow_dim_1_0" Format="i4" Width="64" Height="64" Offset="0xAF40"/>
-		<Texture Name="gTitleScreenMaskGlowDim11Tex" OutName="title_screen_mask_glow_dim_1_1" Format="i4" Width="64" Height="64" Offset="0xB740"/>
-		<Texture Name="gTitleScreenZeldaGlow0Tex" OutName="title_screen_zelda_glow_0" Format="i4" Width="64" Height="64" Offset="0xBF40"/>
-		<Texture Name="gTitleScreenZeldaGlow1Tex" OutName="title_screen_zelda_glow_1" Format="i4" Width="64" Height="64" Offset="0xC740"/>
-		<Texture Name="gTitleScreenMaskGlowBright00Tex" OutName="title_screen_mask_glow_bright_0_0" Format="i4" Width="64" Height="64" Offset="0xCF40"/>
-		<Texture Name="gTitleScreenMaskGlowBright01Tex" OutName="title_screen_mask_glow_bright_0_1" Format="i4" Width="64" Height="64" Offset="0xD740"/>
-		<Texture Name="gTitleScreenMaskGlowBright10Tex" OutName="title_screen_mask_glow_bright_1_0" Format="i4" Width="64" Height="64" Offset="0xDF40"/>
-		<Texture Name="gTitleScreenMaskGlowBright11Tex" OutName="title_screen_mask_glow_bright_1_1" Format="i4" Width="64" Height="64" Offset="0xE740"/>
-		<Texture Name="gTitleScreenGlowRight0Tex" OutName="title_screen_glow_right_0" Format="i4" Width="64" Height="64" Offset="0xEF40"/>
-		<Texture Name="gTitleScreenGlowRight1Tex" OutName="title_screen_glow_right_1" Format="i4" Width="64" Height="64" Offset="0xF740"/>
-		<Texture Name="gTitleScreenFlame0Tex" OutName="title_screen_flame_0" Format="i8" Width="32" Height="32" Offset="0xFF40"/>
-		<Texture Name="gTitleScreenFlame1Tex" OutName="title_screen_flame_1" Format="i8" Width="32" Height="32" Offset="0x10340"/>
-		<Texture Name="gTitleScreenFlame2Tex" OutName="title_screen_flame_2" Format="i8" Width="32" Height="32" Offset="0x10740"/>
-		<Texture Name="gTitleScreenFlame3Tex" OutName="title_screen_flame_3" Format="i8" Width="32" Height="32" Offset="0x10B40"/>
+        <Texture Name="gTitleScreenMaskGlowDim00Tex" OutName="title_screen_mask_glow_dim_0_0" Format="i4" Width="64" Height="64" Offset="0x9F40"/>
+        <Texture Name="gTitleScreenMaskGlowDim01Tex" OutName="title_screen_mask_glow_dim_0_1" Format="i4" Width="64" Height="64" Offset="0xA740"/>
+        <Texture Name="gTitleScreenMaskGlowDim10Tex" OutName="title_screen_mask_glow_dim_1_0" Format="i4" Width="64" Height="64" Offset="0xAF40"/>
+        <Texture Name="gTitleScreenMaskGlowDim11Tex" OutName="title_screen_mask_glow_dim_1_1" Format="i4" Width="64" Height="64" Offset="0xB740"/>
+        <Texture Name="gTitleScreenZeldaGlow0Tex" OutName="title_screen_zelda_glow_0" Format="i4" Width="64" Height="64" Offset="0xBF40"/>
+        <Texture Name="gTitleScreenZeldaGlow1Tex" OutName="title_screen_zelda_glow_1" Format="i4" Width="64" Height="64" Offset="0xC740"/>
+        <Texture Name="gTitleScreenMaskGlowBright00Tex" OutName="title_screen_mask_glow_bright_0_0" Format="i4" Width="64" Height="64" Offset="0xCF40"/>
+        <Texture Name="gTitleScreenMaskGlowBright01Tex" OutName="title_screen_mask_glow_bright_0_1" Format="i4" Width="64" Height="64" Offset="0xD740"/>
+        <Texture Name="gTitleScreenMaskGlowBright10Tex" OutName="title_screen_mask_glow_bright_1_0" Format="i4" Width="64" Height="64" Offset="0xDF40"/>
+        <Texture Name="gTitleScreenMaskGlowBright11Tex" OutName="title_screen_mask_glow_bright_1_1" Format="i4" Width="64" Height="64" Offset="0xE740"/>
+        <Texture Name="gTitleScreenGlowRight0Tex" OutName="title_screen_glow_right_0" Format="i4" Width="64" Height="64" Offset="0xEF40"/>
+        <Texture Name="gTitleScreenGlowRight1Tex" OutName="title_screen_glow_right_1" Format="i4" Width="64" Height="64" Offset="0xF740"/>
+        <Texture Name="gTitleScreenFlame0Tex" OutName="title_screen_flame_0" Format="i8" Width="32" Height="32" Offset="0xFF40"/>
+        <Texture Name="gTitleScreenFlame1Tex" OutName="title_screen_flame_1" Format="i8" Width="32" Height="32" Offset="0x10340"/>
+        <Texture Name="gTitleScreenFlame2Tex" OutName="title_screen_flame_2" Format="i8" Width="32" Height="32" Offset="0x10740"/>
+        <Texture Name="gTitleScreenFlame3Tex" OutName="title_screen_flame_3" Format="i8" Width="32" Height="32" Offset="0x10B40"/>
 
-		<Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="128" Height="16" Offset="0x10F40"/>
-		<Texture Name="gTitleScreenControllerNotConnectedTextTex" OutName="title_screen_controller_not_connected_text" Format="i4" Width="256" Height="9" Offset="0x11740"/>
-		<Texture Name="gTitleScreenInsertControllerTextTex" OutName="title_screen_insert_controller_text" Format="i4" Width="144" Height="9" Offset="0x11BC0"/>
-		<Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="128" Height="112" Offset="0x11E48"/>
+        <Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="128" Height="16" Offset="0x10F40"/>
+        <Texture Name="gTitleScreenControllerNotConnectedTextTex" OutName="title_screen_controller_not_connected_text" Format="i4" Width="256" Height="9" Offset="0x11740"/>
+        <Texture Name="gTitleScreenInsertControllerTextTex" OutName="title_screen_insert_controller_text" Format="i4" Width="144" Height="9" Offset="0x11BC0"/>
+        <Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="128" Height="112" Offset="0x11E48"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_mag.xml
+++ b/assets/xml/objects/object_mag.xml
@@ -15,16 +15,16 @@
 		<Texture Name="gTitleScreenMaskGlowBright01Tex" OutName="title_screen_mask_glow_bright_0_1" Format="i4" Width="64" Height="64" Offset="0xD740"/>
 		<Texture Name="gTitleScreenMaskGlowBright10Tex" OutName="title_screen_mask_glow_bright_1_0" Format="i4" Width="64" Height="64" Offset="0xDF40"/>
 		<Texture Name="gTitleScreenMaskGlowBright11Tex" OutName="title_screen_mask_glow_bright_1_1" Format="i4" Width="64" Height="64" Offset="0xE740"/>
-		<Texture Name="gTitleScreenGlowRight0Tex" OutName="title_screen_glow_right_0" Format="i4" Width="64" Height="128" Offset="0xEF40"/>
-		<Texture Name="gTitleScreenGlowRight1Tex" OutName="title_screen_glow_right_1" Format="i4" Width="64" Height="128" Offset="0xF740"/>
+		<Texture Name="gTitleScreenGlowRight0Tex" OutName="title_screen_glow_right_0" Format="i4" Width="64" Height="64" Offset="0xEF40"/>
+		<Texture Name="gTitleScreenGlowRight1Tex" OutName="title_screen_glow_right_1" Format="i4" Width="64" Height="64" Offset="0xF740"/>
 		<Texture Name="gTitleScreenFlame0Tex" OutName="title_screen_flame_0" Format="i8" Width="32" Height="32" Offset="0xFF40"/>
 		<Texture Name="gTitleScreenFlame1Tex" OutName="title_screen_flame_1" Format="i8" Width="32" Height="32" Offset="0x10340"/>
 		<Texture Name="gTitleScreenFlame2Tex" OutName="title_screen_flame_2" Format="i8" Width="32" Height="32" Offset="0x10740"/>
 		<Texture Name="gTitleScreenFlame3Tex" OutName="title_screen_flame_3" Format="i8" Width="32" Height="32" Offset="0x10B40"/>
 
-		<Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="64" Height="64" Offset="0x10F40"/>
+		<Texture Name="gTitleScreenCopyright2000NintendoTex" OutName="title_screen_copyright_2000_nintendo_text" Format="i8" Width="128" Height="16" Offset="0x10F40"/>
 		<Texture Name="gTitleScreenControllerNotConnectedTextTex" OutName="title_screen_controller_not_connected_text" Format="i4" Width="256" Height="9" Offset="0x11740"/>
 		<Texture Name="gTitleScreenInsertControllerTextTex" OutName="title_screen_insert_controller_text" Format="i4" Width="144" Height="9" Offset="0x11BC0"/>
-		<Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="256" Height="256" Offset="0x11E48"/>
+		<Texture Name="gTitleScreenMajorasMaskTex" OutName="title_screen_majoras_mask" Format="rgba32" Width="128" Height="112" Offset="0x11E48"/>
     </File>
 </Root>


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Doing the textures first, because I expect them to be considerably easier than the actual actor.