### PR TITLE
Document object_okuta and ovl_en_syateki_okuta assets

### DIFF
--- a/assets/xml/objects/object_okuta.xml
+++ b/assets/xml/objects/object_okuta.xml
@@ -1,59 +1,72 @@
 ﻿<Root>
+    <!-- Assets for Octoroks -->
     <File Name="object_okuta" Segment="6">
-        <Animation Name="object_okuta_Anim_00044C" Offset="0x44C" />
-        <DList Name="object_okuta_DL_000DC0" Offset="0xDC0" />
-        <DList Name="object_okuta_DL_000E70" Offset="0xE70" />
-        <DList Name="object_okuta_DL_000F28" Offset="0xF28" />
-        <DList Name="object_okuta_DL_000FD8" Offset="0xFD8" />
-        <DList Name="object_okuta_DL_001088" Offset="0x1088" />
-        <DList Name="object_okuta_DL_001140" Offset="0x1140" />
-        <DList Name="object_okuta_DL_0011F0" Offset="0x11F0" />
-        <DList Name="object_okuta_DL_0012A0" Offset="0x12A0" />
-        <DList Name="object_okuta_DL_001358" Offset="0x1358" />
-        <DList Name="object_okuta_DL_001408" Offset="0x1408" />
-        <DList Name="object_okuta_DL_0014B8" Offset="0x14B8" />
-        <DList Name="object_okuta_DL_001570" Offset="0x1570" />
-        <DList Name="object_okuta_DL_001620" Offset="0x1620" />
-        <DList Name="object_okuta_DL_001730" Offset="0x1730" />
-        <DList Name="object_okuta_DL_0017F0" Offset="0x17F0" />
-        <DList Name="object_okuta_DL_0018B0" Offset="0x18B0" />
-        <DList Name="object_okuta_DL_001970" Offset="0x1970" />
-        <DList Name="object_okuta_DL_001A38" Offset="0x1A38" />
-        <DList Name="object_okuta_DL_001B18" Offset="0x1B18" />
-        <DList Name="object_okuta_DL_001BE8" Offset="0x1BE8" />
-        <DList Name="object_okuta_DL_001C20" Offset="0x1C20" />
-        <Texture Name="object_okuta_Tex_001D20" OutName="tex_001D20" Format="rgba16" Width="16" Height="16" Offset="0x1D20" />
-        <Texture Name="object_okuta_Tex_001F20" OutName="tex_001F20" Format="rgba16" Width="8" Height="16" Offset="0x1F20" />
-        <Texture Name="object_okuta_Tex_002020" OutName="tex_002020" Format="rgba16" Width="16" Height="32" Offset="0x2020" />
-        <Texture Name="object_okuta_Tex_002420" OutName="tex_002420" Format="rgba16" Width="16" Height="16" Offset="0x2420" />
-        <Texture Name="object_okuta_Tex_002620" OutName="tex_002620" Format="rgba16" Width="16" Height="16" Offset="0x2620" />
-        <Texture Name="object_okuta_Tex_002820" OutName="tex_002820" Format="rgba16" Width="8" Height="16" Offset="0x2820" />
-        <Texture Name="object_okuta_Tex_002920" OutName="tex_002920" Format="rgba32" Width="16" Height="16" Offset="0x2920" />
-        <!-- <Blob Name="object_okuta_Blob_002D20" Size="0x200" Offset="0x2D20" /> -->
-        <Texture Name="object_okuta_Tex_002F20" OutName="tex_002F20" Format="rgba16" Width="8" Height="8" Offset="0x2F20" />
-        <Texture Name="object_okuta_Tex_002FA0" OutName="tex_002FA0" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" />
-        <Texture Name="object_okuta_Tex_003020" OutName="tex_003020" Format="rgba16" Width="16" Height="16" Offset="0x3020" />
-        <DList Name="object_okuta_DL_003250" Offset="0x3250" />
-        <Limb Name="object_okuta_Standardlimb_0032E0" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_01" Offset="0x32E0" />
-        <Limb Name="object_okuta_Standardlimb_0032EC" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_02" Offset="0x32EC" />
-        <Limb Name="object_okuta_Standardlimb_0032F8" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_03" Offset="0x32F8" />
-        <Limb Name="object_okuta_Standardlimb_003304" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_04" Offset="0x3304" />
-        <Limb Name="object_okuta_Standardlimb_003310" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_05" Offset="0x3310" />
-        <Limb Name="object_okuta_Standardlimb_00331C" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_06" Offset="0x331C" />
-        <Limb Name="object_okuta_Standardlimb_003328" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_07" Offset="0x3328" />
-        <Limb Name="object_okuta_Standardlimb_003334" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_08" Offset="0x3334" />
-        <Limb Name="object_okuta_Standardlimb_003340" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_09" Offset="0x3340" />
-        <Limb Name="object_okuta_Standardlimb_00334C" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0A" Offset="0x334C" />
-        <Limb Name="object_okuta_Standardlimb_003358" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0B" Offset="0x3358" />
-        <Limb Name="object_okuta_Standardlimb_003364" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0C" Offset="0x3364" />
-        <Limb Name="object_okuta_Standardlimb_003370" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0D" Offset="0x3370" />
-        <Limb Name="object_okuta_Standardlimb_00337C" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0E" Offset="0x337C" />
-        <Limb Name="object_okuta_Standardlimb_003388" Type="Standard" EnumName="OBJECT_OKUTA_LIMB_0F" Offset="0x3388" />
-        <Skeleton Name="object_okuta_Skel_0033D0" Type="Normal" LimbType="Standard" LimbNone="OBJECT_OKUTA_LIMB_NONE" LimbMax="OBJECT_OKUTA_LIMB_MAX" EnumName="object_okuta_Limbs" Offset="0x33D0" />
-        <Animation Name="object_okuta_Anim_003958" Offset="0x3958" />
-        <Animation Name="object_okuta_Anim_003B24" Offset="0x3B24" />
-        <Animation Name="object_okuta_Anim_003EE4" Offset="0x3EE4" />
-        <Animation Name="object_okuta_Anim_004204" Offset="0x4204" />
-        <Animation Name="object_okuta_Anim_00466C" Offset="0x466C" />
+        <Animation Name="gOctorokShootAnim" Offset="0x44C" /> <!-- Original name is "oc_atack" -->
+
+        <!-- Octorok Limb DisplayLists -->
+        <DList Name="gFrontRightLegBaseDL" Offset="0xDC0" />
+        <DList Name="gFrontRightLegMiddleDL" Offset="0xE70" />
+        <DList Name="gFrontRightLegEndDL" Offset="0xF28" />
+        <DList Name="gBackRightLegBaseDL" Offset="0xFD8" />
+        <DList Name="gBackRightLegMiddleDL" Offset="0x1088" />
+        <DList Name="gBackRightLegEndDL" Offset="0x1140" />
+        <DList Name="gBackLeftLegBaseDL" Offset="0x11F0" />
+        <DList Name="gBackLeftLegMiddleDL" Offset="0x12A0" />
+        <DList Name="gBackLeftLegEndDL" Offset="0x1358" />
+        <DList Name="gFrontLeftLegBaseDL" Offset="0x1408" />
+        <DList Name="gFrontLeftLegMiddleDL" Offset="0x14B8" />
+        <DList Name="gFrontLeftLegEndDL" Offset="0x1570" />
+        <DList Name="gOctorokSnoutDL" Offset="0x1620" />
+        <DList Name="gOctorokUnderEyeTrianglesDL" Offset="0x1730" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokHeadBottomDL" Offset="0x17F0" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokHeadFrontDL" Offset="0x18B0" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokHeadTopDL" Offset="0x1970" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokHeadBackDL" Offset="0x1A38" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokEyesDL" Offset="0x1B18" /> <!-- Used as part of the head displaylist -->
+        <DList Name="gOctorokHeadDL" Offset="0x1BE8" />
+        <DList Name="gOctorokBodyDL" Offset="0x1C20" />
+
+        <!-- Octorok Textures -->
+        <Texture Name="gOctorokRoughSkinTex" OutName="octorok_rough_skin" Format="rgba16" Width="16" Height="16" Offset="0x1D20" />
+        <Texture Name="gOctorokMouthTex" OutName="octorok_mouth" Format="rgba16" Width="8" Height="16" Offset="0x1F20" />
+        <Texture Name="gOctorokArmTex" OutName="octorok_arm" Format="rgba16" Width="16" Height="32" Offset="0x2020" />
+        <Texture Name="gOctorokFinTex" OutName="octorok_fin" Format="rgba16" Width="16" Height="16" Offset="0x2420" />
+        <Texture Name="gOctorokEyeTex" OutName="octorok_eye" Format="rgba16" Width="16" Height="16" Offset="0x2620" />
+        <Texture Name="gOctorokStripesTex" OutName="octorok_stripes" Format="rgba16" Width="8" Height="16" Offset="0x2820" />
+        <Texture Name="gOctorokScalesTex" OutName="octorok_scales" Format="rgba32" Width="16" Height="16" Offset="0x2920" />
+        <Texture Name="gOctorokScalesOoTTex" OutName="octorok_scales_oot" Format="rgba16" Width="16" Height="16" Offset="0x2D20" /> <!-- Unused OoT leftover -->
+        <Texture Name="gOctorokHeadBottomTex" OutName="octorok_head_bottom" Format="rgba16" Width="8" Height="8" Offset="0x2F20" />
+        <Texture Name="gOctorokShadedSkinTex" OutName="octorok_shaded_skin" Format="rgba16" Width="8" Height="8" Offset="0x2FA0" />
+
+        <!-- Octorok Projectile Texture and DisplayList -->
+        <Texture Name="gOctorokProjectileTex" OutName="octorok_projectile" Format="rgba16" Width="16" Height="16" Offset="0x3020" />
+        <DList Name="gOctorokProjectileDL" Offset="0x3250" />
+
+        <!-- Octorok Limbs -->
+        <Limb Name="gOctorokBodyLimb" Type="Standard" EnumName="OCTOROK_LIMB_BODY" Offset="0x32E0" />
+        <Limb Name="gFrontLeftLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_BASE" Offset="0x32EC" />
+        <Limb Name="gFrontLeftLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_MIDDLE" Offset="0x32F8" />
+        <Limb Name="gFrontLeftLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_END" Offset="0x3304" />
+        <Limb Name="gFrontRightLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_BASE" Offset="0x3310" />
+        <Limb Name="gFrontRightLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_MIDDLE" Offset="0x331C" />
+        <Limb Name="gFrontRightLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_END" Offset="0x3328" />
+        <Limb Name="gBackLeftLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_BASE" Offset="0x3334" />
+        <Limb Name="gBackLeftLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_MIDDLE" Offset="0x3340" />
+        <Limb Name="gBackLeftLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_END" Offset="0x334C" />
+        <Limb Name="gBackRightLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_BASE" Offset="0x3358" />
+        <Limb Name="gBackRightLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_MIDDLE" Offset="0x3364" />
+        <Limb Name="gBackRightLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_END" Offset="0x3370" />
+        <Limb Name="gOctorokHeadLimb" Type="Standard" EnumName="OCTOROK_LIMB_HEAD" Offset="0x337C" />
+        <Limb Name="gOctorokSnoutLimb" Type="Standard" EnumName="OCTOROK_LIMB_SNOUT" Offset="0x3388" />
+
+        <!-- Octorok Skeleton -->
+        <Skeleton Name="gOctorokSkel" Type="Normal" LimbType="Standard" LimbNone="OCTOROK_LIMB_NONE" LimbMax="OCTOROK_LIMB_MAX" EnumName="OctorokLimbs" Offset="0x33D0" />
+
+        <!-- Octorok Animations -->
+        <Animation Name="gOctorokDieAnim" Offset="0x3958" /> <!-- Original name is "oc_dead" -->
+        <Animation Name="gOctorokHideAnim" Offset="0x3B24" /> <!-- Original name is "oc_down" -->
+        <Animation Name="gOctorokFloatAnim" Offset="0x3EE4" /> <!-- Original name is "oc_float" -->
+        <Animation Name="gOctorokHitAnim" Offset="0x4204" /> <!-- Original name is "oc_predead" -->
+        <Animation Name="gOctorokAppearAnim" Offset="0x466C" /> <!-- Original name is "oc_up" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_okuta.xml
+++ b/assets/xml/objects/object_okuta.xml
@@ -4,18 +4,18 @@
         <Animation Name="gOctorokShootAnim" Offset="0x44C" /> <!-- Original name is "oc_atack" -->
 
         <!-- Octorok Limb DisplayLists -->
