### PR TITLE
Document sun textures/displaylist

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1319,7 +1319,7 @@
         <Texture Name="gSun1Tex" OutName="sun_1" Format="i4" Width="64" Height="31" Offset="0x79B10" />
         <Texture Name="gSun2Tex" OutName="sun_2" Format="i4" Width="64" Height="16" Offset="0x79EF0" />
         <Texture Name="gSun3Tex" OutName="sun_3" Format="i4" Width="64" Height="17" Offset="0x7A0F0" />
-        <Texture Name="gSunEvening1Tex" OutName="sun_evening" Format="i4" Width="64" Height="31" Offset="0x7A310" />
+        <Texture Name="gSunEvening1Tex" OutName="sun_evening_1" Format="i4" Width="64" Height="31" Offset="0x7A310" />
         <Texture Name="gSunEvening2Tex" OutName="sun_evening_2" Format="i4" Width="64" Height="16" Offset="0x7A6F0" />
         <Texture Name="gSunEvening3Tex" OutName="sun_evening_3" Format="i4" Width="64" Height="17" Offset="0x7A8F0" />
         <DList Name="gameplay_keep_DL_07AB10" Offset="0x7AB10" /> <!-- sun (sparkles when small) displaylist -->

--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1316,12 +1316,15 @@
         <Texture Name="gameplay_keep_Tex_077A40" OutName="tex_077A40" Format="ia8" Width="32" Height="128" Offset="0x77A40" />
         <DList Name="gameplay_keep_DL_078A80" Offset="0x78A80" />
         <Texture Name="gameplay_keep_Tex_078B10" OutName="tex_078B10" Format="rgba16" Width="32" Height="64" Offset="0x78B10" />
+
+        <!-- Sun Textures. These should be 64x64, but they get broken into pieces in gSunDL, and ZAPD cannot currently handle that. -->
         <Texture Name="gSun1Tex" OutName="sun_1" Format="i4" Width="64" Height="31" Offset="0x79B10" />
         <Texture Name="gSun2Tex" OutName="sun_2" Format="i4" Width="64" Height="16" Offset="0x79EF0" />
         <Texture Name="gSun3Tex" OutName="sun_3" Format="i4" Width="64" Height="17" Offset="0x7A0F0" />
         <Texture Name="gSunEvening1Tex" OutName="sun_evening_1" Format="i4" Width="64" Height="31" Offset="0x7A310" />
         <Texture Name="gSunEvening2Tex" OutName="sun_evening_2" Format="i4" Width="64" Height="16" Offset="0x7A6F0" />
         <Texture Name="gSunEvening3Tex" OutName="sun_evening_3" Format="i4" Width="64" Height="17" Offset="0x7A8F0" />
+        
         <DList Name="gameplay_keep_DL_07AB10" Offset="0x7AB10" /> <!-- sun (sparkles when small) displaylist -->
         <DList Name="gameplay_keep_DL_07AB58" Offset="0x7AB58" />
         <DList Name="gSunDL" Offset="0x7AB70" />

--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1316,15 +1316,15 @@
         <Texture Name="gameplay_keep_Tex_077A40" OutName="tex_077A40" Format="ia8" Width="32" Height="128" Offset="0x77A40" />
         <DList Name="gameplay_keep_DL_078A80" Offset="0x78A80" />
         <Texture Name="gameplay_keep_Tex_078B10" OutName="tex_078B10" Format="rgba16" Width="32" Height="64" Offset="0x78B10" />
