### PR TITLE
ABI FPR names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,9 @@ AS         := $(MIPS_BINUTILS_PREFIX)as
 LD         := $(MIPS_BINUTILS_PREFIX)ld
 OBJCOPY    := $(MIPS_BINUTILS_PREFIX)objcopy
 OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
-# ASM_PROC   := python3 tools/asm-processor/build.py --input-enc=utf-8 --output-enc=euc-jp
 ASM_PROC   := python3 tools/asm-processor/build.py
+
+ASM_PROC_FLAGS := --input-enc=utf-8 --output-enc=euc-jp
 
 IINC       := -Iinclude -Isrc -Iassets -Ibuild -I.
 
@@ -183,6 +184,7 @@ build/src/libultra/flash/%.o: MIPS_VERSION := -mips1
 build/src/code/audio/%.o: OPTFLAGS := -O2
 
 build/assets/%.o: OPTFLAGS := -O1
+build/assets/%.o: ASM_PROC_FLAGS := 
 
 # file flags
 build/src/boot_O2_g3/fault.o: CFLAGS += -trapuv
@@ -199,19 +201,19 @@ build/src/libultra/libc/llcvt.o: OPTFLAGS := -O1
 build/src/libultra/libc/llcvt.o: MIPS_VERSION := -mips3 -32
 
 # cc & asm-processor
-build/src/boot_O2/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
-build/src/boot_O2_g3/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
+build/src/boot_O2/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
+build/src/boot_O2_g3/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
 
 build/src/libultra/%.o: CC := $(CC_OLD)
 # Needed at least until voice is decompiled
-build/src/libultra/voice/%.o: CC := $(ASM_PROC) $(CC_OLD) -- $(AS) $(ASFLAGS) --
+build/src/libultra/voice/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC_OLD) -- $(AS) $(ASFLAGS) --
 
-build/src/code/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
-build/src/code/audio/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
+build/src/code/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
+build/src/code/audio/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
 
-build/src/overlays/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
+build/src/overlays/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
 
-build/assets/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
+build/assets/%.o: CC := $(ASM_PROC) $(ASM_PROC_FLAGS) $(CC) -- $(AS) $(ASFLAGS) --
 
 #### Main Targets ###
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ MIPS_VERSION := -mips2
 CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm $(IINC) -nostdinc -Wab,-r4300_mul -woff 624,649,838,712
 
 # Use relocations and abi fpr names in the dump
-OBJDUMP_FLAGS := -dr -Mreg-names=32
+OBJDUMP_FLAGS := -d -r -Mreg-names=32
 
 ifeq ($(shell getconf LONG_BIT), 32)
   # Work around memory allocation bug in QEMU
@@ -211,7 +211,7 @@ build/src/code/audio/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
 
 build/src/overlays/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
 
-build/assets/%.o: CC := python3 tools/asm-processor/build.py $(CC) -- $(AS) $(ASFLAGS) --
+build/assets/%.o: CC := $(ASM_PROC) $(CC) -- $(AS) $(ASFLAGS) --
 
 #### Main Targets ###
 
@@ -323,7 +323,7 @@ build/src/libultra/libc/ll.o: src/libultra/libc/ll.c
 	$(CC_CHECK) $<
 	$(CC) -c $(CFLAGS) $(MIPS_VERSION) $(OPTFLAGS) -o $@ $<
 	python3 tools/set_o32abi_bit.py $@
