### PR TITLE
ZAPD hotfix

### DIFF
--- a/tools/ZAPD/.gitrepo
+++ b/tools/ZAPD/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/zeldaret/ZAPD.git
 	branch = master
-	commit = be71e26d9afc470a9293e74a6f56ca87f7412be0
-	parent = 1531f5b56ff4438d44c4aaac29da93d0c6176c72
+	commit = 119a6883e6f795815744b9afd6a79084c619ddb6
+	parent = 66a66f61b6368af0ed711803c54a963494329217
 	method = merge
 	cmdver = 0.4.3

--- a/tools/ZAPD/.gitrepo
+++ b/tools/ZAPD/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/zeldaret/ZAPD.git
 	branch = master
-	commit = 0ba78130478ee1272bc0e2f2fec2d162e7f7f995
-	parent = aa90d1ee2be577fb8a18c1c3c6dcafda2e732190
+	commit = be71e26d9afc470a9293e74a6f56ca87f7412be0
+	parent = 1531f5b56ff4438d44c4aaac29da93d0c6176c72
 	method = merge
 	cmdver = 0.4.3

--- a/tools/ZAPD/ZAPD/WarningHandler.cpp
+++ b/tools/ZAPD/ZAPD/WarningHandler.cpp
@@ -199,8 +199,16 @@ bool WarningHandler::WasElevatedToError(WarningType warnType) {
  * Print file/line/function info for debugging
  */
 void WarningHandler::FunctionPreamble(const char* filename, int32_t line, const char* function) {
-    if (Globals::Instance->verbosity >= VerbosityLevel::VERBOSITY_DEBUG) {
-        fprintf(stderr, "%s:%i: in function %s:\n", filename, line, function);
+    bool forcePrint = false;
+
+#ifdef DEVELOPMENT
+    forcePrint = true;
+#endif
+
+    fprintf(stderr, "\n");
+
+    if (forcePrint || Globals::Instance->verbosity >= VerbosityLevel::VERBOSITY_DEBUG) {
+        fprintf(stderr, "%s:%i: in function <%s>:\n", filename, line, function);
     }
 }
 

--- a/tools/ZAPD/ZAPD/ZAnimation.cpp
+++ b/tools/ZAPD/ZAPD/ZAnimation.cpp
@@ -51,7 +51,7 @@ void ZNormalAnimation::ParseRawData()
 {
 	ZAnimation::ParseRawData();
 
-	const uint8_t* data = parent->GetRawData().data();
+	auto& data = parent->GetRawData();
 
 	rotationValuesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 4);
 	rotationIndicesSeg = BitConverter::ToInt32BE(data, rawDataIndex + 8);

--- a/tools/ZAPD/ZAPD/ZCollision.cpp
+++ b/tools/ZAPD/ZAPD/ZCollision.cpp
@@ -256,32 +256,28 @@ size_t ZCollisionHeader::GetRawDataSize() const
 
 PolygonEntry::PolygonEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	type = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	vtxA = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	vtxB = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	vtxC = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
-	a = BitConverter::ToUInt16BE(data, rawDataIndex + 8);
-	b = BitConverter::ToUInt16BE(data, rawDataIndex + 10);
-	c = BitConverter::ToUInt16BE(data, rawDataIndex + 12);
-	d = BitConverter::ToUInt16BE(data, rawDataIndex + 14);
+	type = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	vtxA = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	vtxB = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	vtxC = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	a = BitConverter::ToUInt16BE(rawData, rawDataIndex + 8);
+	b = BitConverter::ToUInt16BE(rawData, rawDataIndex + 10);
+	c = BitConverter::ToUInt16BE(rawData, rawDataIndex + 12);
+	d = BitConverter::ToUInt16BE(rawData, rawDataIndex + 14);
 }
 
 WaterBoxHeader::WaterBoxHeader(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	xMin = BitConverter::ToInt16BE(data, rawDataIndex + 0);
-	ySurface = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	zMin = BitConverter::ToInt16BE(data, rawDataIndex + 4);
-	xLength = BitConverter::ToInt16BE(data, rawDataIndex + 6);
-	zLength = BitConverter::ToInt16BE(data, rawDataIndex + 8);
+	xMin = BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
+	ySurface = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	zMin = BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	xLength = BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
+	zLength = BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
 
 	if (Globals::Instance->game == ZGame::OOT_SW97)
-		properties = BitConverter::ToInt16BE(data, rawDataIndex + 10);
+		properties = BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
 	else
-		properties = BitConverter::ToInt32BE(data, rawDataIndex + 12);
+		properties = BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
 }
 
 std::string WaterBoxHeader::GetBodySourceCode() const

--- a/tools/ZAPD/ZAPD/ZCutscene.cpp
+++ b/tools/ZAPD/ZAPD/ZCutscene.cpp
@@ -445,30 +445,26 @@ size_t CutsceneCommand::GetCommandSize()
 
 CutsceneCameraPoint::CutsceneCameraPoint(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
+	continueFlag = rawData.at(rawDataIndex + 0);
+	cameraRoll = rawData.at(rawDataIndex + 1);
+	nextPointFrame = BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	viewAngle = BitConverter::ToFloatBE(rawData, rawDataIndex + 4);
 
-	continueFlag = data[rawDataIndex + 0];
-	cameraRoll = data[rawDataIndex + 1];
-	nextPointFrame = BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	viewAngle = BitConverter::ToFloatBE(data, rawDataIndex + 4);
+	posX = BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
+	posY = BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	posZ = BitConverter::ToInt16BE(rawData, rawDataIndex + 12);
 
-	posX = BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	posY = BitConverter::ToInt16BE(data, rawDataIndex + 10);
-	posZ = BitConverter::ToInt16BE(data, rawDataIndex + 12);
-
-	unused = BitConverter::ToInt16BE(data, rawDataIndex + 14);
+	unused = BitConverter::ToInt16BE(rawData, rawDataIndex + 14);
 }
 
 CutsceneCommandSetCameraPos::CutsceneCommandSetCameraPos(const std::vector<uint8_t>& rawData,
                                                          uint32_t rawDataIndex)
 	: CutsceneCommand(rawData, rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	base = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	startFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	endFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	unused = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unused = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
 
 	entries = std::vector<CutsceneCameraPoint*>();
 
@@ -994,23 +990,21 @@ size_t CutsceneCommandTextbox::GetCommandSize()
 
 ActorAction::ActorAction(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	action = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 4);
-	rotX = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 6);
-	rotY = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 8);
-	rotZ = (uint16_t)BitConverter::ToInt16BE(data, rawDataIndex + 10);
-	startPosX = BitConverter::ToInt32BE(data, rawDataIndex + 12);
-	startPosY = BitConverter::ToInt32BE(data, rawDataIndex + 16);
-	startPosZ = BitConverter::ToInt32BE(data, rawDataIndex + 20);
-	endPosX = BitConverter::ToInt32BE(data, rawDataIndex + 24);
-	endPosY = BitConverter::ToInt32BE(data, rawDataIndex + 28);
-	endPosZ = BitConverter::ToInt32BE(data, rawDataIndex + 32);
-	normalX = BitConverter::ToFloatBE(data, rawDataIndex + 36);
-	normalY = BitConverter::ToFloatBE(data, rawDataIndex + 40);
-	normalZ = BitConverter::ToFloatBE(data, rawDataIndex + 44);
+	action = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
+	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
+	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	rotX = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
+	rotY = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
+	rotZ = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	startPosX = BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
+	startPosY = BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
+	startPosZ = BitConverter::ToInt32BE(rawData, rawDataIndex + 20);
+	endPosX = BitConverter::ToInt32BE(rawData, rawDataIndex + 24);
+	endPosY = BitConverter::ToInt32BE(rawData, rawDataIndex + 28);
+	endPosZ = BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
+	normalX = BitConverter::ToFloatBE(rawData, rawDataIndex + 36);
+	normalY = BitConverter::ToFloatBE(rawData, rawDataIndex + 40);
+	normalZ = BitConverter::ToFloatBE(rawData, rawDataIndex + 44);
 }
 
 CutsceneCommandActorAction::CutsceneCommandActorAction(const std::vector<uint8_t>& rawData,
@@ -1128,22 +1122,20 @@ size_t CutsceneCommandEnd::GetCommandSize()
 
 SpecialActionEntry::SpecialActionEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	const uint8_t* data = rawData.data();
-
-	base = BitConverter::ToUInt16BE(data, rawDataIndex + 0);
-	startFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 2);
-	endFrame = BitConverter::ToUInt16BE(data, rawDataIndex + 4);
-	unused0 = BitConverter::ToUInt16BE(data, rawDataIndex + 6);
-	unused1 = BitConverter::ToUInt32BE(data, rawDataIndex + 8);
-	unused2 = BitConverter::ToUInt32BE(data, rawDataIndex + 12);
-	unused3 = BitConverter::ToUInt32BE(data, rawDataIndex + 16);
-	unused4 = BitConverter::ToUInt32BE(data, rawDataIndex + 20);
-	unused5 = BitConverter::ToUInt32BE(data, rawDataIndex + 24);
-	unused6 = BitConverter::ToUInt32BE(data, rawDataIndex + 28);
-	unused7 = BitConverter::ToUInt32BE(data, rawDataIndex + 32);
-	unused8 = BitConverter::ToUInt32BE(data, rawDataIndex + 36);
-	unused9 = BitConverter::ToUInt32BE(data, rawDataIndex + 40);
-	unused10 = BitConverter::ToUInt32BE(data, rawDataIndex + 44);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unused0 = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	unused1 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
+	unused2 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+	unused3 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 16);
+	unused4 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 20);
+	unused5 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 24);
+	unused6 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 28);
+	unused7 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 32);
+	unused8 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 36);
+	unused9 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 40);
+	unused10 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 44);
 }
 
 CutsceneCommandSpecialAction::CutsceneCommandSpecialAction(const std::vector<uint8_t>& rawData,

--- a/tools/ZAPD/ZAPD/ZCutscene.cpp
+++ b/tools/ZAPD/ZAPD/ZCutscene.cpp
@@ -707,17 +707,17 @@ size_t CutsceneCommandStopBGM::GetCommandSize()
 
 EnvLightingEntry::EnvLightingEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	setting = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
-	unused0 = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
-	unused1 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 8);
-	unused2 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
-	unused3 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
-	unused4 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 20);
-	unused5 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 24);
-	unused6 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 28);
-	unused7 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
+	setting = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unused0 = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	unused1 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
+	unused2 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+	unused3 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 16);
+	unused4 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 20);
+	unused5 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 24);
+	unused6 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 28);
+	unused7 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 32);
 }
 
 CutsceneCommandEnvLighting::CutsceneCommandEnvLighting(const std::vector<uint8_t>& rawData,
@@ -765,9 +765,9 @@ size_t CutsceneCommandEnvLighting::GetCommandSize()
 
 Unknown9Entry::Unknown9Entry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
 	unk2 = rawData[rawDataIndex + 6];
 	unk3 = rawData[rawDataIndex + 7];
 	unk4 = rawData[rawDataIndex + 8];
@@ -820,18 +820,18 @@ size_t CutsceneCommandUnknown9::GetCommandSize()
 
 UnkEntry::UnkEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	unused0 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 0);
