### PR TITLE
contramread OK

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -79,7 +79,7 @@ extern float D_80097F90;
 // extern UNK_TYPE1 D_80097FA0;
 // extern UNK_TYPE1 D_80097FA4;
 // extern UNK_TYPE1 D_80097FA5;
-// extern UNK_TYPE4 D_80097FB0;
+extern UNK_TYPE4 __osPfsLastChannel;
 extern OSViMode osViModeNtscLan1;
 extern OSViMode osViModeMpalLan1;
 // extern __OSViContext D_80098060[2];

--- a/include/variables.h
+++ b/include/variables.h
@@ -79,7 +79,7 @@ extern float D_80097F90;
 // extern UNK_TYPE1 D_80097FA0;
 // extern UNK_TYPE1 D_80097FA4;
 // extern UNK_TYPE1 D_80097FA5;
-extern UNK_TYPE4 __osPfsLastChannel;
+extern s32 __osPfsLastChannel;
 extern OSViMode osViModeNtscLan1;
 extern OSViMode osViModeMpalLan1;
 // extern __OSViContext D_80098060[2];

--- a/spec
+++ b/spec
@@ -163,7 +163,6 @@ beginseg
     include "build/src/libultra/voice/voicesetadconverter.o"
     include "build/src/libultra/io/aisetfreq.o"
     include "build/src/libultra/io/contramread.o"
-    include "build/data/boot/contramread.data.o"
     include "build/src/libultra/voice/voicecontwrite20.o"
     include "build/src/libultra/io/crc.o"
     include "build/src/libultra/os/getactivequeue.o"

--- a/src/libultra/io/contramread.c
+++ b/src/libultra/io/contramread.c
@@ -4,7 +4,7 @@
 
 s32 __osPfsLastChannel = -1;
 
-s32 __osContRamRead(OSMesgQueue* ctrlrqueue, s32 channel, u16 addr, u8* data) {
+s32 __osContRamRead(OSMesgQueue* ctrlrqueue, s32 channel, u16 addr, u8* buffer) {
     s32 ret;
     s32 i;
     u8* bufptr;
@@ -48,7 +48,7 @@ s32 __osContRamRead(OSMesgQueue* ctrlrqueue, s32 channel, u16 addr, u8* data) {
                 }
                 ret = 4; // Retry
             } else {
-                bcopy(bufptr + 6, data, BLOCKSIZE);
+                bcopy(bufptr + 6, buffer, BLOCKSIZE);
             }
         } else {
             ret = 1; // Error

--- a/src/libultra/io/contramread.c
+++ b/src/libultra/io/contramread.c
@@ -1,3 +1,63 @@
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/contramread/__osContRamRead.s")
+#define BLOCKSIZE 32
+
+s32 __osPfsLastChannel = -1;
+
+s32 __osContRamRead(OSMesgQueue* ctrlrqueue, s32 channel, u16 addr, u8* data) {
+    s32 ret;
+    s32 i;
+    u8* bufptr;
+    s32 retryCount = 2;
+
+    __osSiGetAccess();
+    do {
+        bufptr = (u8*)&__osPfsPifRam;
+
+        if ((__osContLastPoll != 2) || (__osPfsLastChannel != channel)) {
+            __osContLastPoll = 2;
+            __osPfsLastChannel = channel;
+            // clang-format off
+            for (i = 0; i < channel; i++) { *bufptr++ = 0; }
+            // clang-format on
+            __osPfsPifRam.status = 1;
+            ((__OSContRamReadFormat*)bufptr)->dummy = 0xFF;
+            ((__OSContRamReadFormat*)bufptr)->txsize = 3;
+            ((__OSContRamReadFormat*)bufptr)->rxsize = 0x21;
+            ((__OSContRamReadFormat*)bufptr)->cmd = CONT_CMD_READ_MEMPACK; // read mempak; send byte 0
+            ((__OSContRamReadFormat*)bufptr)->datacrc = 0xFF;              // read mempak; send byte 0
+            // Received bytes are 6-26 inclusive
+            bufptr[sizeof(__OSContRamReadFormat)] = CONT_CMD_END; // End of commands
+        } else {
+            bufptr += channel;
+        }
+
+        ((__OSContRamReadFormat*)bufptr)->hi = addr >> 3;                                    // send byte 1
+        ((__OSContRamReadFormat*)bufptr)->lo = (s8)(__osContAddressCrc(addr) | (addr << 5)); // send byte 2
+        __osSiRawStartDma(OS_WRITE, &__osPfsPifRam);
+        osRecvMesg(ctrlrqueue, NULL, OS_MESG_BLOCK);
+        __osSiRawStartDma(OS_READ, &__osPfsPifRam);
+        osRecvMesg(ctrlrqueue, NULL, OS_MESG_BLOCK);
+
+        ret = (((__OSContRamReadFormat*)bufptr)->rxsize & 0xC0) >> 4;
+        if (!ret) {
+            if (((__OSContRamReadFormat*)bufptr)->datacrc != __osContDataCrc(bufptr + 6)) {
+                ret = __osPfsGetStatus(ctrlrqueue, channel);
+                if (ret) {
+                    break;
+                }
+                ret = 4; // Retry
+            } else {
+                bcopy(bufptr + 6, data, BLOCKSIZE);
+            }
+        } else {
+            ret = 1; // Error
+        }
+        if (ret != 4) {
+            break;
+        }
+    } while (0 <= retryCount--);
+    __osSiRelAccess();
+
+    return ret;
+}

--- a/tools/disasm/variables.txt
+++ b/tools/disasm/variables.txt
@@ -72,7 +72,7 @@
     0x80097FA0:("D_80097FA0","UNK_TYPE1","",0x1),
     0x80097FA4:("D_80097FA4","UNK_TYPE1","",0x1),
     0x80097FA5:("D_80097FA5","UNK_TYPE1","",0x1),
-    0x80097FB0:("D_80097FB0","UNK_TYPE4","",0x4),
+    0x80097FB0:("__osPfsLastChannel","UNK_TYPE4","",0x4),
     0x80097FC0:("osViModeNtscLan1","OSViMode","",0x50),
     0x80098010:("osViModeMpalLan1","OSViMode","",0x50),
     0x80098060:("D_80098060","__OSViContext","[2]",0x60),

--- a/tools/disasm/variables.txt
+++ b/tools/disasm/variables.txt
@@ -72,7 +72,7 @@
     0x80097FA0:("D_80097FA0","UNK_TYPE1","",0x1),
     0x80097FA4:("D_80097FA4","UNK_TYPE1","",0x1),
     0x80097FA5:("D_80097FA5","UNK_TYPE1","",0x1),
-    0x80097FB0:("__osPfsLastChannel","UNK_TYPE4","",0x4),
+    0x80097FB0:("__osPfsLastChannel","s32","",0x4),
     0x80097FC0:("osViModeNtscLan1","OSViMode","",0x50),
     0x80098010:("osViModeMpalLan1","OSViMode","",0x50),
     0x80098060:("D_80098060","__OSViContext","[2]",0x60),


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
I did not rename the structs or variables in the header, but adapted the function to work with the current ones, since @Thar0 will be cleaning up libultra once it's all decompiled anyway. (And after this and contramwrite, it's just voice left)