### PR TITLE
Two small xmls for parameter-related asset files

### DIFF
--- a/assets/xml/interface/week_static.xml
+++ b/assets/xml/interface/week_static.xml
@@ -1,0 +1,7 @@
+<Root>
+    <File Name="week_static">
+        <Texture Name="gClockDay1stTex" OutName="clock_day_1st_tex" Format="i8" Width="48" Height="27" Offset="0x0"/>
+        <Texture Name="gClockDay2ndTex" OutName="clock_day_2nd_tex" Format="i8" Width="48" Height="27" Offset="0x510"/>
+        <Texture Name="gClockDayFinalTex" OutName="clock_day_final_tex" Format="i8" Width="48" Height="27" Offset="0xA20"/>
+    </File>
+</Root>

--- a/assets/xml/misc/story_static.xml
+++ b/assets/xml/misc/story_static.xml
@@ -1,0 +1,8 @@
+<Root>
+    <File Name="story_static">
+        <Texture Name="gStoryMaskFestivalTex" OutName="story_mask_festival" Format="ci8" Width="320" Height="240" TlutOffset="0x25800" Offset="0x0"/>
+        <Texture Name="gStoryGiantsLeavingTex" OutName="story_giants_leaving" Format="ci8" Width="320" Height="240" TlutOffset="0x25A00" Offset="0x12C00"/>
+        <Texture Name="gStoryMaskFestivalTLUT" OutName="story_mask_festival_tlut" Format="rgba16" Width="16" Height="16" Offset="0x25800"/>
+        <Texture Name="gStoryGiantsLeavingTLUT" OutName="story_giants_leaving_tlut" Format="rgba16" Width="16" Height="16" Offset="0x25A00"/>
+    </File>
+</Root>


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Recommend looking at the story_static images, they're really detailed and vibrant (being the full 320 by 240)