### PR TITLE
contramwrite OK

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -79,7 +79,7 @@ extern float D_80097F90;
 // extern UNK_TYPE1 D_80097FA0;
 // extern UNK_TYPE1 D_80097FA4;
 // extern UNK_TYPE1 D_80097FA5;
-// extern UNK_TYPE4 D_80097FB0;
+extern s32 __osPfsLastChannel;
 extern OSViMode osViModeNtscLan1;
 extern OSViMode osViModeMpalLan1;
 // extern __OSViContext D_80098060[2];

--- a/src/libultra/io/contramwrite.c
+++ b/src/libultra/io/contramwrite.c
@@ -1,3 +1,68 @@
+#include "ultra64.h"
 #include "global.h"
 
-#pragma GLOBAL_ASM("asm/non_matchings/boot/contramwrite/__osContRamWrite.s")
+s32 __osContRamWrite(OSMesgQueue* mq, s32 channel, u16 address, u8* buffer, s32 force) {
+    s32 ret = 0;
+    s32 i;
+    u8* ptr;
+    s32 retry = 2;
+    u8 crc;
+
+    if ((force != PFS_FORCE) && (address < PFS_LABEL_AREA) && (address != 0)) {
+        return 0;
+    }
+
+    __osSiGetAccess();
+
+    do {
+        ptr = (u8*)(&__osPfsPifRam);
+
+        if (__osContLastPoll != CONT_CMD_WRITE_MEMPACK || __osPfsLastChannel != channel) {
+            __osContLastPoll = CONT_CMD_WRITE_MEMPACK;
+            __osPfsLastChannel = channel;
+
+            // clang-format off
+            for (i = 0; i < channel; i++) { *ptr++ = 0; }
+            // clang-format on
+
+            __osPfsPifRam.status = 1;
+
+            ((__OSContRamReadFormat*)ptr)->dummy = 0xFF;
+            ((__OSContRamReadFormat*)ptr)->txsize = 35;
+            ((__OSContRamReadFormat*)ptr)->rxsize = 1;
+            ((__OSContRamReadFormat*)ptr)->cmd = CONT_CMD_WRITE_MEMPACK;
+            ((__OSContRamReadFormat*)ptr)->datacrc = 0xFF;
+
+            ptr[sizeof(__OSContRamReadFormat)] = CONT_CMD_END;
+        } else {
+            ptr += channel;
+        }
+        ((__OSContRamReadFormat*)ptr)->hi = address >> 3;
+        ((__OSContRamReadFormat*)ptr)->lo = ((address << 5) | __osContAddressCrc(address));
+
+        bcopy(buffer, ((__OSContRamReadFormat*)ptr)->data, BLOCKSIZE);
+
+        ret = __osSiRawStartDma(OS_WRITE, &__osPfsPifRam);
+        crc = __osContDataCrc(buffer);
+        osRecvMesg(mq, (OSMesg*)NULL, OS_MESG_BLOCK);
+
+        ret = __osSiRawStartDma(OS_READ, &__osPfsPifRam);
+        osRecvMesg(mq, (OSMesg*)NULL, OS_MESG_BLOCK);
+
+        ret = ((((__OSContRamReadFormat*)ptr)->rxsize & 0xC0) >> 4);
+        if (!ret) {
+            if (crc != ((__OSContRamReadFormat*)ptr)->datacrc) {
+                if ((ret = __osPfsGetStatus(mq, channel))) {
+                    break;
+                } else {
+                    ret = PFS_ERR_CONTRFAIL;
+                }
+            }
+        } else {
+            ret = PFS_ERR_NOPACK;
+        }
+    } while ((ret == PFS_ERR_CONTRFAIL) && (retry-- >= 0));
+    __osSiRelAccess();
+
+    return ret;
+}

--- a/tools/disasm/variables.txt
+++ b/tools/disasm/variables.txt
@@ -72,7 +72,7 @@
     0x80097FA0:("D_80097FA0","UNK_TYPE1","",0x1),
     0x80097FA4:("D_80097FA4","UNK_TYPE1","",0x1),
     0x80097FA5:("D_80097FA5","UNK_TYPE1","",0x1),
-    0x80097FB0:("D_80097FB0","UNK_TYPE4","",0x4),
+    0x80097FB0:("__osPfsLastChannel","s32","",0x4),
     0x80097FC0:("osViModeNtscLan1","OSViMode","",0x50),
     0x80098010:("osViModeMpalLan1","OSViMode","",0x50),
     0x80098060:("D_80098060","__OSViContext","[2]",0x60),


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
And the other one. Same remarks as #577 apply.