-	unused1 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 4);
-	unused2 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 8);
-	unused3 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
-	unused4 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
-	unused5 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 20);
-	unused6 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 24);
-	unused7 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 28);
-	unused8 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 32);
-	unused9 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 36);
-	unused10 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 40);
-	unused11 = (uint32_t)BitConverter::ToInt32BE(rawData, rawDataIndex + 44);
+	unused0 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 0);
+	unused1 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 4);
+	unused2 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 8);
+	unused3 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 12);
+	unused4 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 16);
+	unused5 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 20);
+	unused6 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 24);
+	unused7 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 28);
+	unused8 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 32);
+	unused9 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 36);
+	unused10 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 40);
+	unused11 = BitConverter::ToUInt32BE(rawData, rawDataIndex + 44);
 }
 
 CutsceneCommandUnknown::CutsceneCommandUnknown(const std::vector<uint8_t>& rawData,
@@ -879,9 +879,9 @@ size_t CutsceneCommandUnknown::GetCommandSize()
 
 DayTimeEntry::DayTimeEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
 	hour = rawData[rawDataIndex + 6];
 	minute = rawData[rawDataIndex + 7];
 	unused = rawData[rawDataIndex + 8];
@@ -930,12 +930,12 @@ size_t CutsceneCommandDayTime::GetCommandSize()
 
 TextboxEntry::TextboxEntry(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
-	type = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
-	textID1 = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
-	textID2 = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	type = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	textID1 = BitConverter::ToUInt16BE(rawData, rawDataIndex + 8);
+	textID2 = BitConverter::ToUInt16BE(rawData, rawDataIndex + 10);
 }
 
 CutsceneCommandTextbox::CutsceneCommandTextbox(const std::vector<uint8_t>& rawData,
@@ -990,12 +990,12 @@ size_t CutsceneCommandTextbox::GetCommandSize()
 
 ActorAction::ActorAction(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 {
-	action = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
-	rotX = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);
-	rotY = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 8);
-	rotZ = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 10);
+	action = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	rotX = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);
+	rotY = BitConverter::ToUInt16BE(rawData, rawDataIndex + 8);
+	rotZ = BitConverter::ToUInt16BE(rawData, rawDataIndex + 10);
 	startPosX = BitConverter::ToInt32BE(rawData, rawDataIndex + 12);
 	startPosY = BitConverter::ToInt32BE(rawData, rawDataIndex + 16);
 	startPosZ = BitConverter::ToInt32BE(rawData, rawDataIndex + 20);