-        <DList Name="gFrontRightLegBaseDL" Offset="0xDC0" />
-        <DList Name="gFrontRightLegMiddleDL" Offset="0xE70" />
-        <DList Name="gFrontRightLegEndDL" Offset="0xF28" />
-        <DList Name="gBackRightLegBaseDL" Offset="0xFD8" />
-        <DList Name="gBackRightLegMiddleDL" Offset="0x1088" />
-        <DList Name="gBackRightLegEndDL" Offset="0x1140" />
-        <DList Name="gBackLeftLegBaseDL" Offset="0x11F0" />
-        <DList Name="gBackLeftLegMiddleDL" Offset="0x12A0" />
-        <DList Name="gBackLeftLegEndDL" Offset="0x1358" />
-        <DList Name="gFrontLeftLegBaseDL" Offset="0x1408" />
-        <DList Name="gFrontLeftLegMiddleDL" Offset="0x14B8" />
-        <DList Name="gFrontLeftLegEndDL" Offset="0x1570" />
+        <DList Name="gFrontRightArmBaseDL" Offset="0xDC0" />
+        <DList Name="gFrontRightArmMiddleDL" Offset="0xE70" />
+        <DList Name="gFrontRightArmEndDL" Offset="0xF28" />
+        <DList Name="gBackRightArmBaseDL" Offset="0xFD8" />
+        <DList Name="gBackRightArmMiddleDL" Offset="0x1088" />
+        <DList Name="gBackRightArmEndDL" Offset="0x1140" />
+        <DList Name="gBackLeftArmBaseDL" Offset="0x11F0" />
+        <DList Name="gBackLeftArmMiddleDL" Offset="0x12A0" />
+        <DList Name="gBackLeftArmEndDL" Offset="0x1358" />
+        <DList Name="gFrontLeftArmBaseDL" Offset="0x1408" />
+        <DList Name="gFrontLeftArmMiddleDL" Offset="0x14B8" />
+        <DList Name="gFrontLeftArmEndDL" Offset="0x1570" />
         <DList Name="gOctorokSnoutDL" Offset="0x1620" />
         <DList Name="gOctorokUnderEyeTrianglesDL" Offset="0x1730" /> <!-- Used as part of the head displaylist -->
         <DList Name="gOctorokHeadBottomDL" Offset="0x17F0" /> <!-- Used as part of the head displaylist -->
