### PR TITLE
Add comment to Arrow_Ice xml and update DL names

### DIFF
--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -1,11 +1,12 @@
 <Root>
+    <!-- Ice Arrow assets -->
     <File Name="ovl_Arrow_Ice" BaseAddress="0x80922430" RangeStart="0x980" RangeEnd="0x1DA0">
         <Texture Name="sIceArrow1Tex" OutName="ice_tex_1" Format="ia8" Width="32" Height="64" Offset="0x980"/>
         <Texture Name="sIceArrow2Tex" OutName="ice_tex_2" Format="ia8" Width="32" Height="64" Offset="0x1180"/>
         <Array Name="sIceArrowVtx" Count="43" Offset="0x1980">
             <Vtx/>
         </Array>
-        <DList Name="sIceArrowDL" Offset="0x1C30"/>
-        <DList Name="sIceArrowVtxDL" Offset="0x1CE0"/>
+        <DList Name="sMaterialDL" Offset="0x1C30"/>
+        <DList Name="sModelDL" Offset="0x1CE0"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -1,12 +1,12 @@
 <Root>
     <!-- Ice Arrow assets -->
     <File Name="ovl_Arrow_Ice" BaseAddress="0x80922430" RangeStart="0x980" RangeEnd="0x1DA0">
-        <Texture Name="sIceArrow1Tex" OutName="ice_tex_1" Format="ia8" Width="32" Height="64" Offset="0x980"/>
-        <Texture Name="sIceArrow2Tex" OutName="ice_tex_2" Format="ia8" Width="32" Height="64" Offset="0x1180"/>
-        <Array Name="sIceArrowVtx" Count="43" Offset="0x1980">
+        <Texture Name="gIceArrow1Tex" OutName="ice_arrow_tex_1" Format="ia8" Width="32" Height="64" Offset="0x980"/>
+        <Texture Name="gIceArrow2Tex" OutName="ice_arrow_tex_2" Format="ia8" Width="32" Height="64" Offset="0x1180"/>
+        <Array Name="gIceArrowVtx" Count="43" Offset="0x1980">
             <Vtx/>
         </Array>
-        <DList Name="sMaterialDL" Offset="0x1C30"/>
-        <DList Name="sModelDL" Offset="0x1CE0"/>
+        <DList Name="gIceArrowMaterialDL" Offset="0x1C30"/>
+        <DList Name="gIceArrowModelDL" Offset="0x1CE0"/>
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -1,8 +1,8 @@
 <Root>
     <!-- Ice Arrow assets -->
     <File Name="ovl_Arrow_Ice" BaseAddress="0x80922430" RangeStart="0x980" RangeEnd="0x1DA0">
-        <Texture Name="gIceArrow1Tex" OutName="ice_arrow_tex_1" Format="ia8" Width="32" Height="64" Offset="0x980"/>
-        <Texture Name="gIceArrow2Tex" OutName="ice_arrow_tex_2" Format="ia8" Width="32" Height="64" Offset="0x1180"/>
+        <Texture Name="gIceArrowTex" OutName="ice_arrow" Format="ia8" Width="32" Height="64" Offset="0x980"/>
+        <Texture Name="gIceArrowMaskTex" OutName="ice_arrow_mask" Format="ia8" Width="32" Height="64" Offset="0x1180"/>
         <Array Name="gIceArrowVtx" Count="43" Offset="0x1980">
             <Vtx/>
         </Array>

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -228,11 +228,11 @@ void ArrowIce_Draw(Actor* thisx, GlobalContext* globalCtx) {
         Matrix_Scale(this->radius * 0.2f, this->height * 3.0f, this->radius * 0.2f, MTXMODE_APPLY);
         Matrix_InsertTranslation(0.0f, -700.0f, 0.0f, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPDisplayList(POLY_XLU_DISP++, sMaterialDL);
+        gSPDisplayList(POLY_XLU_DISP++, gIceArrowMaterialDL);
         gSPDisplayList(POLY_XLU_DISP++,
                        Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 511 - (stateFrames * 5) % 512, 0, 128, 32, 1,
                                         511 - (stateFrames * 10) % 512, 511 - (stateFrames * 10) % 512, 4, 16));
-        gSPDisplayList(POLY_XLU_DISP++, sModelDL);
+        gSPDisplayList(POLY_XLU_DISP++, gIceArrowModelDL);
 
         CLOSE_DISPS(globalCtx->state.gfxCtx);
     }

--- a/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
+++ b/src/overlays/actors/ovl_Arrow_Ice/z_arrow_ice.c
@@ -228,11 +228,11 @@ void ArrowIce_Draw(Actor* thisx, GlobalContext* globalCtx) {
         Matrix_Scale(this->radius * 0.2f, this->height * 3.0f, this->radius * 0.2f, MTXMODE_APPLY);
         Matrix_InsertTranslation(0.0f, -700.0f, 0.0f, MTXMODE_APPLY);
         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-        gSPDisplayList(POLY_XLU_DISP++, sIceArrowDL);
+        gSPDisplayList(POLY_XLU_DISP++, sMaterialDL);
         gSPDisplayList(POLY_XLU_DISP++,
                        Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 511 - (stateFrames * 5) % 512, 0, 128, 32, 1,
                                         511 - (stateFrames * 10) % 512, 511 - (stateFrames * 10) % 512, 4, 16));
-        gSPDisplayList(POLY_XLU_DISP++, sIceArrowVtxDL);
+        gSPDisplayList(POLY_XLU_DISP++, sModelDL);
 
         CLOSE_DISPS(globalCtx->state.gfxCtx);
     }


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
This PR does two simple things:
- Adds a comment to the top of the ovl_Arrow_Ice XML
- Updates the names of the display lists to use the "material"/"model" naming scheme like OoT now does from: https://github.com/zeldaret/oot/pull/985