### PR TITLE
Bring merged assets up to current standards

### DIFF
--- a/assets/xml/objects/object_bigpo.xml
+++ b/assets/xml/objects/object_bigpo.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <!-- Assets for Big Poes -->
     <File Name="object_bigpo" Segment="6">
         <Animation Name="gBigpoSwingLampAttackAnim" Offset="0x158" />
         <Animation Name="gBigpoShockAnim" Offset="0x454" />

--- a/assets/xml/objects/object_bigslime.xml
+++ b/assets/xml/objects/object_bigslime.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <!-- Assets for the Gekko and Mad Jelly minibosses -->
     <File Name="object_bigslime" Segment="6">
         <Animation Name="gGekkoFullFistPumpAnim" Offset="0x994" />
         <Animation Name="gGekkoSurpriseJumpAnim" Offset="0x10F4" />

--- a/assets/xml/objects/object_bigslime.xml
+++ b/assets/xml/objects/object_bigslime.xml
@@ -1,5 +1,5 @@
 ﻿<Root>
-    <!-- Assets for the Gekko and Mad Jelly minibosses -->
+    <!-- Assets for the Gekko, Minislime, and Bigslime -->
     <File Name="object_bigslime" Segment="6">
         <Animation Name="gGekkoFullFistPumpAnim" Offset="0x994" />
         <Animation Name="gGekkoSurpriseJumpAnim" Offset="0x10F4" />

--- a/assets/xml/objects/object_gmo.xml
+++ b/assets/xml/objects/object_gmo.xml
@@ -1,9 +1,10 @@
 ﻿<Root>
+    <!-- Assets for Nejiron -->
     <File Name="object_gmo" Segment="6">
         <Animation Name="gNejironIdleAnim" Offset="0x18" /> <!-- Original name might be "gm_default" -->
         <DList Name="gNejironBodyDL" Offset="0xB70" />
         <DList Name="gNejironEyesDL" Offset="0xE38" />
-        <Texture Name="gNejironBodyTLUT" OutName="nejiron_body_palette" Format="rgba16" Width="16" Height="16" Offset="0xEC8" />
+        <Texture Name="gNejironBodyTLUT" OutName="nejiron_body_tlut" Format="rgba16" Width="16" Height="16" Offset="0xEC8" />
         <Texture Name="gNejironBodyTex" OutName="nejiron_body" Format="ci8" Width="32" Height="32" Offset="0x10C8" />
         <Texture Name="gNejironEyeOpenTex" OutName="nejiron_eye_open" Format="rgba16" Width="16" Height="32" Offset="0x14C8" />
         <Texture Name="gNejironEyeHalfTex" OutName="nejiron_eye_half" Format="rgba16" Width="16" Height="32" Offset="0x18C8" />

--- a/assets/xml/objects/object_mag.xml
+++ b/assets/xml/objects/object_mag.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <!-- Textures for the title screen -->
     <File Name="object_mag" Segment="6">
         <Texture Name="gTitleScreenZeldaLogoTex" OutName="title_screen_zelda_logo" Format="rgba32" Width="144" Height="64" Offset="0x0"/>
         <Texture Name="gTitleScreenMajorasMaskSubtitleTex" OutName="title_screen_majoras_mask_subtitle" Format="i8" Width="104" Height="16" Offset="0x9000"/>

--- a/assets/xml/objects/object_tokei_step.xml
+++ b/assets/xml/objects/object_tokei_step.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <!-- Assets for the Clock Tower steps -->
     <File Name="object_tokei_step" Segment="6">
         <DList Name="gClocktowerPanelEmptyDL" Offset="0x80" />
         <DList Name="gClocktowerPanelDL" Offset="0x88" />


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Some assets have been already merged without a comment at the top describing what they are, so I included that comment. I didn't have a ton of context on some of these, so if you can think of a better description, feel free to post it. I also used "tlut" instead of "palette" on object_gmo, since we decided we wanted to standardize on "tlut".