### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,26 @@ We recommend using Debian or Ubuntu 20.04 Linux distributions.
 
 ### MacOS
 
-Preparation is covered in a [separate document](docsBUILDING_MACOS.md).
+Preparation is covered in a [separate document](docs/BUILDING_MACOS.md).
 
 
 ### Linux (Native or under WSL / VM)
 
-#### 1. Install build dependencies
+#### 1. Fork the repository
+
+Create your own fork of the repository at `https://github.com/zeldaret/mm`. Then clone your fork where you wish to have the project, with the command:
+
+```bash
+git clone https://github.com/<YOUR_USERNAME>/mm.git
+```
+
+This will copy the GitHub repository contents into a new folder in the current directory called `mm`. Change into this directory before doing anything else:
+
+```bash
+cd mm
+```
+
+#### 2. Install build dependencies
 
 The build process has the following package requirements:
 
@@ -78,14 +92,6 @@ To install the Python dependencies simply run in a terminal:
 
 ```bash
 python3 -m pip install -r requirements.txt
-```
-
-#### 2. Fork the repository
-
-Create your own fork of the repository at `https://github.com/zeldaret/mm`. Then clone your fork where you wish to have the project, with the command:
-
-```bash
-git clone https://github.com/<YOUR_USERNAME>/mm.git
 ```
 
 #### 3. Prepare a base ROM


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

This was brought up in discord awhile ago (forget when or where), but cloning the repo should be the first step, since our setup requires using `requirments.txt` in the repo for python dependencies. So this PR changes steps 1 and 2, as well as fix the linking bug in the MacOS instructions.