@@ -44,18 +44,18 @@
 
         <!-- Octorok Limbs -->
         <Limb Name="gOctorokBodyLimb" Type="Standard" EnumName="OCTOROK_LIMB_BODY" Offset="0x32E0" />
-        <Limb Name="gFrontLeftLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_BASE" Offset="0x32EC" />
-        <Limb Name="gFrontLeftLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_MIDDLE" Offset="0x32F8" />
-        <Limb Name="gFrontLeftLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_LEG_END" Offset="0x3304" />
-        <Limb Name="gFrontRightLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_BASE" Offset="0x3310" />
-        <Limb Name="gFrontRightLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_MIDDLE" Offset="0x331C" />
-        <Limb Name="gFrontRightLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_LEG_END" Offset="0x3328" />
-        <Limb Name="gBackLeftLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_BASE" Offset="0x3334" />
-        <Limb Name="gBackLeftLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_MIDDLE" Offset="0x3340" />
-        <Limb Name="gBackLeftLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_LEG_END" Offset="0x334C" />
-        <Limb Name="gBackRightLegBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_BASE" Offset="0x3358" />
-        <Limb Name="gBackRightLegMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_MIDDLE" Offset="0x3364" />
-        <Limb Name="gBackRightLegEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_LEG_END" Offset="0x3370" />
+        <Limb Name="gFrontLeftArmBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_ARM_BASE" Offset="0x32EC" />
+        <Limb Name="gFrontLeftArmMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_ARM_MIDDLE" Offset="0x32F8" />
+        <Limb Name="gFrontLeftArmEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_LEFT_ARM_END" Offset="0x3304" />
+        <Limb Name="gFrontRightArmBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_ARM_BASE" Offset="0x3310" />
+        <Limb Name="gFrontRightArmMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_ARM_MIDDLE" Offset="0x331C" />
+        <Limb Name="gFrontRightArmEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_FRONT_RIGHT_ARM_END" Offset="0x3328" />
+        <Limb Name="gBackLeftArmBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_ARM_BASE" Offset="0x3334" />
+        <Limb Name="gBackLeftArmMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_ARM_MIDDLE" Offset="0x3340" />
+        <Limb Name="gBackLeftArmEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_LEFT_ARM_END" Offset="0x334C" />
+        <Limb Name="gBackRightArmBaseLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_ARM_BASE" Offset="0x3358" />
+        <Limb Name="gBackRightArmMiddleLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_ARM_MIDDLE" Offset="0x3364" />
+        <Limb Name="gBackRightArmEndLimb" Type="Standard" EnumName="OCTOROK_LIMB_BACK_RIGHT_ARM_END" Offset="0x3370" />
         <Limb Name="gOctorokHeadLimb" Type="Standard" EnumName="OCTOROK_LIMB_HEAD" Offset="0x337C" />
         <Limb Name="gOctorokSnoutLimb" Type="Standard" EnumName="OCTOROK_LIMB_SNOUT" Offset="0x3388" />
 