@@ -1068,10 +1068,10 @@ CutsceneCommandTerminator::CutsceneCommandTerminator(const std::vector<uint8_t>&
 {
 	rawDataIndex += 4;
 
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
-	unknown = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 6);  // endFrame duplicate
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
+	unknown = BitConverter::ToUInt16BE(rawData, rawDataIndex + 6);  // endFrame duplicate
 }
 
 std::string CutsceneCommandTerminator::GetCName()
@@ -1096,9 +1096,9 @@ size_t CutsceneCommandTerminator::GetCommandSize()
 CutsceneCommandEnd::CutsceneCommandEnd(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 	: CutsceneCommand(rawData, rawDataIndex)
 {
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
 }
 
 std::string CutsceneCommandEnd::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)
@@ -1186,9 +1186,9 @@ size_t CutsceneCommandSpecialAction::GetCommandSize()
 CutsceneCommandNop::CutsceneCommandNop(const std::vector<uint8_t>& rawData, uint32_t rawDataIndex)
 	: CutsceneCommand(rawData, rawDataIndex)
 {
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
 }
 
 std::string CutsceneCommandNop::GetCName()
@@ -1207,9 +1207,9 @@ CutsceneCommandSceneTransFX::CutsceneCommandSceneTransFX(const std::vector<uint8
 {
 	rawDataIndex += 4;
 
-	base = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 0);
-	startFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 2);
-	endFrame = (uint16_t)BitConverter::ToInt16BE(rawData, rawDataIndex + 4);
+	base = BitConverter::ToUInt16BE(rawData, rawDataIndex + 0);
+	startFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 2);
+	endFrame = BitConverter::ToUInt16BE(rawData, rawDataIndex + 4);
 }
 
 std::string CutsceneCommandSceneTransFX::GenerateSourceCode([[maybe_unused]] uint32_t baseAddress)

--- a/tools/ZAPD/ZAPD/ZFile.cpp
+++ b/tools/ZAPD/ZAPD/ZFile.cpp
@@ -406,7 +406,7 @@ void ZFile::AddResource(ZResource* res)
 	resources.push_back(res);
 }
 
