### PR TITLE
General Cleanup

### DIFF
--- a/spec
+++ b/spec
@@ -2687,11 +2687,7 @@ beginseg
     name "ovl_Obj_Iceblock"
     compress
     include "build/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_Obj_Iceblock/ovl_Obj_Iceblock_reloc.o"
-#else
-    include "build/data/ovl_Obj_Iceblock/ovl_Obj_Iceblock.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/src/boot_O2_g3/boot_main.c
+++ b/src/boot_O2_g3/boot_main.c
@@ -1,6 +1,5 @@
 #include "prevent_bss_reordering.h"
 #include "global.h"
-#include "prevent_bss_reordering.h"
 
 StackEntry sBootThreadInfo;
 OSThread sIdleThread;

--- a/src/boot_O2_g3/idle.c
+++ b/src/boot_O2_g3/idle.c
@@ -1,6 +1,5 @@
 #include "prevent_bss_reordering.h"
 #include "global.h"
-#include "prevent_bss_reordering.h"
 
 u8 D_80096B20 = 1;
 vu8 gViConfigUseDefault = 1;

--- a/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
+++ b/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
@@ -40,7 +40,7 @@ void BgFuKaiten_Init(Actor* thisx, GlobalContext* globalCtx) {
     CollisionHeader_GetVirtual(&D_06002D30, &header);
     this->dyna.bgId = DynaPoly_SetBgActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, header);
 
-    this->bouceHeight = 0.0;
+    this->bounceHeight = 0.0;
     this->rotationSpeed = 0;
     this->bounceSpeed = 0;
     this->bounce = 0;