--- a/assets/xml/overlays/ovl_En_Syateki_Okuta.xml
+++ b/assets/xml/overlays/ovl_En_Syateki_Okuta.xml
@@ -1,13 +1,13 @@
 <Root>
     <!-- Shooting Gallery Octorok assets -->
     <File Name="ovl_En_Syateki_Okuta" BaseAddress="0x80A35FF0" RangeStart="0x1640" RangeEnd="0x1B98">
-        <DList Name="ovl_En_Syateki_Okuta_DL_001640" Offset="0x1640"/>
-        <Texture Name="ovl_En_Syateki_Okuta_Tex_001658" OutName="tex_001658" Format="ia16" Width="16" Height="16" Offset="0x1658"/>
-        <Texture Name="ovl_En_Syateki_Okuta_Tex_001858" OutName="tex_001858" Format="ia16" Width="16" Height="16" Offset="0x1858"/>
-        <Array Name="ovl_En_Syateki_Okuta_Vtx_001A58" Count="4" Offset="0x1A58">
-            <Vtx/>
-        </Array>
-        <DList Name="ovl_En_Syateki_Okuta_DL_001A98" Offset="0x1A98"/>
-        <DList Name="ovl_En_Syateki_Okuta_DL_001B18" Offset="0x1B18"/>
+        <!-- DisplayList that turns certain Octoroks blue -->
+        <DList Name="gShootingGalleryOctorokBlueMaterialDL" Offset="0x1640"/>
+
+        <!-- Textures and DisplayLists for the cross and circle indicators that appear when you shoot an Octorok -->
+        <Texture Name="gShootingGalleryOctorokCrossTex" OutName="shooting_gallery_octorok_cross" Format="ia16" Width="16" Height="16" Offset="0x1658"/>
+        <Texture Name="gShootingGalleryOctorokCircleTex" OutName="shooting_gallery_octorok_circle" Format="ia16" Width="16" Height="16" Offset="0x1858"/>
+        <DList Name="gShootingGalleryOctorokCrossDL" Offset="0x1A98"/>
+        <DList Name="gShootingGalleryOctorokCircleDL" Offset="0x1B18"/>
     </File>
 </Root>