-ZResource* ZFile::FindResource(uint32_t rawDataIndex)
+ZResource* ZFile::FindResource(offset_t rawDataIndex)
 {
 	for (ZResource* res : resources)
 	{
@@ -776,6 +776,11 @@ void ZFile::GenerateSourceHeaderFiles()
 {
 	OutputFormatter formatter;
 
+	std::string objectNameUpper = StringHelper::ToUpper(GetName());
+
+	formatter.Write(StringHelper::Sprintf("#ifndef %s_H\n#define %s_H 1\n\n",
+	                                      objectNameUpper.c_str(), objectNameUpper.c_str()));
+
 	for (ZResource* res : resources)
 	{
 		std::string resSrc = res->GetSourceOutputHeader("");
@@ -791,6 +796,8 @@ void ZFile::GenerateSourceHeaderFiles()
 	}
 
 	formatter.Write(ProcessExterns());
+
+	formatter.Write("#endif\n");
 
 	fs::path headerFilename = GetSourceOutputFolderPath() / outName.stem().concat(".h");
 

--- a/tools/ZAPD/ZAPD/ZFile.h
+++ b/tools/ZAPD/ZAPD/ZFile.h
@@ -52,7 +52,7 @@ public:
 	void ExtractResources();
 	void BuildSourceFile();
 	void AddResource(ZResource* res);
-	ZResource* FindResource(uint32_t rawDataIndex);
+	ZResource* FindResource(offset_t rawDataIndex);
 	std::vector<ZResource*> GetResourcesOfType(ZResourceType resType);
 
 	Declaration* AddDeclaration(offset_t address, DeclarationAlignment alignment, size_t size,

--- a/tools/ZAPD/ZAPD/ZLimb.h
+++ b/tools/ZAPD/ZAPD/ZLimb.h
@@ -18,9 +18,14 @@ enum class ZLimbType
 	Legacy,
 };
 
+class ZLimbTable;
+
 class ZLimb : public ZResource
 {
 public:
+	std::string enumName;
+	ZLimbTable* limbsTable = nullptr;  // borrowed pointer, do not delete!
+
 	ZLimbType type = ZLimbType::Standard;
 
 	ZLimbSkinType skinSegmentType = ZLimbSkinType::SkinType_0;  // Skin only
@@ -38,6 +43,8 @@ public:
 
 	int16_t transX, transY, transZ;
 	uint8_t childIndex, siblingIndex;
+
+	uint8_t limbIndex = 0;
 
 	ZLimb(ZFile* nParent);
 
@@ -58,6 +65,8 @@ public:
 	void SetLimbType(ZLimbType value);
 	static const char* GetSourceTypeName(ZLimbType limbType);
 	static ZLimbType GetTypeByAttributeName(const std::string& attrName);
+
+	void SetLimbIndex(uint8_t nLimbIndex);
 
 protected:
 	void DeclareDList(segptr_t dListSegmentedPtr, const std::string& prefix,

--- a/tools/ZAPD/ZAPD/ZSkeleton.cpp
+++ b/tools/ZAPD/ZAPD/ZSkeleton.cpp
@@ -10,10 +10,13 @@
 REGISTER_ZFILENODE(Skeleton, ZSkeleton);
 REGISTER_ZFILENODE(LimbTable, ZLimbTable);
 
-ZSkeleton::ZSkeleton(ZFile* nParent) : ZResource(nParent), limbsTable(nParent)
+ZSkeleton::ZSkeleton(ZFile* nParent) : ZResource(nParent)
 {
 	RegisterRequiredAttribute("Type");
 	RegisterRequiredAttribute("LimbType");
+	RegisterOptionalAttribute("EnumName");
+	RegisterOptionalAttribute("LimbNone");
+	RegisterOptionalAttribute("LimbMax");
 }
 
 void ZSkeleton::ParseXML(tinyxml2::XMLElement* reader)
@@ -42,6 +45,41 @@ void ZSkeleton::ParseXML(tinyxml2::XMLElement* reader)
 		                          limbTypeXml.c_str()),
 			"Defaulting to 'Standard'.");
 	}
+
+	enumName = registeredAttributes.at("EnumName").value;
+	limbNoneName = registeredAttributes.at("LimbNone").value;
+	limbMaxName = registeredAttributes.at("LimbMax").value;
+
+	if (enumName != "")
+	{
+		if (limbNoneName == "" || limbMaxName == "")
+		{
+			HANDLE_ERROR_RESOURCE(WarningType::MissingAttribute, parent, this, rawDataIndex,
+			                      "'EnumName' attribute was used but either 'LimbNone' or "
+			                      "'LimbMax' attribute is missing",
+			                      "");
+		}
+	}
+
+	if (limbNoneName != "")
+	{
+		if (limbMaxName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"'LimbNone' attribute was used but 'LimbMax' attribute is missing", "");
+		}
+	}
+
+	if (limbMaxName != "")
+	{
+		if (limbNoneName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"'LimbMax' attribute was used but 'LimbNone' attribute is missing", "");
+		}
+	}
 }
 
 void ZSkeleton::ParseRawData()
@@ -56,12 +94,6 @@ void ZSkeleton::ParseRawData()
 	{
 		dListCount = BitConverter::ToUInt8BE(rawData, rawDataIndex + 8);
 	}
-
-	if (limbsArrayAddress != 0 && GETSEGNUM(limbsArrayAddress) == parent->segment)
-	{
-		uint32_t ptr = Seg2Filespace(limbsArrayAddress, parent->baseAddress);
-		limbsTable.ExtractFromBinary(ptr, limbType, limbCount);
-	}
 }
 
 void ZSkeleton::DeclareReferences(const std::string& prefix)
@@ -72,14 +104,33 @@ void ZSkeleton::DeclareReferences(const std::string& prefix)
 
 	ZResource::DeclareReferences(defaultPrefix);
 
-	if (limbsArrayAddress != 0 && GETSEGNUM(limbsArrayAddress) == parent->segment)
+	if (limbsArrayAddress != SEGMENTED_NULL && GETSEGNUM(limbsArrayAddress) == parent->segment)
 	{
-		uint32_t ptr = Seg2Filespace(limbsArrayAddress, parent->baseAddress);
+		offset_t ptr = Seg2Filespace(limbsArrayAddress, parent->baseAddress);
+
 		if (!parent->HasDeclaration(ptr))
 		{
-			limbsTable.SetName(StringHelper::Sprintf("%sLimbs", defaultPrefix.c_str()));
-			limbsTable.DeclareReferences(prefix);
-			limbsTable.GetSourceOutputCode(prefix);
+			limbsTable = new ZLimbTable(parent);
+			limbsTable->ExtractFromBinary(ptr, limbType, limbCount);
+			limbsTable->SetName(StringHelper::Sprintf("%sLimbs", defaultPrefix.c_str()));
+			parent->AddResource(limbsTable);
+		}
+		else
+		{
+			limbsTable = static_cast<ZLimbTable*>(parent->FindResource(ptr));
+		}
+
+		if (limbsTable->enumName == "")
+		{
+			limbsTable->enumName = enumName;
+		}
+		if (limbsTable->limbNoneName == "")
+		{
+			limbsTable->limbNoneName = limbNoneName;
+		}
+		if (limbsTable->limbMaxName == "")
+		{
+			limbsTable->limbMaxName = limbMaxName;
 		}
 	}
 }
@@ -89,14 +140,26 @@ std::string ZSkeleton::GetBodySourceCode() const
 	std::string limbArrayName;
 	Globals::Instance->GetSegmentedPtrName(limbsArrayAddress, parent, "", limbArrayName);
 