-        <Texture Name="gameplay_keep_Tex_079B10" OutName="tex_079B10" Format="i4" Width="64" Height="31" Offset="0x79B10" />
-        <Texture Name="gameplay_keep_Tex_079EF0" OutName="tex_079EF0" Format="i4" Width="64" Height="16" Offset="0x79EF0" />
-        <Texture Name="gameplay_keep_Tex_07A0F0" OutName="tex_07A0F0" Format="i4" Width="64" Height="17" Offset="0x7A0F0" />
-        <Texture Name="gameplay_keep_Tex_07A310" OutName="tex_07A310" Format="i4" Width="64" Height="31" Offset="0x7A310" />
-        <Texture Name="gameplay_keep_Tex_07A6F0" OutName="tex_07A6F0" Format="i4" Width="64" Height="16" Offset="0x7A6F0" />
-        <Texture Name="gameplay_keep_Tex_07A8F0" OutName="tex_07A8F0" Format="i4" Width="64" Height="17" Offset="0x7A8F0" />
+        <Texture Name="gSun1Tex" OutName="sun_1" Format="i4" Width="64" Height="31" Offset="0x79B10" />
+        <Texture Name="gSun2Tex" OutName="sun_2" Format="i4" Width="64" Height="16" Offset="0x79EF0" />
+        <Texture Name="gSun3Tex" OutName="sun_3" Format="i4" Width="64" Height="17" Offset="0x7A0F0" />
+        <Texture Name="gSunEvening1Tex" OutName="sun_evening" Format="i4" Width="64" Height="31" Offset="0x7A310" />
+        <Texture Name="gSunEvening2Tex" OutName="sun_evening_2" Format="i4" Width="64" Height="16" Offset="0x7A6F0" />
+        <Texture Name="gSunEvening3Tex" OutName="sun_evening_3" Format="i4" Width="64" Height="17" Offset="0x7A8F0" />
         <DList Name="gameplay_keep_DL_07AB10" Offset="0x7AB10" /> <!-- sun (sparkles when small) displaylist -->
         <DList Name="gameplay_keep_DL_07AB58" Offset="0x7AB58" />
-        <DList Name="gameplay_keep_DL_07AB70" Offset="0x7AB70" />
+        <DList Name="gSunDL" Offset="0x7AB70" />
         <DList Name="gZTargetLockOnTriangleDL" Offset="0x7AE00" />
         <DList Name="gameplay_keep_DL_07AFB0" Offset="0x7AFB0" />
         <DList Name="gameplay_keep_DL_07B0B8" Offset="0x7B0B8" />

--- a/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
+++ b/src/overlays/actors/ovl_Demo_Kankyo/z_demo_kankyo.c
@@ -523,7 +523,7 @@ void DemoKakyo_DrawLostWoodsSparkle(Actor* thisx, GlobalContext* globalCtx2) {
 
         POLY_XLU_DISP = Gfx_CallSetupDL(POLY_XLU_DISP, 20);
 
-        gSPSegment(POLY_XLU_DISP++, 0x08, Lib_SegmentedToVirtual(gameplay_keep_Tex_079B10));
+        gSPSegment(POLY_XLU_DISP++, 0x08, Lib_SegmentedToVirtual(gSun1Tex));
         gSPDisplayList(POLY_XLU_DISP++, gameplay_keep_DL_07AB10);
 
         for (i = 0; i < globalCtx->envCtx.unk_F2[3]; i++) {

--- a/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
+++ b/src/overlays/actors/ovl_En_Encount2/z_en_encount2.c
@@ -277,7 +277,7 @@ void EnEncount2_DrawParticles(EnEncount2* this, GlobalContext* globalCtx) {
             Matrix_InsertTranslation(sPtr->pos.x, sPtr->pos.y, sPtr->pos.z, MTXMODE_NEW);
             Matrix_Scale(sPtr->scale, sPtr->scale, sPtr->scale, MTXMODE_APPLY);
             POLY_XLU_DISP = Gfx_CallSetupDL(POLY_XLU_DISP, 20);
-            gSPSegment(POLY_XLU_DISP++, 0x08, Lib_SegmentedToVirtual(gameplay_keep_Tex_079B10));
+            gSPSegment(POLY_XLU_DISP++, 0x08, Lib_SegmentedToVirtual(gSun1Tex));
             gSPDisplayList(POLY_XLU_DISP++, gameplay_keep_DL_07AB10);
             gDPPipeSync(POLY_XLU_DISP++);
             gDPSetPrimColor(POLY_XLU_DISP++, 0, 0, 255, 255, 255, 255);


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
There was some talk about how the sun worked in OoT today, so I ported over the OoT names into MM. According to Emil, these should actually be a single 64x64 texture, but that doesn't quite work with ZAPD, so I left them as three separate textures for now.