### PR TITLE
Fix m2ctx for new z_actor

### DIFF
--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -40,7 +40,7 @@ def custom_replacements(output):
             for x in range(12):
                 actorList.append(actorListText.replace("first;", f"{actorCats[x]};") + "\n")
                 if x == 2:
-                    actorList[x] = actorList[x].replace("Actor*", "Player*")
+                    actorList[x] = actorList[x].replace("Actor*", "struct Player*")
         elif "ActorListEntry actorLists[ACTORCAT_MAX];" in line:
             output[i] = "struct {\n" + "".join(actorList) + "};"
         ########################################################


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