+	std::string countStr;
+	assert(limbsTable != nullptr);
+	// There are some Skeletons with the wrong limb count on them, so this check is necessary.
+	if (limbsTable->count == limbCount)
+	{
+		countStr = StringHelper::Sprintf("ARRAY_COUNT(%s)", limbArrayName.c_str());
+	}
+	else
+	{
+		countStr = StringHelper::Sprintf("%i", limbCount);
+	}
+
 	switch (type)
 	{
 	case ZSkeletonType::Normal:
 	case ZSkeletonType::Curve:
-		return StringHelper::Sprintf("\n\t%s, %i\n", limbArrayName.c_str(), limbCount);
+		return StringHelper::Sprintf("\n\t%s, %s\n", limbArrayName.c_str(), countStr.c_str());
 
 	case ZSkeletonType::Flex:
-		return StringHelper::Sprintf("\n\t{ %s, %i }, %i\n", limbArrayName.c_str(), limbCount,
+		return StringHelper::Sprintf("\n\t{ %s, %s }, %i\n", limbArrayName.c_str(), countStr.c_str(),
 		                             dListCount);
 	}
 
@@ -153,6 +216,9 @@ ZLimbTable::ZLimbTable(ZFile* nParent) : ZResource(nParent)
 {
 	RegisterRequiredAttribute("LimbType");
 	RegisterRequiredAttribute("Count");
+	RegisterOptionalAttribute("EnumName");
+	RegisterOptionalAttribute("LimbNone");
+	RegisterOptionalAttribute("LimbMax");
 }
 
 void ZLimbTable::ExtractFromBinary(uint32_t nRawDataIndex, ZLimbType nLimbType, size_t nCount)
@@ -179,6 +245,40 @@ void ZLimbTable::ParseXML(tinyxml2::XMLElement* reader)
 	}
 
 	count = StringHelper::StrToL(registeredAttributes.at("Count").value);
+
+	enumName = registeredAttributes.at("EnumName").value;
+	limbNoneName = registeredAttributes.at("LimbNone").value;
+	limbMaxName = registeredAttributes.at("LimbMax").value;
+
+	if (enumName != "")
+	{
+		if (limbNoneName == "" || limbMaxName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"'EnumName' attribute was used but 'LimbNone'/'LimbMax' attributes is missing", "");
+		}
+	}
+
+	if (limbNoneName != "")
+	{
+		if (limbMaxName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"'LimbNone' attribute was used but 'LimbMax' attribute is missing", "");
+		}
+	}
+
+	if (limbMaxName != "")
+	{
+		if (limbNoneName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"'LimbMax' attribute was used but 'LimbNone' attribute is missing", "");
+		}
+	}
 }
 
 void ZLimbTable::ParseRawData()
@@ -209,15 +309,28 @@ void ZLimbTable::DeclareReferences(const std::string& prefix)
 		if (limbAddress != 0 && GETSEGNUM(limbAddress) == parent->segment)
 		{
 			uint32_t limbOffset = Seg2Filespace(limbAddress, parent->baseAddress);
+			ZLimb* limb;
+
 			if (!parent->HasDeclaration(limbOffset))
 			{
-				ZLimb* limb = new ZLimb(parent);
+				limb = new ZLimb(parent);
 				limb->ExtractFromBinary(limbOffset, limbType);
 				limb->SetName(limb->GetDefaultName(varPrefix));
 				limb->DeclareVar(varPrefix, "");
 				limb->DeclareReferences(varPrefix);
 				parent->AddResource(limb);
 			}
+			else
+			{
+				limb = static_cast<ZLimb*>(parent->FindResource(limbOffset));
+				assert(limb != nullptr);
+				assert(limb->GetResourceType() == ZResourceType::Limb);
+			}
+
+			limb->limbsTable = this;
+			limb->SetLimbIndex(i + 1);
+
+			limbsReferences.push_back(limb);
 		}
 	}
 }
@@ -246,11 +359,58 @@ std::string ZLimbTable::GetBodySourceCode() const
 		Globals::Instance->GetSegmentedPtrName(limbsAddresses[i], parent, "", limbName);
 		body += StringHelper::Sprintf("\t%s,", limbName.c_str());
 
+		auto& limb = limbsReferences.at(i);
+		std::string limbEnumName = limb->enumName;
+		if (limbEnumName != "")
+		{
+			body += StringHelper::Sprintf(" /* %s */", limbEnumName.c_str());
+		}
+
 		if (i + 1 < count)
 			body += "\n";
 	}
 
 	return body;
+}
+
+std::string ZLimbTable::GetSourceOutputHeader([[maybe_unused]] const std::string& prefix)
+{
+	if (limbNoneName == "" || limbMaxName == "" || enumName == "")
+	{
+		// Don't produce a enum of any of those attributes is missing
+		return "";
+	}
+
+	std::string limbEnum = StringHelper::Sprintf("typedef enum %s {\n", enumName.c_str());
+
+	// This assumes there isn't any skeleton with more than 0x100 limbs
+
+	limbEnum += StringHelper::Sprintf("    /* 0x00 */ %s,\n", limbNoneName.c_str());
+
+	size_t i = 0;
+	for (; i < count; i++)
+	{
+		auto& limb = limbsReferences.at(i);
+		std::string limbEnumName = limb->enumName;
+
+		if (limbEnumName == "")
+		{
+			HANDLE_ERROR_RESOURCE(
+				WarningType::MissingAttribute, parent, this, rawDataIndex,
+				"Skeleton's enum attributes were used but at least one limb is missing its "
+				"'LimbName' attribute",
+				StringHelper::Sprintf("When processing limb %02i, named '%s' at offset '0x%X'",
+			                          i + 1, limb->GetName().c_str(), limb->GetRawDataIndex()));
+		}
+
+		limbEnum += StringHelper::Sprintf("    /* 0x%02X */ %s,\n", i + 1, limbEnumName.c_str());
+	}
+
+	limbEnum += StringHelper::Sprintf("    /* 0x%02X */ %s\n", i + 1, limbMaxName.c_str());
+
+	limbEnum += StringHelper::Sprintf("} %s;\n", enumName.c_str());
+
+	return limbEnum;
 }
 
 std::string ZLimbTable::GetSourceTypeName() const
@@ -282,4 +442,29 @@ ZResourceType ZLimbTable::GetResourceType() const
 size_t ZLimbTable::GetRawDataSize() const
 {
 	return 4 * limbsAddresses.size();
+}
+
+std::string ZLimbTable::GetLimbEnumName(uint8_t limbIndex) const
+{
+	if (limbIndex == 0xFF)
+	{
+		return "LIMB_DONE";
+	}
+
+	if (limbIndex < count)
+	{
+		std::string limbEnumName = limbsReferences.at(limbIndex)->enumName;
+		if (limbEnumName != "")
+		{
+			return StringHelper::Sprintf("%s - 1", limbEnumName.c_str());
+		}
+	}
+	else
+	{
+		HANDLE_WARNING_RESOURCE(WarningType::InvalidExtractedData, parent, this, rawDataIndex,
+		                        StringHelper::Sprintf("Limb index '%02i' out of range", limbIndex),
+		                        "");
+	}
+
+	return StringHelper::Sprintf("0x%02X", limbIndex);
 }