-	@$(OBJDUMP) -$(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
+	@$(OBJDUMP) $(OBJDUMP_FLAGS) $@ > $(@:.o=.s)
 	$(RM_MDEBUG)
 
 build/src/libultra/libc/llcvt.o: src/libultra/libc/llcvt.c

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ setup:
 ## Assembly generation
 disasm:
 	$(RM) -rf asm data
-	python3 tools/disasm/disasm.py -j $(N_THREADS) $(DISASM_FLAGS)
+	python3 tools/disasm/disasm.py -j $(N_THREADS) $(DISASM_FLAGS) -Mreg-names=o32
 
 diff-init: uncompressed
 	$(RM) -rf expected/

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ ifeq ($(NON_MATCHING),1)
   COMPARE := 0
 endif
 
-DISASM_FLAGS ?= 
+DISASM_FLAGS := --reg-names=o32
 ifneq ($(FULL_DISASM), 0)
-  DISASM_FLAGS += --full
+  DISASM_FLAGS += --all
 endif
 
 PROJECT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -103,7 +103,7 @@ MIPS_VERSION := -mips2
 CFLAGS += -G 0 -non_shared -Xfullwarn -Xcpluscomm $(IINC) -nostdinc -Wab,-r4300_mul -woff 624,649,838,712
 
 # Use relocations and abi fpr names in the dump
-OBJDUMP_FLAGS := -d -r -Mreg-names=32
+OBJDUMP_FLAGS := -d -r -z -Mreg-names=32
 
 ifeq ($(shell getconf LONG_BIT), 32)
   # Work around memory allocation bug in QEMU
@@ -268,7 +268,7 @@ setup:
 ## Assembly generation
 disasm:
 	$(RM) -rf asm data
-	python3 tools/disasm/disasm.py -j $(N_THREADS) $(DISASM_FLAGS) -Mreg-names=o32
+	python3 tools/disasm/disasm.py -j $(N_THREADS) $(DISASM_FLAGS)
 
 diff-init: uncompressed
 	$(RM) -rf expected/

--- a/diff_settings.py
+++ b/diff_settings.py
@@ -5,4 +5,5 @@ def apply(config, args):
     config['myimg'] = 'mm.us.rev1.rom_uncompressed.z64'
     config['mapfile'] = 'build/mm.map'
     config['source_directories'] = ['./src','./include']
+    config['objdump_flags'] = ['-M','reg-names=32']
     config['makeflags'] = ['KEEP_MDEBUG=1']

--- a/include/macro.inc
+++ b/include/macro.inc
@@ -37,3 +37,39 @@
 .set TagHi,         $29
 .set ErrorEPC,      $30
 .set Reserved31,    $31
+
+
+# Float register aliases (o32 ABI, odd ones are rarely used)
+
+.set $fv0,          $f0
+.set $fv0f,         $f1
+.set $fv1,          $f2
+.set $fv1f,         $f3
+.set $ft0,          $f4
+.set $ft0f,         $f5
+.set $ft1,          $f6
+.set $ft1f,         $f7
+.set $ft2,          $f8
+.set $ft2f,         $f9
+.set $ft3,          $f10
+.set $ft3f,         $f11
+.set $fa0,          $f12
+.set $fa0f,         $f13
+.set $fa1,          $f14
+.set $fa1f,         $f15
+.set $ft4,          $f16
+.set $ft4f,         $f17
+.set $ft5,          $f18
+.set $ft5f,         $f19
+.set $fs0,          $f20
+.set $fs0f,         $f21
+.set $fs1,          $f22
+.set $fs1f,         $f23
+.set $fs2,          $f24
+.set $fs2f,         $f25
+.set $fs3,          $f26
+.set $fs3f,         $f27
+.set $fs4,          $f28
+.set $fs4f,         $f29
+.set $fs5,          $f30
+.set $fs5f,         $f31

--- a/tools/asm-differ/.gitrepo
+++ b/tools/asm-differ/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/simonlindholm/asm-differ
 	branch = main
-	commit = 6f8f80b719359d018a2b734288c977aae6538870
-	parent = 91a6e9f647d2035eba281d286c78f089f70f269f
+	commit = 1236288d1520335c2bfb672078fec65084d7cb5c
+	parent = 2c5690701a350c7e7c3d6252dff925ad65d59910
 	method = merge
 	cmdver = 0.4.3

--- a/tools/asm-differ/.pre-commit-config.yaml
+++ b/tools/asm-differ/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
     - id: black
-      language_version: python3.6

--- a/tools/asm-differ/README.md
+++ b/tools/asm-differ/README.md
@@ -11,10 +11,10 @@ Nice differ for assembly code. Currently supports MIPS, PPC, AArch64, and ARM32;
 
 ## Usage
 
-Create a file `diff_settings.sh` in some directory (see the one in this repo for an example). Then from that directory, run
+Create a file `diff_settings.py` in some directory (see the one in this repo for an example). Then from that directory, run
 
 ```bash
-/path/to/diff.sh [flags] (function|rom addr)
+/path/to/diff.py [flags] (function|rom addr)
 ```
 
 Recommended flags are `-mwo` (automatically run `make` on source file changes, and include symbols in diff). See `--help` for more details.

--- a/tools/asm-processor/build.py
+++ b/tools/asm-processor/build.py
@@ -10,30 +10,49 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 prelude = os.path.join(dir_path, "prelude.inc")
 
 all_args = sys.argv[1:]
-sep1 = all_args.index('--')
-sep2 = all_args.index('--', sep1+1)
+sep0 = [index for index, arg in enumerate(all_args) if not arg.startswith("-")][0]
+sep1 = all_args.index("--")
+sep2 = all_args.index("--", sep1 + 1)
 
-compiler = all_args[:sep1]
+asmproc_flags = all_args[:sep0]
+compiler = all_args[sep0:sep1]
 
-assembler = all_args[sep1+1:sep2]
-assembler_sh = ' '.join(shlex.quote(x) for x in assembler)
+assembler = all_args[sep1 + 1 : sep2]
+assembler_sh = " ".join(shlex.quote(x) for x in assembler)
 
-compile_args = all_args[sep2+1:]
+compile_args = all_args[sep2 + 1 :]
 in_file = compile_args[-1]
-out_ind = compile_args.index('-o')
+out_ind = compile_args.index("-o")
 out_file = compile_args[out_ind + 1]
 del compile_args[-1]
 del compile_args[out_ind + 1]
 del compile_args[out_ind]
 
 in_dir = os.path.split(os.path.realpath(in_file))[0]
-opt_flags = [x for x in compile_args if x in ['-g3', '-g', '-O1', '-O2', '-framepointer']]
+opt_flags = [
+    x for x in compile_args if x in ["-g3", "-g", "-O0", "-O1", "-O2", "-framepointer"]
+]
+if "-mips2" not in compile_args:
+    opt_flags.append("-mips1")
 
-preprocessed_file = tempfile.NamedTemporaryFile(prefix='preprocessed', suffix='.c', delete=False)
+asmproc_flags += opt_flags + [in_file]
+
+# Drop .mdebug and .gptab sections from resulting binaries. This makes
+# resulting .o files much smaller and speeds up builds, but loses line
+# number debug data.
+# asmproc_flags += ["--drop-mdebug-gptab"]
+
+# Convert encoding before compiling.
+# asmproc_flags += ["--input-enc", "utf-8", "--output-enc", "euc-jp"]
+
+preprocessed_file = tempfile.NamedTemporaryFile(
+    prefix="preprocessed", suffix=".c", delete=False
+)
 
 try:
-    asmproc_flags = opt_flags + [in_file, '--input-enc', 'utf-8', '--output-enc', 'euc-jp']
-    compile_cmdline = compiler + compile_args + ['-I', in_dir, '-o', out_file, preprocessed_file.name]
+    compile_cmdline = (
+        compiler + compile_args + ["-I", in_dir, "-o", out_file, preprocessed_file.name]
+    )
 
     functions, deps = asm_processor.run(asmproc_flags, outfile=preprocessed_file)
     try:
@@ -41,13 +60,24 @@ try:
     except subprocess.CalledProcessError as e:
         print("Failed to compile file " + in_file + ". Command line:")
         print()
-        print(' '.join(shlex.quote(x) for x in compile_cmdline))
+        print(" ".join(shlex.quote(x) for x in compile_cmdline))
         print()
         sys.exit(55)
         # To keep the preprocessed file:
         # os._exit(1)
 
-    asm_processor.run(asmproc_flags + ['--post-process', out_file, '--assembler', assembler_sh, '--asm-prelude', prelude], functions=functions)
+    asm_processor.run(
+        asmproc_flags
+        + [
+            "--post-process",
+            out_file,
+            "--assembler",
+            assembler_sh,
+            "--asm-prelude",
+            prelude,
+        ],
+        functions=functions,
+    )
 
     deps_file = out_file[:-2] + ".asmproc.d"
     if deps:

--- a/tools/asm-processor/prelude.inc
+++ b/tools/asm-processor/prelude.inc
@@ -1,5 +1,43 @@
 .set noat
 .set noreorder
 .set gp=64
-.include "macro.inc"
+.macro glabel label
+    .global \label
+    \label:
+.endm
 
+
+# Float register aliases (o32 ABI, odd ones are rarely used)
+
+.set $fv0,          $f0
+.set $fv0f,         $f1
+.set $fv1,          $f2
+.set $fv1f,         $f3
+.set $ft0,          $f4
+.set $ft0f,         $f5
+.set $ft1,          $f6
+.set $ft1f,         $f7
+.set $ft2,          $f8
+.set $ft2f,         $f9
+.set $ft3,          $f10
+.set $ft3f,         $f11
+.set $fa0,          $f12
+.set $fa0f,         $f13
+.set $fa1,          $f14
+.set $fa1f,         $f15
+.set $ft4,          $f16
+.set $ft4f,         $f17
+.set $ft5,          $f18
+.set $ft5f,         $f19
+.set $fs0,          $f20
+.set $fs0f,         $f21
+.set $fs1,          $f22
+.set $fs1f,         $f23
+.set $fs2,          $f24
+.set $fs2f,         $f25
+.set $fs3,          $f26
+.set $fs3f,         $f27
+.set $fs4,          $f28
+.set $fs4f,         $f29
+.set $fs5,          $f30
+.set $fs5f,         $f31

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -4,7 +4,6 @@ import argparse, ast, math, os, re, struct
 import bisect
 import multiprocessing
 from pathlib import Path
-# global mips_isa.mips_fpr_names
 import mips_isa
 
 # Consider implementing gpr naming too, but already uses abi names by default
@@ -18,22 +17,22 @@ parser.add_argument(
     "-j", dest="jobs", type=int, default=1, help="number of processes to run at once"
 )
 parser.add_argument(
-    "--full",
-    "-f",
-    dest="full",
+    "-a",
+    "--all",
+    dest="all",
     action="store_true",
     default=False,
     help="Decompile all files regardless of whether they are used or not",
 )
 parser.add_argument(
-    "-files",
+    "-f",
     "--files",
     dest="files",
     nargs="+",
     required=False,
     help="Optional list of files to diassemble separated by a space. This is a whitelist, all files will be skipped besides the ones listed here if used.",
 )
-parser.add_argument("-Mreg-names", choices=fpr_name_options.keys(), help="How to name registers in the output")
+parser.add_argument("--reg-names", choices=fpr_name_options.keys(), help="How to name registers in the output")
 
 args = parser.parse_args()
 jobs = args.jobs
@@ -2216,7 +2215,7 @@ for segment in files_spec:
         new[offset] = name
     full_file_list[segment[0]] = new
 
-if args.full:
+if args.all:
     new_spec = []
     for segment in files_spec:
         if args.files and not any(

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -37,7 +37,7 @@ parser.add_argument("--reg-names", choices=fpr_name_options.keys(), help="How to
 args = parser.parse_args()
 jobs = args.jobs
 
-mips_isa.mips_fpr_names = fpr_name_options.get(args.Mreg_names, mips_isa.mips_fpr_names)
+mips_isa.mips_fpr_names = fpr_name_options.get(args.reg_names, mips_isa.mips_fpr_names)
 
 
 ASM_OUT = "asm/"

--- a/tools/disasm/mips_isa.py
+++ b/tools/disasm/mips_isa.py
@@ -304,7 +304,7 @@ o32_fpr_names = [
     "$31", # Floating-point control/status register
 ]
 
-mips_fpr_names = o32_fpr_names
+mips_fpr_names = numeric_fpr_names
 
 # Instruction field fetching
 

--- a/tools/disasm/mips_isa.py
+++ b/tools/disasm/mips_isa.py
@@ -286,14 +286,25 @@ mips_cop0_names = [
     "TagLo"     , "TagHi"     , "ErrorEPC"  , "Reserved31",
 ]
 
-mips_fpr_names = [
+numeric_fpr_names = [
     "$f0", "$f1", "$f2", "$f3",
     "$f4", "$f5", "$f6", "$f7", "$f8", "$f9", "$f10", "$f11",
     "$f12", "$f13", "$f14", "$f15",
     "$f16", "$f17", "$f18", "$f19",
     "$f20", "$f21", "$f22", "$f23", "$f24", "$f25", "$f26", "$f27", "$f28", "$f29", "$f30",
-    "$31",
+    "$31", # Floating-point control/status register
 ]
+
+o32_fpr_names = [
+    "$fv0", "$fv0f", "$fv1", "$fv1f",
+    "$ft0", "$ft0f", "$ft1", "$ft1f", "$ft2", "$ft2f", "$ft3", "$ft3f",
+    "$fa0", "$fa0f", "$fa1", "$fa1f",
+    "$ft4", "$ft4f", "$ft5", "$ft5f",
+    "$fs0", "$fs0f", "$fs1", "$fs1f", "$fs2", "$fs2f", "$fs3", "$fs3f", "$fs4", "$fs4f", "$fs5",
+    "$31", # Floating-point control/status register
+]
+
+mips_fpr_names = o32_fpr_names
 
 # Instruction field fetching
 


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Use the o32 ABI names for floating-point registers in the assembly. Finally the float registers usage makes some sense!

![image](https://user-images.githubusercontent.com/73679967/160294214-eedcc998-846b-427d-be08-8ab738a9a031.png)

This involved changing quite a lot of tools:
- Add the aliases to `macro.inc`.
- Add support to `diff.py`.
- Add support to `mips_to_c`.
- Change the disassembler to enable the choice of abi or numeric names for float registers. This required tweaking the imports, since `*` imports apparently don't let you edit variables in other files....
- Change the makefile to support this flag.
- Add aliases to `asm-processor`'s `prelude.inc`.
- Also did some other cleanup of the makefile to use the newest asm-processor.

Everything here should be automatic: the end user should not have to do anything apart from updating mips_to_c and any other forks they've made of the external scripts. If you really want to still use the numeric names, you can edit the disassembler line in the makefile to remove the new flag (since I don't expect this to be a popular option, I didn't add a makefile variable).