### PR TITLE
Fix two small things in Bg_F40_Switch

### DIFF
--- a/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.h
+++ b/src/overlays/actors/ovl_Bg_F40_Switch/z_bg_f40_switch.h
@@ -5,12 +5,12 @@
 
 struct BgF40Switch;
 
-#define BGF40SWITCH_GET_SWITCHFLAG(this) (((this)->actor.actor.params & 0xFE00) >> 9)
+#define BGF40SWITCH_GET_SWITCHFLAG(thisx) (((thisx)->params & 0xFE00) >> 9)
 
 typedef void (*BgF40SwitchActionFunc)(struct BgF40Switch*, GlobalContext*);
 
 typedef struct BgF40Switch {
-    /* 0x0000 */ DynaPolyActor actor;
+    /* 0x0000 */ DynaPolyActor dyna;
     /* 0x015C */ s16 switchReleaseDelay; // frames until a pressed switch becomes released if nothing is still pressing it
     /* 0x015E */ s8 isPressed; // Logical state of the switch (pressed or unpressed). Animation state may lag behind this slightly.
     /* 0x015F */ s8 wasPressed; // used as temporary during update function


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
mzx pointed out in discord that this file was using `this` for the params macro instead of `thisx`, so I went and fixed that. While I was in there, I noticed that the `DynaPolyActor*` was called `actor` instead of `dyna`, so I fixed that too.