--- a/tools/ZAPD/ZAPD/ZSkeleton.h
+++ b/tools/ZAPD/ZAPD/ZSkeleton.h
@@ -18,6 +18,17 @@ enum class ZSkeletonType
 class ZLimbTable : public ZResource
 {
 public:
+	ZLimbType limbType = ZLimbType::Standard;
+	size_t count = 0;
+
+	std::vector<segptr_t> limbsAddresses;
+	std::vector<ZLimb*> limbsReferences;  // borrowed pointers, do not delete!
+
+	// XML attributes
+	std::string enumName;
+	std::string limbNoneName;
+	std::string limbMaxName;
+
 	ZLimbTable(ZFile* nParent);
 
 	void ExtractFromBinary(uint32_t nRawDataIndex, ZLimbType nLimbType, size_t nCount);
@@ -30,16 +41,14 @@ public:
 
 	std::string GetBodySourceCode() const override;
 
+	std::string GetSourceOutputHeader(const std::string& prefix) override;
+
 	std::string GetSourceTypeName() const override;
 	ZResourceType GetResourceType() const override;
 
 	size_t GetRawDataSize() const override;
 
-protected:
-	ZLimbType limbType = ZLimbType::Standard;
-	size_t count = 0;
-
-	std::vector<segptr_t> limbsAddresses;
+	std::string GetLimbEnumName(uint8_t limbIndex) const;
 };
 
 class ZSkeleton : public ZResource
@@ -47,6 +56,10 @@ class ZSkeleton : public ZResource
 public:
 	ZSkeletonType type = ZSkeletonType::Normal;
 	ZLimbType limbType = ZLimbType::Standard;
+	std::string enumName;
+	std::string limbNoneName;
+	std::string limbMaxName;
+
 	segptr_t limbsArrayAddress;
 	uint8_t limbCount = 0;
 	uint8_t dListCount = 0;  // FLEX SKELETON ONLY
@@ -68,5 +81,5 @@ public:
 	uint8_t GetLimbCount();
 
 protected:
-	ZLimbTable limbsTable;
+	ZLimbTable* limbsTable = nullptr;  // borrowed pointer, do not delete!
 };

--- a/tools/ZAPD/ZAPD/ZTexture.cpp
+++ b/tools/ZAPD/ZAPD/ZTexture.cpp
@@ -350,34 +350,42 @@ void ZTexture::DeclareReferences([[maybe_unused]] const std::string& prefix)
 
 void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 {
+	textureData.ReadPng(pngFilePath);
+
+	width = textureData.GetWidth();
+	height = textureData.GetHeight();
+
+	textureDataRaw.clear();
+	textureDataRaw.resize(ALIGN8(GetRawDataSize()));
+
 	switch (format)
 	{
 	case TextureType::RGBA16bpp:
-		PrepareRawDataRGBA16(pngFilePath);
+		PrepareRawDataRGBA16();
 		break;
 	case TextureType::RGBA32bpp:
-		PrepareRawDataRGBA32(pngFilePath);
+		PrepareRawDataRGBA32();
 		break;
 	case TextureType::Grayscale4bpp:
-		PrepareRawDataGrayscale4(pngFilePath);
+		PrepareRawDataGrayscale4();
 		break;
 	case TextureType::Grayscale8bpp:
-		PrepareRawDataGrayscale8(pngFilePath);
+		PrepareRawDataGrayscale8();
 		break;
 	case TextureType::GrayscaleAlpha4bpp:
-		PrepareRawDataGrayscaleAlpha4(pngFilePath);
+		PrepareRawDataGrayscaleAlpha4();
 		break;
 	case TextureType::GrayscaleAlpha8bpp:
-		PrepareRawDataGrayscaleAlpha8(pngFilePath);
+		PrepareRawDataGrayscaleAlpha8();
 		break;
 	case TextureType::GrayscaleAlpha16bpp:
-		PrepareRawDataGrayscaleAlpha16(pngFilePath);
+		PrepareRawDataGrayscaleAlpha16();
 		break;
 	case TextureType::Palette4bpp:
-		PrepareRawDataPalette4(pngFilePath);
+		PrepareRawDataPalette4();
 		break;
 	case TextureType::Palette8bpp:
-		PrepareRawDataPalette8(pngFilePath);
+		PrepareRawDataPalette8();
 		break;
 	case TextureType::Error:
 		HANDLE_ERROR_PROCESS(WarningType::InvalidPNG, "Input PNG file has invalid format type", "");
@@ -385,15 +393,8 @@ void ZTexture::PrepareRawDataFromFile(const fs::path& pngFilePath)
 	}
 }
 