@@ -64,9 +64,9 @@ void BgFuKaiten_UpdateRotation(BgFuKaiten* this) {
 
 void BgFuKaiten_UpdateHeight(BgFuKaiten* this) {
     this->bounce += this->bounceSpeed;
-    this->dyna.actor.world.pos.y = this->dyna.actor.home.pos.y + this->elevation + this->bouceHeight;
+    this->dyna.actor.world.pos.y = this->dyna.actor.home.pos.y + this->elevation + this->bounceHeight;
 
-    this->dyna.actor.world.pos.y -= this->bouceHeight * Math_CosS(this->bounce);
+    this->dyna.actor.world.pos.y -= this->bounceHeight * Math_CosS(this->bounce);
 }
 
 void BgFuKaiten_Update(Actor* thisx, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
+++ b/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.c
@@ -31,31 +31,34 @@ extern Gfx D_060005D0[];
 extern CollisionHeader D_06002D30;
 
 void BgFuKaiten_Init(Actor* thisx, GlobalContext* globalCtx) {
-    UNK_TYPE pad0;
-    UNK_TYPE pad1;
-    CollisionHeader* header = 0;
+    s32 pad;
+    BgFuKaiten* this = THIS;
+    CollisionHeader* header = NULL;
 
     Actor_SetScale(thisx, 1.0);
-    DynaPolyActor_Init(&THIS->dyna, 3);
+    DynaPolyActor_Init(&this->dyna, 3);
     CollisionHeader_GetVirtual(&D_06002D30, &header);
-    THIS->dyna.bgId = DynaPoly_SetBgActor(globalCtx, &globalCtx->colCtx.dyna, &THIS->dyna.actor, header);
+    this->dyna.bgId = DynaPoly_SetBgActor(globalCtx, &globalCtx->colCtx.dyna, &this->dyna.actor, header);
 
-    THIS->bouceHeight = 0.0;
-    THIS->rotationSpeed = 0;
-    THIS->bounceSpeed = 0;
-    THIS->bounce = 0;
+    this->bouceHeight = 0.0;
+    this->rotationSpeed = 0;
+    this->bounceSpeed = 0;
+    this->bounce = 0;
 }
 
 void BgFuKaiten_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    DynaPoly_DeleteBgActor(globalCtx, &globalCtx->colCtx.dyna, THIS->dyna.bgId);
+    BgFuKaiten* this = THIS;
+
+    DynaPoly_DeleteBgActor(globalCtx, &globalCtx->colCtx.dyna, this->dyna.bgId);
 }
 
 void BgFuKaiten_UpdateRotation(BgFuKaiten* this) {
     f32 f0;
+
     this->dyna.actor.shape.rot.y += this->rotationSpeed;
     if (this->rotationSpeed > 0) {
-        f0 = this->rotationSpeed * .002f;
-        func_8019FAD8(&this->dyna.actor.projectedPos, 8310, f0);
+        f0 = this->rotationSpeed * 0.002f;
+        func_8019FAD8(&this->dyna.actor.projectedPos, NA_SE_EV_WOOD_GEAR - SFX_FLAG, f0);
     }
 }
 
@@ -67,16 +70,18 @@ void BgFuKaiten_UpdateHeight(BgFuKaiten* this) {
 }
 
 void BgFuKaiten_Update(Actor* thisx, GlobalContext* globalCtx) {
-    BgFuKaiten_UpdateRotation(THIS);
-    BgFuKaiten_UpdateHeight(THIS);
+    BgFuKaiten* this = THIS;
+
+    BgFuKaiten_UpdateRotation(this);
+    BgFuKaiten_UpdateHeight(this);
 }
 
 void BgFuKaiten_Draw(Actor* thisx, GlobalContext* globalCtx) {
-    GraphicsContext* gfxCtx = globalCtx->state.gfxCtx;
-    UNK_TYPE pad;
+    OPEN_DISPS(globalCtx->state.gfxCtx);
 
-    func_8012C28C(gfxCtx);
+    func_8012C28C(globalCtx->state.gfxCtx);
 
-    gSPMatrix(gfxCtx->polyOpa.p++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    gSPDisplayList(gfxCtx->polyOpa.p++, D_060005D0);
+    gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
+    gSPDisplayList(POLY_OPA_DISP++, D_060005D0);
+    CLOSE_DISPS(globalCtx->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.h
+++ b/src/overlays/actors/ovl_Bg_Fu_Kaiten/z_bg_fu_kaiten.h
@@ -9,11 +9,10 @@ typedef struct BgFuKaiten {
     /* 0x000 */ DynaPolyActor dyna;
     /* 0x15C */ UNK_TYPE1 pad15C[0x4];
     /* 0x160 */ f32 elevation;
-    /* 0x164 */ f32 bouceHeight;
+    /* 0x164 */ f32 bounceHeight;
     /* 0x168 */ s16 rotationSpeed;
     /* 0x16A */ s16 bounceSpeed;
     /* 0x16C */ s16 bounce;
-    /* 0x16E */ UNK_TYPE1 pad16E[0x2];
 } BgFuKaiten; // size = 0x170
 
 extern const ActorInit Bg_Fu_Kaiten_InitVars;

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -512,8 +512,8 @@ void DemoKankyo_Update(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, GlobalContext* globalCtx2) {
-    DemoKankyo* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    DemoKankyo* this = THIS;
     s16 i;
     f32 scaleAlpha;
     Vec3f worldPos;
@@ -603,8 +603,8 @@ void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, GlobalContext* globalCtx2) {
 
 // draw, giants and moon
 void DemoKankyo_DrawMoonAndGiant(Actor* thisx, GlobalContext* globalCtx2) {
-    DemoKankyo* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    DemoKankyo* this = THIS;
     s16 i;
     f32 alphaScale;
 

--- a/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
+++ b/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
@@ -184,7 +184,7 @@ static InitChainEntry sInitChain[] = {
 };
 
 void DoorSpiral_Init(Actor* thisx, GlobalContext* globalCtx) {
-    DoorSpiral* this = (DoorSpiral*)thisx;
+    DoorSpiral* this = THIS;
     s32 pad;
     s32 transition = GET_TRANSITION_ID_PARAM(thisx);
     s8 objBankId;
@@ -310,7 +310,7 @@ void DoorSpiral_PlayerClimb(DoorSpiral* this, GlobalContext* globalCtx) {
 }
 
 void DoorSpiral_Update(Actor* thisx, GlobalContext* globalCtx) {
-    DoorSpiral* this = (DoorSpiral*)thisx;
+    DoorSpiral* this = THIS;
     s32 pad;
     Player* player = GET_PLAYER(globalCtx);
 
@@ -321,7 +321,7 @@ void DoorSpiral_Update(Actor* thisx, GlobalContext* globalCtx) {
 
 void DoorSpiral_Draw(Actor* thisx, GlobalContext* globalCtx) {
     s32 pad;
-    DoorSpiral* this = (DoorSpiral*)thisx;
+    DoorSpiral* this = THIS;
 
     if (this->actor.objBankIndex == this->bankIndex) {
         SpiralInfo* spiralInfo = &sSpiralInfo[this->spiralType];

--- a/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
+++ b/src/overlays/actors/ovl_Door_Spiral/z_door_spiral.c
@@ -8,6 +8,8 @@
 
 #define FLAGS 0x00000010
 
+#define THIS ((DoorSpiral*)thisx)
+
 #define GET_ORIENTATION_PARAM(this) ((((Actor*)(this))->params >> 7) & 0x1)
 #define GET_UNK145_PARAM(this) ((((Actor*)(this))->params >> 8) & 0x3)
 #define GET_TRANSITION_ID_PARAM(this) ((u16)((Actor*)(this))->params >> 10)

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -175,7 +175,7 @@ static Vec3f D_80B65084[] = {
 
 void EnBigpo_Init(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     EnBigpoFireEffect* firesPtr;
     s32 i;
 
@@ -228,20 +228,19 @@ void EnBigpo_Init(Actor* thisx, GlobalContext* globalCtx2) {
     }
 }
 
-void EnBigpo_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
-    GlobalContext* globalCtx2;
+void EnBigpo_Destroy(Actor* thisx, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
+    EnBigpo* this = THIS;
     s32 fireCount;
 
     if ((this->actor.params != ENBIGPO_POSSIBLEFIRE) && (this->actor.params != ENBIGPO_CHOSENFIRE) &&
         (this->actor.params != ENBIGPO_REVEALEDFIRE) && (this->actor.params != ENBIGPO_UNK5)) {
         // if NOT a fire type, *ENBIGPO_REGULAR and ENBIGPO_SUMMONED (combat types only)
-        if (1) {}
-        globalCtx2 = globalCtx;
+        if(1) {}
         for (fireCount = 0; fireCount < ARRAY_COUNT(this->fires); fireCount++) {
-            LightContext_RemoveLight(globalCtx2, &globalCtx2->lightCtx, this->fires[fireCount].light);
+            LightContext_RemoveLight(globalCtx, &globalCtx->lightCtx, this->fires[fireCount].light);
         }
-        Collider_DestroyCylinder(globalCtx2, &this->collider);
+        Collider_DestroyCylinder(globalCtx, &this->collider);
     }
 }
 
@@ -1150,7 +1149,7 @@ s32 EnBigpo_ApplyDamage(EnBigpo* this, GlobalContext* globalCtx) {
 }
 
 void EnBigpo_Update(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     s32 pad;
     ColliderCylinder* thisCollider;
 
@@ -1218,7 +1217,7 @@ void EnBigpo_Update(Actor* thisx, GlobalContext* globalCtx) {
  * alt update func: the revealed fires under dampe's house
  */
 void EnBigpo_UpdateFire(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     this->actor.shape.rot.y = BINANG_ROT180(func_800DFCDC(GET_ACTIVE_CAM(globalCtx)));
     this->actionFunc(this, globalCtx);
 }
@@ -1290,7 +1289,7 @@ void EnBigpo_PostLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, 
 }
 
 void EnBigpo_DrawMainBigpo(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     Gfx* dispHead;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -1331,7 +1330,7 @@ void EnBigpo_DrawMainBigpo(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnBigpo_DrawScoopSoul(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     s32 pad;
 
     OPEN_DISPS(globalCtx->state.gfxCtx);
@@ -1364,7 +1363,7 @@ void EnBigpo_DrawScoopSoul(Actor* thisx, GlobalContext* globalCtx) {
  *  might be able to find an alternative match with the macros, so far no success
  */
 void EnBigpo_DrawLantern(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     f32 magnitude;
     f32 magnitude2;
     Gfx* dispHead;
@@ -1420,7 +1419,7 @@ void EnBigpo_DrawLantern(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnBigpo_DrawCircleFlames(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     s32 pad[3];
     s16 fireRadius;
     MtxF* mtfxPtr;
@@ -1462,7 +1461,7 @@ void EnBigpo_DrawCircleFlames(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnBigpo_RevealedFire(Actor* thisx, GlobalContext* globalCtx) {
-    EnBigpo* this = (EnBigpo*)thisx;
+    EnBigpo* this = THIS;
     EnBigpo* parent = (EnBigpo*)thisx->parent;
     s32 pad;
 

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -236,7 +236,7 @@ void EnBigpo_Destroy(Actor* thisx, GlobalContext* globalCtx2) {
     if ((this->actor.params != ENBIGPO_POSSIBLEFIRE) && (this->actor.params != ENBIGPO_CHOSENFIRE) &&
         (this->actor.params != ENBIGPO_REVEALEDFIRE) && (this->actor.params != ENBIGPO_UNK5)) {
         // if NOT a fire type, *ENBIGPO_REGULAR and ENBIGPO_SUMMONED (combat types only)
-        if(1) {}
+        if (1) {}
         for (fireCount = 0; fireCount < ARRAY_COUNT(this->fires); fireCount++) {
             LightContext_RemoveLight(globalCtx, &globalCtx->lightCtx, this->fires[fireCount].light);
         }

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -1218,6 +1218,7 @@ void EnBigpo_Update(Actor* thisx, GlobalContext* globalCtx) {
  */
 void EnBigpo_UpdateFire(Actor* thisx, GlobalContext* globalCtx) {
     EnBigpo* this = THIS;
+
     this->actor.shape.rot.y = BINANG_ROT180(func_800DFCDC(GET_ACTIVE_CAM(globalCtx)));
     this->actionFunc(this, globalCtx);
 }

--- a/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -316,8 +316,8 @@ void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx2) {
         (33 << 8) | 0x01, // Southern Swamp Frog Returned
         (33 << 8) | 0x02, // Laundry Pool Frog Returned
     };
-    EnBigslime* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnBigslime* this = THIS;
     s32 i;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);

--- a/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -307,7 +307,7 @@ static InitChainEntry sInitChain[] = {
     ICHAIN_U8(targetMode, 5, ICHAIN_STOP),
 };
 
-void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx) {
+void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx2) {
     // gSaveContext.weekEventReg[KEY] = VALUE
     // KEY | VALUE
     static s32 isFrogReturnedFlags[] = {
@@ -317,7 +317,7 @@ void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx) {
         (33 << 8) | 0x02, // Laundry Pool Frog Returned
     };
     EnBigslime* this = THIS;
-    GlobalContext* globalCtx2 = globalCtx;
+    GlobalContext* globalCtx = globalCtx2;
     s32 i;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
@@ -341,7 +341,7 @@ void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx) {
         Actor_MarkForDeath(&this->actor);
         if (!(gSaveContext.weekEventReg[isFrogReturnedFlags[this->actor.params - 1] >> 8] &
               (u8)isFrogReturnedFlags[this->actor.params - 1])) {
-            Actor_Spawn(&globalCtx2->actorCtx, globalCtx, ACTOR_EN_MINIFROG, this->actor.world.pos.x,
+            Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_MINIFROG, this->actor.world.pos.x,
                         this->actor.world.pos.y, this->actor.world.pos.z, 0, this->actor.shape.rot.y, 0,
                         this->actor.params);
         }
@@ -354,7 +354,7 @@ void EnBigslime_Init(Actor* thisx, GlobalContext* globalCtx) {
         this->actor.home.pos.y = GBT_ROOM_5_MAX_Y - 75.0f;
         this->actor.home.pos.z = GBT_ROOM_5_CENTER_Z;
         for (i = 0; i < MINISLIME_NUM_SPAWN; i++) {
-            this->minislime[i] = (EnMinislime*)Actor_SpawnAsChild(&globalCtx2->actorCtx, &this->actor, globalCtx,
+            this->minislime[i] = (EnMinislime*)Actor_SpawnAsChild(&globalCtx->actorCtx, &this->actor, globalCtx,
                                                                   ACTOR_EN_MINISLIME, 0.0f, 0.0f, 0.0f, 0, 0, 0, i);
             if (this->minislime[i] == NULL) {
                 for (i = i - 1; i >= 0; i--) {
@@ -2905,9 +2905,9 @@ void EnBigslime_SetSysMatrix(Vec3f* pos, GlobalContext* globalCtx, Gfx* shadowDL
     CLOSE_DISPS(globalCtx->state.gfxCtx);
 }
 
-void EnBigslime_DrawMinislime(EnBigslime* this, GlobalContext* globalCtx) {
+void EnBigslime_DrawMinislime(EnBigslime* this, GlobalContext* globalCtx2) {
     EnMinislime* minislime;
-    GlobalContext* globalCtx2 = globalCtx;
+    GlobalContext* globalCtx = globalCtx2;
     s32 pad;
     s32 currIndex;
     s32 i;
@@ -2933,8 +2933,8 @@ void EnBigslime_DrawMinislime(EnBigslime* this, GlobalContext* globalCtx) {
     OPEN_DISPS(globalCtx->state.gfxCtx);
     for (i = 0; i < MINISLIME_NUM_SPAWN; i++) {
         minislime = this->minislime[indices[i]];
-        lights = LightContext_NewLights(&globalCtx2->lightCtx, globalCtx->state.gfxCtx);
-        Lights_BindAll(lights, globalCtx2->lightCtx.listHead, &minislime->actor.world.pos, globalCtx);
+        lights = LightContext_NewLights(&globalCtx->lightCtx, globalCtx->state.gfxCtx);
+        Lights_BindAll(lights, globalCtx->lightCtx.listHead, &minislime->actor.world.pos, globalCtx);
         Lights_Draw(lights, globalCtx->state.gfxCtx);
         func_8012C2DC(globalCtx->state.gfxCtx);
         func_800B8118(&minislime->actor, globalCtx, 0);

--- a/src/overlays/actors/ovl_En_Cha/z_en_cha.c
+++ b/src/overlays/actors/ovl_En_Cha/z_en_cha.c
@@ -109,7 +109,7 @@ void EnCha_Update(Actor* thisx, GlobalContext* globalCtx2) {
 
     CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     this->actionFunc(this, globalCtx);
-    if ((this->actor.shape.rot.z >= -0x1F3F) && (this->actor.shape.rot.z < 0x1F40)) {
+    if ((this->actor.shape.rot.z > -0x1F40) && (this->actor.shape.rot.z < 0x1F40)) {
         CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     }
 }

--- a/src/overlays/actors/ovl_En_Cha/z_en_cha.c
+++ b/src/overlays/actors/ovl_En_Cha/z_en_cha.c
@@ -104,8 +104,8 @@ void EnCha_Idle(EnCha* this, GlobalContext* globalCtx) {
 }
 
 void EnCha_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnCha* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnCha* this = THIS;
 
     CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     this->actionFunc(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Cha/z_en_cha.c
+++ b/src/overlays/actors/ovl_En_Cha/z_en_cha.c
@@ -103,14 +103,14 @@ void EnCha_Idle(EnCha* this, GlobalContext* globalCtx) {
     this->actor.home.rot.z *= 0.96f;
 }
 
-void EnCha_Update(Actor* thisx, GlobalContext* globalCtx) {
+void EnCha_Update(Actor* thisx, GlobalContext* globalCtx2) {
     EnCha* this = THIS;
-    GlobalContext* globalCtx2 = globalCtx;
+    GlobalContext* globalCtx = globalCtx2;
 
-    CollisionCheck_SetOC(globalCtx, &globalCtx2->colChkCtx, &this->collider.base);
+    CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     this->actionFunc(this, globalCtx);
     if ((this->actor.shape.rot.z >= -0x1F3F) && (this->actor.shape.rot.z < 0x1F40)) {
-        CollisionCheck_SetAC(globalCtx, &globalCtx2->colChkCtx, &this->collider.base);
+        CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
+++ b/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
@@ -1355,8 +1355,8 @@ s32 func_8089D60C(EnDinofos* this, GlobalContext* globalCtx) {
 }
 
 void EnDinofos_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnDinofos* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnDinofos* this = THIS;
     s32 pad;
     Vec3f sp30;
 

--- a/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
+++ b/src/overlays/actors/ovl_En_Dodongo/z_en_dodongo.c
@@ -1025,8 +1025,8 @@ void EnDodongo_UpdateDamage(EnDodongo* this, GlobalContext* globalCtx) {
 }
 
 void EnDodongo_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnDodongo* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnDodongo* this = THIS;
 
     EnDodongo_UpdateDamage(this, globalCtx);
     this->actionFunc(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.c
@@ -816,7 +816,7 @@ void EnFirefly_Draw(Actor* thisx, GlobalContext* globalCtx) {
         gfx = POLY_OPA_DISP;
     }
 
-    gSPDisplayList(gfx, &sSetupDL[150]);
+    gSPDisplayList(gfx, &sSetupDL[6 * 25]);
 
     if (this->currentType == KEESE_FIRE) {
         gDPSetEnvColor(&gfx[1], 0, 0, 0, 0);

--- a/src/overlays/actors/ovl_En_Fish2/z_en_fish2.c
+++ b/src/overlays/actors/ovl_En_Fish2/z_en_fish2.c
@@ -937,8 +937,8 @@ void EnFish2_Update(Actor* thisx, GlobalContext* globalCtx2) {
     static f32 D_80B2B3A8[] = {
         0.0f, 40.0f, -40.0f, 0.0f, 0.0f, 0.0f,
     };
-    EnFish2* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnFish2* this = THIS;
 
     if ((this->actionFunc != func_80B295A4) && (this->actor.params != 1)) {
         SkelAnime_Update(&this->skelAnime);

--- a/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
+++ b/src/overlays/actors/ovl_En_Floormas/z_en_floormas.c
@@ -159,8 +159,8 @@ static s8 D_808D393C[] = {
 static Color_RGBA8 D_808D3958 = { 0, 255, 0, 0 };
 
 void EnFloormas_Init(Actor* thisx, GlobalContext* globalCtx2) {
-    EnFloormas* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnFloormas* this = THIS;
     s32 pad;
     s32 params;
 

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -641,10 +641,10 @@ void func_80962A10(EnFu* this, GlobalContext* globalCtx) {
     BgFuKaiten* fuKaiten = (BgFuKaiten*)this->actor.child;
 
     this->unk_53C = 0;
-    if ((fuKaiten->rotationSpeed < 300) || (fuKaiten->bouceHeight < 40.0f) || (fuKaiten->bounceSpeed < 600)) {
+    if ((fuKaiten->rotationSpeed < 300) || (fuKaiten->bounceHeight < 40.0f) || (fuKaiten->bounceSpeed < 600)) {
         Math_SmoothStepToS(&fuKaiten->rotationSpeed, 300, 10, 5, 5);
         Math_SmoothStepToS(&fuKaiten->bounceSpeed, 600, 20, 10, 10);
-        Math_SmoothStepToF(&fuKaiten->bouceHeight, 40.0f, 0.1f, 1.0f, 1.0f);
+        Math_SmoothStepToF(&fuKaiten->bounceHeight, 40.0f, 0.1f, 1.0f, 1.0f);
         return;
     }
 
@@ -678,11 +678,11 @@ void func_80962BCC(EnFu* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
     BgFuKaiten* fuKaiten = (BgFuKaiten*)this->actor.child;
 
-    if ((fuKaiten->rotationSpeed < 100) || (fuKaiten->bouceHeight < 30.0f) || (fuKaiten->bounceSpeed < 600)) {
+    if ((fuKaiten->rotationSpeed < 100) || (fuKaiten->bounceHeight < 30.0f) || (fuKaiten->bounceSpeed < 600)) {
         Math_SmoothStepToS(&fuKaiten->rotationSpeed, 100, 10, 5, 5);
         Math_SmoothStepToS(&fuKaiten->bounceSpeed, 600, 20, 10, 10);
         Math_SmoothStepToF(&fuKaiten->elevation, 10.0f, 0.1f, 1.0f, 1.0f);
-        Math_SmoothStepToF(&fuKaiten->bouceHeight, 30.0f, 0.1f, 1.0f, 1.0f);
+        Math_SmoothStepToF(&fuKaiten->bounceHeight, 30.0f, 0.1f, 1.0f, 1.0f);
         return;
     }
 
@@ -710,10 +710,10 @@ void func_80962D60(EnFu* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
     BgFuKaiten* fuKaiten = (BgFuKaiten*)this->actor.child;
 
-    if ((fuKaiten->rotationSpeed < 100) || (fuKaiten->bouceHeight < 40.0f) || (fuKaiten->bounceSpeed < 600)) {
+    if ((fuKaiten->rotationSpeed < 100) || (fuKaiten->bounceHeight < 40.0f) || (fuKaiten->bounceSpeed < 600)) {
         Math_SmoothStepToS(&fuKaiten->rotationSpeed, 100, 10, 5, 5);
         Math_SmoothStepToS(&fuKaiten->bounceSpeed, 600, 20, 10, 10);
-        Math_SmoothStepToF(&fuKaiten->bouceHeight, 40.0f, 0.1f, 1.0f, 1.0f);
+        Math_SmoothStepToF(&fuKaiten->bounceHeight, 40.0f, 0.1f, 1.0f, 1.0f);
         return;
     }
 
@@ -858,11 +858,11 @@ void func_80963350(EnFu* this, GlobalContext* globalCtx) {
         D_80964C24 = 1;
     }
 
-    if ((fuKaiten->rotationSpeed != 0) || (fuKaiten->bounceSpeed != 0) || (fuKaiten->bouceHeight > 0.0f) ||
+    if ((fuKaiten->rotationSpeed != 0) || (fuKaiten->bounceSpeed != 0) || (fuKaiten->bounceHeight > 0.0f) ||
         !func_809638F8(globalCtx)) {
         Math_SmoothStepToS(&fuKaiten->rotationSpeed, 0, 10, 10, 5);
         Math_SmoothStepToS(&fuKaiten->bounceSpeed, 0, 10, 15, 5);
-        Math_SmoothStepToF(&fuKaiten->bouceHeight, 0.0f, 0.1f, 1.0f, 1.0f);
+        Math_SmoothStepToF(&fuKaiten->bounceHeight, 0.0f, 0.1f, 1.0f, 1.0f);
         Math_SmoothStepToF(&fuKaiten->elevation, 0.0f, 0.1f, 1.0f, 1.0f);
         func_80962EBC(this, globalCtx);
     } else if (D_80964C24 == 1) {

--- a/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
+++ b/src/overlays/actors/ovl_En_Ishi/z_en_ishi.c
@@ -430,8 +430,11 @@ void EnIshi_Init(Actor* thisx, GlobalContext* globalCtx) {
     func_8095E5AC(this);
 }
 
-void EnIshi_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    Collider_DestroyCylinder(globalCtx, &THIS->collider);
+void EnIshi_Destroy(Actor* thisx, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
+    EnIshi* this = THIS;
+
+    Collider_DestroyCylinder(globalCtx, &this->collider);
 }
 
 void func_8095E5AC(EnIshi* this) {

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -110,7 +110,7 @@ static Vec3f D_808934E8 = {
 static s32 pad = 0;
 
 void EnNiw_Init(Actor* thisx, GlobalContext* globalCtx) {
-    EnNiw* this = (EnNiw*)thisx;
+    EnNiw* this = THIS;
     Vec3f dTemp = D_808934C4;
 
     if (this->actor.params < 0) { // all neg values become zero
@@ -163,7 +163,7 @@ void EnNiw_Init(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnNiw_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    EnNiw* this = (EnNiw*)thisx;
+    EnNiw* this = THIS;
 
     if (this->niwType == ENNIW_TYPE_REGULAR) {
         Collider_DestroyCylinder(globalCtx, &this->collider);
@@ -732,7 +732,7 @@ void EnNiw_CheckRage(EnNiw* this, GlobalContext* globalCtx) {
 }
 
 void EnNiw_Update(Actor* thisx, GlobalContext* globalCtx) {
-    EnNiw* this = (EnNiw*)thisx;
+    EnNiw* this = THIS;
     s8 pad0;
     s16 i;
     Player* player = GET_PLAYER(globalCtx);
@@ -929,7 +929,7 @@ s32 EnNiw_LimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx** dList, Vec3f* 
 }
 
 void EnNiw_Draw(Actor* thisx, GlobalContext* globalCtx) {
-    EnNiw* this = (EnNiw*)thisx;
+    EnNiw* this = THIS;
 
     func_8012C28C(globalCtx->state.gfxCtx);
     SkelAnime_DrawFlexOpa(globalCtx, this->skelanime.skeleton, this->skelanime.jointTable, this->skelanime.dListCount,

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -85,10 +85,9 @@ void EnNutsball_InitColliderParams(EnNutsball* this) {
     this->collider.info.toucher.damage = 2;
 }
 
-void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx) {
+void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx2) {
     EnNutsball* this = THIS;
-    GlobalContext* globalCtx2 = globalCtx;
-
+    GlobalContext* globalCtx = globalCtx2;
     Player* player = GET_PLAYER(globalCtx);
     Vec3f worldPos;
     Vec3s worldRot;
@@ -138,11 +137,11 @@ void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx) {
         Actor_UpdateBgCheckInfo(globalCtx, &this->actor, 10.0f, 5.0f, 10.0f, 0x7);
 
         if (this->actor.bgCheckFlags & 8) {
-            if (func_800C9A4C(&globalCtx2->colCtx, this->actor.wallPoly, this->actor.wallBgId) & 0x30) {
+            if (func_800C9A4C(&globalCtx->colCtx, this->actor.wallPoly, this->actor.wallBgId) & 0x30) {
                 this->actor.bgCheckFlags &= ~8;
-                if (BgCheck_EntityLineTest1(&globalCtx2->colCtx, &this->actor.prevPos, &worldPos,
+                if (BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.prevPos, &worldPos,
                                             &this->actor.world.pos, &poly, true, false, false, true, &bgId)) {
-                    if (func_800C9A4C(&globalCtx2->colCtx, poly, bgId) & 0x30) {
+                    if (func_800C9A4C(&globalCtx->colCtx, poly, bgId) & 0x30) {
                         this->actor.world.pos.x += this->actor.velocity.x * 0.01f;
                         this->actor.world.pos.z += this->actor.velocity.z * 0.01f;
                     } else {
@@ -161,7 +160,7 @@ void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx) {
         CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
 
         if (this->timer < this->timerThreshold) {
-            CollisionCheck_SetOC(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
+            CollisionCheck_SetOC(globalCtx, &globalCtx2->colChkCtx, &this->collider.base);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -139,8 +139,8 @@ void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx2) {
         if (this->actor.bgCheckFlags & 8) {
             if (func_800C9A4C(&globalCtx->colCtx, this->actor.wallPoly, this->actor.wallBgId) & 0x30) {
                 this->actor.bgCheckFlags &= ~8;
-                if (BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.prevPos, &worldPos,
-                                            &this->actor.world.pos, &poly, true, false, false, true, &bgId)) {
+                if (BgCheck_EntityLineTest1(&globalCtx->colCtx, &this->actor.prevPos, &worldPos, &this->actor.world.pos,
+                                            &poly, true, false, false, true, &bgId)) {
                     if (func_800C9A4C(&globalCtx->colCtx, poly, bgId) & 0x30) {
                         this->actor.world.pos.x += this->actor.velocity.x * 0.01f;
                         this->actor.world.pos.z += this->actor.velocity.z * 0.01f;

--- a/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
+++ b/src/overlays/actors/ovl_En_Nutsball/z_en_nutsball.c
@@ -86,8 +86,8 @@ void EnNutsball_InitColliderParams(EnNutsball* this) {
 }
 
 void EnNutsball_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnNutsball* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnNutsball* this = THIS;
     Player* player = GET_PLAYER(globalCtx);
     Vec3f worldPos;
     Vec3s worldRot;

--- a/src/overlays/actors/ovl_En_Poh/z_en_poh.c
+++ b/src/overlays/actors/ovl_En_Poh/z_en_poh.c
@@ -805,8 +805,8 @@ void func_80B2E8E0(EnPoh* this) {
 }
 
 void EnPoh_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnPoh* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnPoh* this = THIS;
     s32 pad;
 
     if (this->colliderSph.base.atFlags & AT_HIT) {

--- a/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.c
+++ b/src/overlays/actors/ovl_En_Ruppecrow/z_en_ruppecrow.c
@@ -623,8 +623,8 @@ void EnRuppecrow_FallToDespawn(EnRuppecrow* this, GlobalContext* globalCtx) {
 }
 
 void EnRuppecrow_Init(Actor* thisx, GlobalContext* globalCtx2) {
-    EnRuppecrow* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnRuppecrow* this = THIS;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
     SkelAnime_InitFlex(globalCtx, &this->skelAnime, &object_crow_Skel_0010C0, &object_crow_Anim_0000F0, this->joinTable,

--- a/src/overlays/actors/ovl_En_Tag_Obj/z_en_tag_obj.c
+++ b/src/overlays/actors/ovl_En_Tag_Obj/z_en_tag_obj.c
@@ -47,7 +47,7 @@ const ActorInit En_Tag_Obj_InitVars = {
 };
 
 void EnTagObj_Init(Actor* thisx, GlobalContext* globalCtx) {
-    EnTagObj* this = (EnTagObj*)thisx;
+    EnTagObj* this = THIS;
 
     this->hasSpawnedSeahorse = 0;
 }
@@ -56,7 +56,7 @@ void EnTagObj_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnTagObj_Update(Actor* thisx, GlobalContext* globalCtx) {
-    EnTagObj* this = (EnTagObj*)thisx;
+    EnTagObj* this = THIS;
 
     if (!this->hasSpawnedSeahorse) {
         Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_OT, this->actor.world.pos.x, this->actor.world.pos.y,

--- a/src/overlays/actors/ovl_En_Test5/z_en_test5.c
+++ b/src/overlays/actors/ovl_En_Test5/z_en_test5.c
@@ -33,8 +33,8 @@ void EnTest5_SetupAction(EnTest5* this, EnTest5ActionFunc actionFunc) {
 }
 
 void EnTest5_Init(Actor* thisx, GlobalContext* globalCtx2) {
-    EnTest5* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnTest5* this = THIS;
     WaterBox* water;
     f32 ySurface; // Unused
 
@@ -80,8 +80,8 @@ void EnTest5_HandleBottleAction(EnTest5* this, GlobalContext* globalCtx) {
 }
 
 void EnTest5_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnTest5* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnTest5* this = THIS;
     Vec3f steamPos;
     CollisionPoly* poly; // Unused
     s32 pad;             // Unused

--- a/src/overlays/actors/ovl_En_Test5/z_en_test5.c
+++ b/src/overlays/actors/ovl_En_Test5/z_en_test5.c
@@ -36,7 +36,7 @@ void EnTest5_Init(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     EnTest5* this = THIS;
     WaterBox* water;
-    f32 ySurface; // Unused
+    f32 ySurface;
 
     // If not spawned above a water source, immediately despawn
     if (!WaterBox_GetSurface1(globalCtx, &globalCtx->colCtx, this->actor.world.pos.x, this->actor.world.pos.z,
@@ -83,8 +83,8 @@ void EnTest5_Update(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     EnTest5* this = THIS;
     Vec3f steamPos;
-    CollisionPoly* poly; // Unused
-    s32 pad;             // Unused
+    CollisionPoly* poly;
+    s32 pad;
 
     this->actionFunc(this, globalCtx);
 

--- a/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.c
+++ b/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.c
@@ -1008,8 +1008,8 @@ void func_80C12D00(EnThiefbird* this) {
 }
 
 void EnThiefbird_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    EnThiefbird* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnThiefbird* this = THIS;
 
     func_80C12B1C(this, globalCtx);
     this->actionFunc(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
+++ b/src/overlays/actors/ovl_En_Weather_Tag/z_en_weather_tag.c
@@ -61,7 +61,7 @@ void EnWeatherTag_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void EnWeatherTag_Init(Actor* thisx, GlobalContext* globalCtx) {
-    EnWeatherTag* this = (EnWeatherTag*)thisx;
+    EnWeatherTag* this = THIS;
     s32 pad;
     Path* path;
     s32 pathID;
@@ -480,7 +480,7 @@ void func_80967608(EnWeatherTag* this, GlobalContext* globalCtx) {
 }
 
 void EnWeatherTag_Update(Actor* thisx, GlobalContext* globalCtx) {
-    EnWeatherTag* this = (EnWeatherTag*)thisx;
+    EnWeatherTag* this = THIS;
     u16 oldTime;
 
     this->actionFunc(this, globalCtx);

--- a/src/overlays/actors/ovl_En_Zot/z_en_zot.c
+++ b/src/overlays/actors/ovl_En_Zot/z_en_zot.c
@@ -93,8 +93,8 @@ void func_80B965D0(EnZot* this, GlobalContext* globalCtx) {
 }
 
 void EnZot_Init(Actor* thisx, GlobalContext* globalCtx2) {
-    EnZot* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    EnZot* this = THIS;
     s32 i;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 20.0f);

--- a/src/overlays/actors/ovl_Obj_Boyo/z_obj_boyo.c
+++ b/src/overlays/actors/ovl_Obj_Boyo/z_obj_boyo.c
@@ -121,8 +121,8 @@ Actor* ObjBoyo_GetCollidedActor(ObjBoyo* this, GlobalContext* globalCtx, s32* nu
 }
 
 void ObjBoyo_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    ObjBoyo* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    ObjBoyo* this = THIS;
     Actor* target;
     s32 num;
 

--- a/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
+++ b/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
@@ -428,8 +428,11 @@ void ObjFlowerpot_Init(Actor* thisx, GlobalContext* globalCtx) {
     D_80A1D400++;
 }
 
-void ObjFlowerpot_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    Collider_DestroyJntSph(globalCtx, &THIS->collider);
+void ObjFlowerpot_Destroy(Actor* thisx, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
+    ObjFlowerpot* this = THIS;
+
+    Collider_DestroyJntSph(globalCtx, &this->collider);
 }
 
 void func_80A1C818(ObjFlowerpot* this) {

--- a/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
+++ b/src/overlays/actors/ovl_Obj_Hugebombiwa/z_obj_hugebombiwa.c
@@ -358,8 +358,11 @@ void ObjHugebombiwa_Init(Actor* thisx, GlobalContext* globalCtx) {
     func_80A54BF0(this);
 }
 
-void ObjHugebombiwa_Destroy(Actor* thisx, GlobalContext* globalCtx) {
-    Collider_DestroyCylinder(globalCtx, &THIS->collider);
+void ObjHugebombiwa_Destroy(Actor* thisx, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
+    ObjHugebombiwa* this = THIS;
+
+    Collider_DestroyCylinder(globalCtx, &this->collider);
 }
 
 void func_80A54BF0(ObjHugebombiwa* this) {

--- a/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
+++ b/src/overlays/actors/ovl_Obj_Kibako/z_obj_kibako.c
@@ -133,8 +133,8 @@ void func_80926394(ObjKibako* this, GlobalContext* globalCtx) {
 }
 
 void ObjKibako_Init(Actor* thisx, GlobalContext* globalCtx2) {
-    ObjKibako* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    ObjKibako* this = THIS;
     s32 whichBankIndex;
 
     whichBankIndex = KIBAKO_BANK_INDEX(thisx);

--- a/src/overlays/actors/ovl_Obj_Milk_Bin/z_obj_milk_bin.c
+++ b/src/overlays/actors/ovl_Obj_Milk_Bin/z_obj_milk_bin.c
@@ -72,8 +72,8 @@ void ObjMilkBin_Destroy(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void ObjMilkBin_Update(Actor* thisx, GlobalContext* globalCtx2) {
-    ObjMilkBin* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    ObjMilkBin* this = THIS;
 
     if (this->type == OBJ_MILK_BIN_TYPE_1) {
         if (gSaveContext.weekEventReg[0x16] & 1) {

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -172,7 +172,7 @@ void ObjMure_SpawnActors1(ObjMure* this, GlobalContext* globalCtx2) {
     for (i = 0; i < maxChildren; i++) {
         ObjMure_GetSpawnPos(&spawnPos, &actor->world.pos, this->ptn, i);
         this->children[i] = Actor_SpawnAsChildAndCutscene(
-            &globalCtx2->actorCtx, globalCtx, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
+            &globalCtx2->actorCtx, globalCtx2, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
             actor->world.rot.x, actor->world.rot.y, actor->world.rot.z,
             (this->type == OBJMURE_TYPE_BUTTERFLY && i == 0) ? 1 : sSpawnParams[this->type], this->actor.cutscene,
             this->actor.unk20, NULL);

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -172,7 +172,7 @@ void ObjMure_SpawnActors1(ObjMure* this, GlobalContext* globalCtx2) {
     for (i = 0; i < maxChildren; i++) {
         ObjMure_GetSpawnPos(&spawnPos, &actor->world.pos, this->ptn, i);
         this->children[i] = Actor_SpawnAsChildAndCutscene(
-            &globalCtx2->actorCtx, globalCtx2, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
+            &globalCtx2->actorCtx, globalCtx, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
             actor->world.rot.x, actor->world.rot.y, actor->world.rot.z,
             (this->type == OBJMURE_TYPE_BUTTERFLY && i == 0) ? 1 : sSpawnParams[this->type], this->actor.cutscene,
             this->actor.unk20, NULL);

--- a/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
+++ b/src/overlays/actors/ovl_Obj_Mure/z_obj_mure.c
@@ -162,8 +162,8 @@ void ObjMure_SpawnActors0(Actor* thisx, GlobalContext* globalCtx) {
     }
 }
 
-void ObjMure_SpawnActors1(ObjMure* this, GlobalContext* globalCtx) {
-    GlobalContext* globalCtx2 = globalCtx;
+void ObjMure_SpawnActors1(ObjMure* this, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
     Actor* actor = &this->actor;
     Vec3f spawnPos;
     s32 maxChildren = ObjMure_GetMaxChildSpawns(this);
@@ -172,7 +172,7 @@ void ObjMure_SpawnActors1(ObjMure* this, GlobalContext* globalCtx) {
     for (i = 0; i < maxChildren; i++) {
         ObjMure_GetSpawnPos(&spawnPos, &actor->world.pos, this->ptn, i);
         this->children[i] = Actor_SpawnAsChildAndCutscene(
-            &globalCtx->actorCtx, globalCtx, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
+            &globalCtx2->actorCtx, globalCtx, sSpawnActorIds[this->type], spawnPos.x, spawnPos.y, spawnPos.z,
             actor->world.rot.x, actor->world.rot.y, actor->world.rot.z,
             (this->type == OBJMURE_TYPE_BUTTERFLY && i == 0) ? 1 : sSpawnParams[this->type], this->actor.cutscene,
             this->actor.unk20, NULL);

--- a/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.c
+++ b/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.c
@@ -164,8 +164,8 @@ void ObjWarpstone_Update(Actor* thisx, GlobalContext* globalCtx) {
 }
 
 void ObjWarpstone_Draw(Actor* thisx, GlobalContext* globalCtx2) {
-    ObjWarpstone* this = THIS;
     GlobalContext* globalCtx = globalCtx2;
+    ObjWarpstone* this = THIS;
 
     Gfx_DrawDListOpa(globalCtx, sOwlStatueDLs[this->modelIndex]);
     if (this->dyna.actor.home.rot.x != 0) {


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

This PR consists of just some general cleanup I've seen:

- Remove some excess `#include "prevent_bss_reordering.h"`
- Instances of `globalCtx2` adjusted to always be the arg so have `globalCtx = globalCtx2` and for the most part `globalCtx` is used in the body.
- Cleaned up usage of `THIS`. Biggest offender was `BgFuKaiten` which was the main reason for the PR.
- Updated spec to use correct `ovl_Obj_Iceblock relocs`
- sSetupDL in EnFirefly