### PR TITLE
Fix some more dummy label matches

### DIFF
--- a/src/boot_O2_g3/z_std_dma.c
+++ b/src/boot_O2_g3/z_std_dma.c
@@ -216,6 +216,7 @@ void DmaMgr_Start(void) {
     {
         DmaEntry* iter = dmadata;
         u32 idx = 0;
+
         while (iter->vromEnd != 0) {
             iter++;
             idx++;

--- a/src/boot_O2_g3/z_std_dma.c
+++ b/src/boot_O2_g3/z_std_dma.c
@@ -211,23 +211,18 @@ s32 DmaMgr_SendRequest0(void* vramStart, uintptr_t vromStart, size_t size) {
 }
 
 void DmaMgr_Start(void) {
-    DmaEntry* iter;
-    u32 idx;
-
     DmaMgr_DMARomToRam(SEGMENT_ROM_START(dmadata), dmadata, SEGMENT_ROM_SIZE(dmadata));
 
-dummy_label:;
+    {
+        DmaEntry* iter = dmadata;
+        u32 idx = 0;
+        while (iter->vromEnd != 0) {
+            iter++;
+            idx++;
+        }
 
-    iter = dmadata;
-    idx = 0;
-    while (iter->vromEnd != 0) {
-        iter++;
-        idx++;
+        numDmaEntries = idx;
     }
-
-    numDmaEntries = idx;
-
-dummy_label_2:;
 
     osCreateMesgQueue(&sDmaMgrMsgQueue, sDmaMgrMsgs, ARRAY_COUNT(sDmaMgrMsgs));
     StackCheck_Init(&sDmaMgrStackInfo, sDmaMgrStack, sDmaMgrStack + sizeof(sDmaMgrStack), 0, 0x100, "dmamgr");

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -320,13 +320,12 @@ void func_800B4AEC(GlobalContext* globalCtx, Actor* actor, f32 y) {
 void func_800B4B50(Actor* actor, Lights* mapper, GlobalContext* globalCtx) {
     f32 spEC;
     f32 temp_f12;
-    f32 temp_f20;
     f32 shadowScaleZ;
     f32 temp_f22;
     f32 temp_f24;
     f32 temp_f8;
-    MtxF sp94;
     s32 lightNum;
+    MtxF sp94;
     s32 numLights;
     s8 phi_v1;
     u8 temp_v0;
@@ -342,7 +341,8 @@ void func_800B4B50(Actor* actor, Lights* mapper, GlobalContext* globalCtx) {
 
         spEC = actor->world.pos.y - actor->floorHeight;
         if (spEC > 20.0f) {
-            temp_f20 = actor->shape.shadowScale;
+            f32 temp_f20 = actor->shape.shadowScale;
+
             temp_v0 = actor->shape.shadowAlpha;
             actor->shape.shadowScale *= 0.3f;
             temp_f12 = (spEC - 20.0f) * 0.02f;
@@ -350,7 +350,6 @@ void func_800B4B50(Actor* actor, Lights* mapper, GlobalContext* globalCtx) {
             ActorShadow_DrawCircle(actor, mapper, globalCtx);
             actor->shape.shadowScale = temp_f20;
             actor->shape.shadowAlpha = temp_v0;
-        dummy_label_111649:;
         } else if (spEC >= -1.0f) {
             numLights = mapper->numLights - 2;
 
@@ -377,8 +376,8 @@ void func_800B4B50(Actor* actor, Lights* mapper, GlobalContext* globalCtx) {
 
             for (j = 0; j < 2; j++, phi_s0++) {
                 if (phi_s0->l.dir[1] > 0) {
-                    lightNum = (ABS_ALT(phi_s0->l.dir[1]) * (phi_s0->l.col[0] + phi_s0->l.col[1] + phi_s0->l.col[2])) -
-                               (lightNumMax * ((void)0, 8));
+                    lightNum = ((phi_s0->l.col[0] + phi_s0->l.col[1] + phi_s0->l.col[2]) * ABS_ALT(phi_s0->l.dir[1])) -
+                               (8 * lightNumMax);
                     if (lightNum > 0) {
                         ActorShadow_DrawFoot(globalCtx, phi_s0, &sp94, lightNum, temp_f22, temp_f24, shadowScaleZ);
                     }

--- a/src/code/z_eff_tire_mark.c
+++ b/src/code/z_eff_tire_mark.c
@@ -255,11 +255,12 @@ void EffectTireMark_Draw(void* thisx, GraphicsContext* gfxCtx) {
 
                 if ((elem - 1)->flags & 1) {
                     if (!(elem->flags & 1)) {
+                        s32 requiredScopeTemp;
+
                         vtx[i * 2 + 0].v.tc[0] = 0;
                         vtx[i * 2 + 0].v.tc[1] = 0;
                         vtx[i * 2 + 1].v.tc[0] = 0;
                         vtx[i * 2 + 1].v.tc[1] = 1024;
-                    dummy_label:;
                     } else if ((i >= 2) && !((elem - 2)->flags & 1)) {
                         vtx[i * 2 - 2].v.tc[0] = 0;
                         vtx[i * 2 - 2].v.tc[1] = 0;

--- a/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
+++ b/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
@@ -717,30 +717,32 @@ void EnFsn_Idle(EnFsn* this, GlobalContext* globalCtx) {
             this->animationIdx = 5;
             func_8013BC6C(&this->skelAnime, sAnimations, this->animationIdx);
         }
-    } else if (this->flags & ENFSN_HAGGLE) {
-    dummy:;
+        return;
+    }
+
+    if (this->flags & ENFSN_HAGGLE) {
         this->actionFunc = EnFsn_Haggle;
-    } else {
-    dummy2:;
-        if (Actor_ProcessTalkRequest(&this->actor, &globalCtx->state)) {
-            if (this->cutsceneState == 0) {
-                if (ActorCutscene_GetCurrentIndex() == 0x7C) {
-                    ActorCutscene_Stop(0x7C);
-                }
-                this->cutscene = this->lookToShopkeeperCutscene;
-                ActorCutscene_SetIntentToPlay(this->cutscene);
-                this->cutsceneState = 1;
+        return;
+    }
+
+    if (Actor_ProcessTalkRequest(&this->actor, &globalCtx->state)) {
+        if (this->cutsceneState == 0) {
+            if (ActorCutscene_GetCurrentIndex() == 0x7C) {
+                ActorCutscene_Stop(0x7C);
             }
-            this->actor.textId = EnFsn_GetWelcome(globalCtx);
-            func_801518B0(globalCtx, this->actor.textId, &this->actor);
-            player->actor.world.pos.x = 1.0f;
-            player->actor.world.pos.z = -34.0f;
-            this->actionFunc = EnFsn_BeginInteraction;
-        } else if (((player->actor.world.pos.x >= -50.0f) && (player->actor.world.pos.x <= 15.0f)) &&
-                   (player->actor.world.pos.y > 0.0f) &&
-                   ((player->actor.world.pos.z >= -35.0f) && (player->actor.world.pos.z <= -20.0f))) {
-            func_800B8614(&this->actor, globalCtx, 400.0f);
+            this->cutscene = this->lookToShopkeeperCutscene;
+            ActorCutscene_SetIntentToPlay(this->cutscene);
+            this->cutsceneState = 1;
         }
+        this->actor.textId = EnFsn_GetWelcome(globalCtx);
+        func_801518B0(globalCtx, this->actor.textId, &this->actor);
+        player->actor.world.pos.x = 1.0f;
+        player->actor.world.pos.z = -34.0f;
+        this->actionFunc = EnFsn_BeginInteraction;
+    } else if (((player->actor.world.pos.x >= -50.0f) && (player->actor.world.pos.x <= 15.0f)) &&
+               (player->actor.world.pos.y > 0.0f) &&
+               ((player->actor.world.pos.z >= -35.0f) && (player->actor.world.pos.z <= -20.0f))) {
+        func_800B8614(&this->actor, globalCtx, 400.0f);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Giant/z_en_giant.c
+++ b/src/overlays/actors/ovl_En_Giant/z_en_giant.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_giant.c
  * Overlay: ovl_En_Giant
- * Description: Giant 
+ * Description: Giant
  */
 
 #include "z_en_giant.h"

--- a/src/overlays/actors/ovl_En_Giant/z_en_giant.c
+++ b/src/overlays/actors/ovl_En_Giant/z_en_giant.c
@@ -1,7 +1,7 @@
 /*
  * File: z_en_giant.c
  * Overlay: ovl_En_Giant
- * Description: Giant
+ * Description: Giant 
  */
 
 #include "z_en_giant.h"


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
This PR fixes most of the dummy label matches currently in the repo. It doesn't fix the one in title_setup.c (because we probably need more data from other gamestate functions to understand what it's doing), nor does it fix the one in invadepoh (because I can't figure it out; here's the scratch if you want to bang your head against it: https://decomp.me/scratch/JVMlL)

Like I expected, most of the problems were problems of scope, but En_Fsn instead required some early returns in order to remove its dummy labels.

Also fixes a small `(void)0` thing in `func_800B4B50`, courtesy of Anon58. Since I was already in there, I figured it made sense to include it here.