-void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
+void ZTexture::PrepareRawDataRGBA16()
 {
-	textureData.ReadPng(rgbaPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -415,15 +416,8 @@ void ZTexture::PrepareRawDataRGBA16(const fs::path& rgbaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
+void ZTexture::PrepareRawDataRGBA32()
 {
-	textureData.ReadPng(rgbaPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -439,15 +433,8 @@ void ZTexture::PrepareRawDataRGBA32(const fs::path& rgbaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
+void ZTexture::PrepareRawDataGrayscale4()
 {
-	textureData.ReadPng(grayPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -461,15 +448,8 @@ void ZTexture::PrepareRawDataGrayscale4(const fs::path& grayPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
+void ZTexture::PrepareRawDataGrayscale8()
 {
-	textureData.ReadPng(grayPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -481,15 +461,8 @@ void ZTexture::PrepareRawDataGrayscale8(const fs::path& grayPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha4()
 {
-	textureData.ReadPng(grayAlphaPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -514,15 +487,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha8()
 {
-	textureData.ReadPng(grayAlphaPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -538,15 +504,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
+void ZTexture::PrepareRawDataGrayscaleAlpha16()
 {
-	textureData.ReadPng(grayAlphaPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)
@@ -563,15 +522,8 @@ void ZTexture::PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath)
 	}
 }
 
-void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
+void ZTexture::PrepareRawDataPalette4()
 {
-	textureData.ReadPng(palPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x += 2)
@@ -586,15 +538,8 @@ void ZTexture::PrepareRawDataPalette4(const fs::path& palPath)
 	}
 }
 
-void ZTexture::PrepareRawDataPalette8(const fs::path& palPath)
+void ZTexture::PrepareRawDataPalette8()
 {
-	textureData.ReadPng(palPath);
-
-	width = textureData.GetWidth();
-	height = textureData.GetHeight();
-
-	textureDataRaw.clear();
-	textureDataRaw.resize(GetRawDataSize());
 	for (uint16_t y = 0; y < height; y++)
 	{
 		for (uint16_t x = 0; x < width; x++)

--- a/tools/ZAPD/ZAPD/ZTexture.h
+++ b/tools/ZAPD/ZAPD/ZTexture.h
@@ -40,15 +40,15 @@ protected:
 	void PrepareBitmapPalette8();
 
 	void PrepareRawDataFromFile(const fs::path& inFolder);
-	void PrepareRawDataRGBA16(const fs::path& rgbaPath);
-	void PrepareRawDataRGBA32(const fs::path& rgbaPath);
-	void PrepareRawDataGrayscale4(const fs::path& grayPath);
-	void PrepareRawDataGrayscale8(const fs::path& grayPath);
-	void PrepareRawDataGrayscaleAlpha4(const fs::path& grayAlphaPath);
-	void PrepareRawDataGrayscaleAlpha8(const fs::path& grayAlphaPath);
-	void PrepareRawDataGrayscaleAlpha16(const fs::path& grayAlphaPath);
-	void PrepareRawDataPalette4(const fs::path& palPath);
-	void PrepareRawDataPalette8(const fs::path& palPath);
+	void PrepareRawDataRGBA16();
+	void PrepareRawDataRGBA32();
+	void PrepareRawDataGrayscale4();
+	void PrepareRawDataGrayscale8();
+	void PrepareRawDataGrayscaleAlpha4();
+	void PrepareRawDataGrayscaleAlpha8();
+	void PrepareRawDataGrayscaleAlpha16();
+	void PrepareRawDataPalette4();
+	void PrepareRawDataPalette8();
 
 public:
 	ZTexture(ZFile* nParent);

--- a/tools/ZAPD/ZAPDUtils/Utils/BitConverter.h
+++ b/tools/ZAPD/ZAPDUtils/Utils/BitConverter.h
@@ -1,155 +1,155 @@
 #pragma once
 
+#include <cinttypes>
 #include <cstdint>
+#include <cstdio>
 #include <limits>
 #include <vector>
+
+#define ALIGN8(val) (((val) + 7) & ~7)
+#define ALIGN16(val) (((val) + 0xF) & ~0xF)
+#define ALIGN64(val) (((val) + 0x3F) & ~0x3F)
 
 class BitConverter
 {
 public:
-	static inline int8_t ToInt8BE(const uint8_t* data, int32_t offset)
+	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return (uint8_t)data[offset + 0];
+		if (offset + 0 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return (int8_t)data.at(offset + 0);
 	}
 
-	static inline int8_t ToInt8BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return (uint8_t)data[offset + 0];
+		if (offset + 0 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying an out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return (uint8_t)data.at(offset + 0);
 	}
 
-	static inline uint8_t ToUInt8BE(const uint8_t* data, int32_t offset)
+	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return (uint8_t)data[offset + 0];
+		if (offset + 1 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
-	static inline uint8_t ToUInt8BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return (uint8_t)data[offset + 0];
+		if (offset + 1 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint16_t)data.at(offset + 0) << 8) + (uint16_t)data.at(offset + 1);
 	}
 
-	static inline int16_t ToInt16BE(const uint8_t* data, int32_t offset)
+	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		if (offset + 3 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
+			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
-	static inline int16_t ToInt16BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		if (offset + 3 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint32_t)data.at(offset + 0) << 24) + ((uint32_t)data.at(offset + 1) << 16) +
+			   ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 	}
 
-	static inline uint16_t ToUInt16BE(const uint8_t* data, int32_t offset)
+	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		if (offset + 7 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
-	static inline uint16_t ToUInt16BE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return ((uint16_t)data[offset + 0] << 8) + (uint16_t)data[offset + 1];
+		if (offset + 7 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
+		return ((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			   ((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			   ((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			   ((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 	}
 
-	static inline int32_t ToInt32BE(const uint8_t* data, int32_t offset)
+	static inline float ToFloatBE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline int32_t ToInt32BE(const std::vector<uint8_t>& data, int32_t offset)
-	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline uint32_t ToUInt32BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline uint32_t ToUInt32BE(const std::vector<uint8_t>& data, int32_t offset)
-	{
-		return ((uint32_t)data[offset + 0] << 24) + ((uint32_t)data[offset + 1] << 16) +
-			   ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-	}
-
-	static inline int64_t ToInt64BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline int64_t ToInt64BE(const std::vector<uint8_t>& data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline uint64_t ToUInt64BE(const uint8_t* data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline uint64_t ToUInt64BE(const std::vector<uint8_t>& data, int32_t offset)
-	{
-		return ((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			   ((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			   ((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			   ((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-	}
-
-	static inline float ToFloatBE(const uint8_t* data, int32_t offset)
-	{
+		if (offset + 3 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		float value;
-		uint32_t floatData = ((uint32_t)data[offset + 0] << 24) +
-							 ((uint32_t)data[offset + 1] << 16) +
-							 ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
+		uint32_t floatData = ((uint32_t)data.at(offset + 0) << 24) +
+							 ((uint32_t)data.at(offset + 1) << 16) +
+							 ((uint32_t)data.at(offset + 2) << 8) + (uint32_t)data.at(offset + 3);
 		static_assert(sizeof(uint32_t) == sizeof(float), "expected 32-bit float");
 		std::memcpy(&value, &floatData, sizeof(value));
 		return value;
 	}
 
-	static inline float ToFloatBE(const std::vector<uint8_t>& data, int32_t offset)
+	static inline double ToDoubleBE(const std::vector<uint8_t>& data, size_t offset)
 	{
-		float value;
-		uint32_t floatData = ((uint32_t)data[offset + 0] << 24) +
-							 ((uint32_t)data[offset + 1] << 16) +
-							 ((uint32_t)data[offset + 2] << 8) + (uint32_t)data[offset + 3];
-		static_assert(sizeof(uint32_t) == sizeof(float), "expected 32-bit float");
-		std::memcpy(&value, &floatData, sizeof(value));
-		return value;
-	}
-
-	static inline double ToDoubleBE(const uint8_t* data, int32_t offset)
-	{
+		if (offset + 7 > data.size())
+		{
+			fprintf(stderr, "%s\n", __PRETTY_FUNCTION__);
+			fprintf(stderr, "Error: Trying a out-of-bounds reading from a data buffer\n");
+			fprintf(stderr, "\t Buffer size: 0x%zX\n", data.size());
+			fprintf(stderr, "\t Trying to read at offset: 0x%zX\n", offset);
+		}
 		double value;
 		uint64_t floatData =
-			((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
-		static_assert(sizeof(uint64_t) == sizeof(double), "expected 64-bit double");
-		// Checks if the float format on the platform the ZAPD binary is running on supports the
-		// same float format as the object file.
-		static_assert(std::numeric_limits<float>::is_iec559,
-		              "expected IEC559 floats on host machine");
-		std::memcpy(&value, &floatData, sizeof(value));
-		return value;
-	}
-
-	static inline double ToDoubleBE(const std::vector<uint8_t>& data, int32_t offset)
-	{
-		double value;
-		uint64_t floatData =
-			((uint64_t)data[offset + 0] << 56) + ((uint64_t)data[offset + 1] << 48) +
-			((uint64_t)data[offset + 2] << 40) + ((uint64_t)data[offset + 3] << 32) +
-			((uint64_t)data[offset + 4] << 24) + ((uint64_t)data[offset + 5] << 16) +
-			((uint64_t)data[offset + 6] << 8) + ((uint64_t)data[offset + 7]);
+			((uint64_t)data.at(offset + 0) << 56) + ((uint64_t)data.at(offset + 1) << 48) +
+			((uint64_t)data.at(offset + 2) << 40) + ((uint64_t)data.at(offset + 3) << 32) +
+			((uint64_t)data.at(offset + 4) << 24) + ((uint64_t)data.at(offset + 5) << 16) +
+			((uint64_t)data.at(offset + 6) << 8) + ((uint64_t)data.at(offset + 7));
 		static_assert(sizeof(uint64_t) == sizeof(double), "expected 64-bit double");
 		// Checks if the float format on the platform the ZAPD binary is running on supports the
 		// same float format as the object file.

--- a/tools/ZAPD/ZAPDUtils/Utils/StringHelper.h
+++ b/tools/ZAPD/ZAPDUtils/Utils/StringHelper.h
@@ -106,6 +106,13 @@ public:
 		return std::all_of(str.begin(), str.end(), ::isdigit);
 	}
 
+	static std::string ToUpper(const std::string& str)
+	{
+		std::string buff = str;
+		std::transform(buff.begin(), buff.end(), buff.begin(), ::toupper);
+		return buff;
+	}
+
 	static bool IEquals(const std::string& a, const std::string& b)
 	{
 		return std::equal(a.begin(), a.end(), b.begin(), b.end(),

--- a/tools/ZAPD/docs/zapd_extraction_xml_reference.md
+++ b/tools/ZAPD/docs/zapd_extraction_xml_reference.md
@@ -382,6 +382,13 @@ Useful only for the unused `object_human`'s animation data.
   - `Name`: Required. Suxffixed by `Skel`.
   - `Type`: Required. Valid values: `Normal`, `Flex` and `Curve`.
   - `LimbType`: Required. Valid values: `Standard`, `LOD`, `Skin`, `Curve` and `Legacy`.
+  - `EnumName`: Optional. The name of `typedef`'d limb enum.
+  - `LimbNone`: Optional. The name of the limb with index zero in the limb enum.
+  - `LimbMax`: Optional. The name of the max limb index in the limb enum.
+
+ZAPD is able to generate a limb enum by itself only if all the required data is provided. Providing some but not all the required data would trigger an error and the execution will halt.
+
+The required data is providing the `EnumName`, `LimbNone` and `LimbMax` attributes in the `Skeleton` or `LimbTable` node and the `EnumName` attribute in every `Limb` of this skeleton.
 
 ※ There are no restrictions in the `Type` and `LimbType` attributes besides the valid values, so any skeleton type can be combined with any limb type.
 
@@ -400,6 +407,11 @@ Useful only for the unused `object_human`'s animation data.
   - `Name`: Required. Suxffixed by `Skel`.
   - `LimbType`: Required. Valid values: `Standard`, `LOD`, `Skin`, `Curve` and `Legacy`.
   - `Count`: Required. Amount of limbs. Integer.
+  - `EnumName`: Optional. The name of `typedef`'d limb enum.
+  - `LimbNone`: Optional. The name of the limb with index zero in the limb enum.
+  - `LimbMax`: Optional. The name of the max limb index in the limb enum.
+
+See [Skeleton](#skeleton) for info on the limb enum generation.
 
 -------------------------
 
@@ -415,6 +427,9 @@ Useful only for the unused `object_human`'s animation data.
 
   - `Name`: Required. Suxffixed by `Limb`.
   - `LimbType`: Required. Valid values: `Standard`, `LOD`, `Skin`, `Curve` and `Legacy`.
+  - `EnumName`: Optional. The name used for this limb in the limbs enum. It must be either present in every limb or in none.
+
+See [Skeleton](#skeleton) for info on the limb enum generation.
 
 -------------------------
 


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Fixes a problem described in https://github.com/zeldaret/ZAPD/pull/236

Also includes the limb enum generation from https://github.com/zeldaret/ZAPD/pull/236