--- a/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
+++ b/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
@@ -94,8 +94,8 @@ void EnSyatekiOkuta_Init(Actor* thisx, GlobalContext* globalCtx) {
     s32 bgId;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
-    SkelAnime_Init(globalCtx, &this->skelAnime, &gOctorokSkel, &gOctorokAppearAnim, this->jointTable,
-                   this->morphTable, OCTOROK_LIMB_MAX);
+    SkelAnime_Init(globalCtx, &this->skelAnime, &gOctorokSkel, &gOctorokAppearAnim, this->jointTable, this->morphTable,
+                   OCTOROK_LIMB_MAX);
     Collider_InitCylinder(globalCtx, &this->collider);
     Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &sCylinderInit);
 
@@ -493,7 +493,7 @@ void EnSyatekiOkuta_Draw(Actor* thisx, GlobalContext* globalCtx) {
     if (this->unk_2A6 == 1) {
         gSPSegment(POLY_OPA_DISP++, 0x08, D_801AEFA0);
     } else {
-        gSPSegment(POLY_OPA_DISP++, 0x08, ovl_En_Syateki_Okuta_DL_001640);
+        gSPSegment(POLY_OPA_DISP++, 0x08, gShootingGalleryOctorokBlueMaterialDL);
     }
 
     SkelAnime_DrawOpa(globalCtx, this->skelAnime.skeleton, this->skelAnime.jointTable, EnSyatekiOkuta_OverrideLimbDraw,
@@ -512,9 +512,9 @@ void EnSyatekiOkuta_Draw(Actor* thisx, GlobalContext* globalCtx) {
         gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(globalCtx->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
 
         if (this->unk_2A6 == 2) {
-            gSPDisplayList(POLY_XLU_DISP++, ovl_En_Syateki_Okuta_DL_001A98);
+            gSPDisplayList(POLY_XLU_DISP++, gShootingGalleryOctorokCrossDL);
         } else {
-            gSPDisplayList(POLY_XLU_DISP++, ovl_En_Syateki_Okuta_DL_001B18);
+            gSPDisplayList(POLY_XLU_DISP++, gShootingGalleryOctorokCircleDL);
         }
     }
 

--- a/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
+++ b/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.c
@@ -61,12 +61,12 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 static AnimationInfo sAnimations[] = {
-    { &object_okuta_Anim_00044C, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
-    { &object_okuta_Anim_003958, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
-    { &object_okuta_Anim_003B24, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
-    { &object_okuta_Anim_003EE4, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, -1.0f },
-    { &object_okuta_Anim_00466C, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
-    { &object_okuta_Anim_004204, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
+    { &gOctorokShootAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
+    { &gOctorokDieAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
+    { &gOctorokHideAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
+    { &gOctorokFloatAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP, -1.0f },
+    { &gOctorokAppearAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
+    { &gOctorokHitAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_ONCE, -1.0f },
 };
 
 #include "assets/overlays/ovl_En_Syateki_Okuta/ovl_En_Syateki_Okuta.c"
@@ -94,8 +94,8 @@ void EnSyatekiOkuta_Init(Actor* thisx, GlobalContext* globalCtx) {
     s32 bgId;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
-    SkelAnime_Init(globalCtx, &this->skelAnime, &object_okuta_Skel_0033D0, &object_okuta_Anim_00466C, this->jointTable,
-                   this->morphTable, OBJECT_OKUTA_LIMB_MAX);
+    SkelAnime_Init(globalCtx, &this->skelAnime, &gOctorokSkel, &gOctorokAppearAnim, this->jointTable,
+                   this->morphTable, OCTOROK_LIMB_MAX);
     Collider_InitCylinder(globalCtx, &this->collider);
     Collider_SetCylinder(globalCtx, &this->collider, &this->actor, &sCylinderInit);
 
@@ -153,7 +153,7 @@ s32 func_80A361F4(EnSyatekiOkuta* this) {
 }
 
 void func_80A36260(EnSyatekiOkuta* this) {
-    Animation_PlayOnceSetSpeed(&this->skelAnime, &object_okuta_Anim_00466C, 0.0f);
+    Animation_PlayOnceSetSpeed(&this->skelAnime, &gOctorokAppearAnim, 0.0f);
     this->actor.draw = NULL;
     this->actionFunc = func_80A362A8;
 }
@@ -173,7 +173,7 @@ void func_80A362A8(EnSyatekiOkuta* this, GlobalContext* globalCtx) {
 }
 
 void func_80A362F8(EnSyatekiOkuta* this) {
-    Animation_PlayOnceSetSpeed(&this->skelAnime, &object_okuta_Anim_00466C, 0.0f);
+    Animation_PlayOnceSetSpeed(&this->skelAnime, &gOctorokAppearAnim, 0.0f);
     this->actor.draw = NULL;
     Actor_SetScale(&this->actor, 0.01f);
     this->actionFunc = func_80A36350;
@@ -474,10 +474,10 @@ s32 EnSyatekiOkuta_OverrideLimbDraw(GlobalContext* globalCtx, s32 limbIndex, Gfx
         curFrame += this->unk_2A4;
     }
 
-    if (limbIndex == OBJECT_OKUTA_LIMB_0E) {
+    if (limbIndex == OCTOROK_LIMB_HEAD) {
         sp20 = this->unk_1D8;
         Matrix_Scale(sp20.x, sp20.y, sp20.z, MTXMODE_APPLY);
-    } else if ((limbIndex == OBJECT_OKUTA_LIMB_0F) && (func_80A370EC(this, curFrame, &sp20))) {
+    } else if ((limbIndex == OCTOROK_LIMB_SNOUT) && (func_80A370EC(this, curFrame, &sp20))) {
         Matrix_Scale(sp20.x, sp20.y, sp20.z, MTXMODE_APPLY);
     }
 

--- a/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.h
+++ b/src/overlays/actors/ovl_En_Syateki_Okuta/z_en_syateki_okuta.h
@@ -16,8 +16,8 @@ typedef struct EnSyatekiOkuta {
     /* 0x188 */ EnSyatekiOkutaActionFunc actionFunc;
     /* 0x18C */ ColliderCylinder collider;
     /* 0x1DC */ Vec3f unk_1D8;
-    /* 0x1E4 */ Vec3s jointTable[OBJECT_OKUTA_LIMB_MAX];
-    /* 0x244 */ Vec3s morphTable[OBJECT_OKUTA_LIMB_MAX];
+    /* 0x1E4 */ Vec3s jointTable[OCTOROK_LIMB_MAX];
+    /* 0x244 */ Vec3s morphTable[OCTOROK_LIMB_MAX];
     /* 0x2A4 */ s16 unk_2A4;
     /* 0x2A6 */ s16 unk_2A6;
     /* 0x2A8 */ UNK_TYPE1 unk_2A8[0x2];


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->
Another relatively simple object that's mostly an OoT port. I also documented the assets within ovl_en_syateki_okuta, since that actor is really my motivation for doing this. I deleted the Vtx array in the overlay because ZAPD can autogenerate it and I don't care enough to name it.