### PR TITLE
Match 8 Various NON_MATCHING functions

### DIFF
--- a/spec
+++ b/spec
@@ -2770,11 +2770,7 @@ beginseg
     name "ovl_Obj_Vspinyroll"
     compress
     include "build/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_Obj_Vspinyroll/ovl_Obj_Vspinyroll_reloc.o"
-#else
-    include "build/data/ovl_Obj_Vspinyroll/ovl_Obj_Vspinyroll.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -820,11 +820,7 @@ beginseg
     name "ovl_En_Horse"
     compress
     include "build/src/overlays/actors/ovl_En_Horse/z_en_horse.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_En_Horse/ovl_En_Horse_reloc.o"
-#else
-    include "build/data/ovl_En_Horse/ovl_En_Horse.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -2999,11 +2999,7 @@ beginseg
     name "ovl_Obj_Driftice"
     compress
     include "build/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_Obj_Driftice/ovl_Obj_Driftice_reloc.o"
-#else
-    include "build/data/ovl_Obj_Driftice/ovl_Obj_Driftice.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -4875,11 +4875,7 @@ beginseg
     name "ovl_En_Rg"
     compress
     include "build/src/overlays/actors/ovl_En_Rg/z_en_rg.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_En_Rg/ovl_En_Rg_reloc.o"
-#else
-    include "build/data/ovl_En_Rg/ovl_En_Rg.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/spec
+++ b/spec
@@ -1502,11 +1502,7 @@ beginseg
     name "ovl_En_Goroiwa"
     compress
     include "build/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.o"
-#ifdef NON_MATCHING
     include "build/src/overlays/actors/ovl_En_Goroiwa/ovl_En_Goroiwa_reloc.o"
-#else
-    include "build/data/ovl_En_Goroiwa/ovl_En_Goroiwa.reloc.o"
-#endif
 endseg
 
 beginseg

--- a/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
+++ b/src/overlays/actors/ovl_En_Goroiwa/z_en_goroiwa.c
@@ -739,24 +739,22 @@ void func_80940090(EnGoroiwa* this, GlobalContext* globalCtx) {
     }
 }
 
-#ifdef NON_MATCHING
-// Stack
 void func_80940588(GlobalContext* globalCtx, Vec3f* arg1, Gfx* arg2[], Color_RGBA8* arg3, Color_RGBA8* arg4, f32 arg5) {
     Gfx* phi_s7;
     Vec3f sp100;
     Vec3f spF4;
     Vec3f spE8;
     f32 temp_f20;
-    s32 phi_fp;
+    f32 spB0;
     s32 j;
     s32 i;
     s32 phi_s0;
     s32 spD0;
     s16 spCE;
-    s16 spC8;
-    f32 spB0;
-    f32 spAC;
     s16 spA8;
+    s16 phi_fp;
+    s16 spC8;
+    f32 spAC;
 
     spD0 = (s32)(arg5 * 35.0f) + 6;
     temp_f20 = (arg5 + 0.1f) * 0.5f;
@@ -815,10 +813,6 @@ void func_80940588(GlobalContext* globalCtx, Vec3f* arg1, Gfx* arg2[], Color_RGB
         }
     }
 }
-#else
-void func_80940588(GlobalContext* globalCtx, Vec3f* arg1, Gfx* arg2[], Color_RGBA8* arg3, Color_RGBA8* arg4, f32 arg5);
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Goroiwa/func_80940588.s")
-#endif
 
 void func_80940A1C(GlobalContext* globalCtx, Vec3f* arg1, Gfx** arg2, Color_RGBA8* arg3, Color_RGBA8* arg4, f32 arg5) {
     s32 i;

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -4156,37 +4156,36 @@ s32 EnHorse_RandInt(f32 arg0) {
     return Rand_ZeroOne() * arg0;
 }
 
-#ifdef NON_MATCHING
-void EnHorse_Update(Actor* thisx, GlobalContext* globalCtx) {
-    static EnHorseActionFunc sActionFuncs[] = {
-        EnHorse_Frozen,
-        EnHorse_Inactive,
-        EnHorse_Idle,
-        EnHorse_FollowPlayer,
-        EnHorse_UpdateIngoRace,
-        func_808819D8,
-        func_80881398,
-        EnHorse_MountedIdle,
-        EnHorse_MountedIdleWhinneying,
-        EnHorse_MountedTurn,
-        EnHorse_MountedWalk,
-        EnHorse_MountedTrot,
-        EnHorse_MountedGallop,
-        EnHorse_MountedRearing,
-        EnHorse_Stopping,
-        EnHorse_Reverse,
-        EnHorse_LowJump,
-        EnHorse_HighJump,
-        EnHorse_CutsceneUpdate,
-        EnHorse_UpdateHorsebackArchery,
-        EnHorse_FleePlayer,
-        func_80884718,
-        func_8087CA04,
-        func_808848C8,
-        func_80884A40,
-        func_80884E0C,
-    };
-    s32 pad;
+static EnHorseActionFunc sActionFuncs[] = {
+    EnHorse_Frozen,
+    EnHorse_Inactive,
+    EnHorse_Idle,
+    EnHorse_FollowPlayer,
+    EnHorse_UpdateIngoRace,
+    func_808819D8,
+    func_80881398,
+    EnHorse_MountedIdle,
+    EnHorse_MountedIdleWhinneying,
+    EnHorse_MountedTurn,
+    EnHorse_MountedWalk,
+    EnHorse_MountedTrot,
+    EnHorse_MountedGallop,
+    EnHorse_MountedRearing,
+    EnHorse_Stopping,
+    EnHorse_Reverse,
+    EnHorse_LowJump,
+    EnHorse_HighJump,
+    EnHorse_CutsceneUpdate,
+    EnHorse_UpdateHorsebackArchery,
+    EnHorse_FleePlayer,
+    func_80884718,
+    func_8087CA04,
+    func_808848C8,
+    func_80884A40,
+    func_80884E0C,
+};
+void EnHorse_Update(Actor* thisx, GlobalContext* globalCtx2) {
+    GlobalContext* globalCtx = globalCtx2;
     EnHorse* this = THIS;
     Vec3f dustAcc = { 0.0f, 0.0f, 0.0f };
     Vec3f dustVel = { 0.0f, 1.0f, 0.0f };
@@ -4228,7 +4227,7 @@ void EnHorse_Update(Actor* thisx, GlobalContext* globalCtx) {
     }
 
     this->curFrame = this->skin.skelAnime.curFrame;
-    this->lastPos = this->actor.world.pos;
+    this->lastPos = thisx->world.pos;
 
     if (!(this->stateFlags & ENHORSE_INACTIVE)) {
         if ((this->action == ENHORSE_ACT_STOPPING) || (this->action == ENHORSE_ACT_MOUNTED_REARING) ||
@@ -4400,39 +4399,6 @@ void EnHorse_Update(Actor* thisx, GlobalContext* globalCtx) {
         this->stateFlags &= ~ENHORSE_DRAW;
     }
 }
-#else
-EnHorseActionFunc sActionFuncs[] = {
-    EnHorse_Frozen,
-    EnHorse_Inactive,
-    EnHorse_Idle,
-    EnHorse_FollowPlayer,
-    EnHorse_UpdateIngoRace,
-    func_808819D8,
-    func_80881398,
-    EnHorse_MountedIdle,
-    EnHorse_MountedIdleWhinneying,
-    EnHorse_MountedTurn,
-    EnHorse_MountedWalk,
-    EnHorse_MountedTrot,
-    EnHorse_MountedGallop,
-    EnHorse_MountedRearing,
-    EnHorse_Stopping,
-    EnHorse_Reverse,
-    EnHorse_LowJump,
-    EnHorse_HighJump,
-    EnHorse_CutsceneUpdate,
-    EnHorse_UpdateHorsebackArchery,
-    EnHorse_FleePlayer,
-    func_80884718,
-    func_8087CA04,
-    func_808848C8,
-    func_80884A40,
-    func_80884E0C,
-};
-Vec3f D_808891C8 = { 0.0f, 0.0f, 0.0f };
-Vec3f D_808891D4 = { 0.0f, 1.0f, 0.0f };
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Horse/EnHorse_Update.s")
-#endif
 
 s32 EnHorse_PlayerDirToMountSide(EnHorse* this, GlobalContext* globalCtx, Player* player) {
     if (this->playerDir == PLAYER_DIR_SIDE_L) {

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -673,16 +673,16 @@ void func_8087C9F8(EnHorse* this) {
 void func_8087CA04(EnHorse* this, GlobalContext* globalCtx) {
 }
 
-#ifdef NON_MATCHING
 void EnHorse_Init(Actor* thisx, GlobalContext* globalCtx2) {
     GlobalContext* globalCtx = globalCtx2;
     EnHorse* this = THIS;
+    Skin* skin = &this->skin;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
     EnHorse_ClearDustFlags(&this->dustFlags);
     D_801BDAA4 = 0;
     Skin_Setup(&this->skin);
-    this->riderPos = this->actor.world.pos;
+    this->riderPos = thisx->world.pos;
     this->unk_52C = 0;
     this->noInputTimer = 0;
     this->riderPos.y += 70.0f;
@@ -906,9 +906,6 @@ void EnHorse_Init(Actor* thisx, GlobalContext* globalCtx2) {
         this->colliderCylinder2.info.bumper.dmgFlags = 0x10000 | 0x2000 | 0x1000 | 0x800 | 0x20;
     }
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Horse/EnHorse_Init.s")
-#endif
 
 void func_8087D540(Actor* thisx, GlobalContext* globalCtx) {
     EnHorse* this = THIS;
@@ -2952,13 +2949,12 @@ void EnHorse_UpdateHorsebackArchery(EnHorse* this, GlobalContext* globalCtx) {
     }
 }
 
-#ifdef NON_MATCHING
 void EnHorse_FleePlayer(EnHorse* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
     f32 distToHome;
     f32 playerDistToHome;
     f32 distToPlayer;
-    s32 nextAnim;
+    s32 nextAnim = this->animationIdx;
     s32 animFinished;
     s16 yaw;
 
@@ -3098,10 +3094,6 @@ void EnHorse_FleePlayer(EnHorse* this, GlobalContext* globalCtx) {
                          -3.0f);
     }
 }
-#else
-void EnHorse_FleePlayer(EnHorse* this, GlobalContext* globalCtx);
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Horse/EnHorse_FleePlayer.s")
-#endif
 
 void func_80883B70(EnHorse* this, CsCmdActorAction* action) {
     this->actor.world.pos.x = action->startPos.x;

--- a/src/overlays/actors/ovl_En_Rg/z_en_rg.c
+++ b/src/overlays/actors/ovl_En_Rg/z_en_rg.c
@@ -368,7 +368,6 @@ s32 func_80BF42BC(EnRg* this, f32 arg1) {
     return false;
 }
 
-#ifdef NON_MATCHING
 s32 func_80BF43FC(EnRg* this) {
     Vec3f sp9C;
     Vec3f sp90;
@@ -378,13 +377,18 @@ s32 func_80BF43FC(EnRg* this) {
     f32 phi_f20 = 0.0f;
     s32 temp_s7 = ENRG_GET_7F80(&this->actor);
     s32 phi_s4 = -1;
-    s16 phi_s6 = 0;
     s32 temp_s5 = this->unk_344;
+    s16 phi_s6 = 0;
     s32 phi_s0 = D_80BF57E4[this->unk_344][temp_s7];
 
     while (true) {
         SubS_CopyPointFromPathCheckBounds(this->path, phi_s0 - 1, &sp9C);
         SubS_CopyPointFromPathCheckBounds(this->path, phi_s0 + 1, &sp90);
+        if (1) {}
+        if (1) {}
+        if (1) {}
+        if (1) {}
+        if (1) {}
         if (Math3D_PointDistToLine2D(this->actor.world.pos.x, this->actor.world.pos.z, sp9C.x, sp9C.z, sp90.x, sp90.z,
                                      &sp8C, &sp88, &sp84) &&
             (!phi_s6 || ((phi_s4 + 1) == phi_s0) || (sp84 < phi_f20))) {
@@ -400,10 +404,6 @@ s32 func_80BF43FC(EnRg* this) {
 
     return phi_s4;
 }
-#else
-s32 func_80BF43FC(EnRg* this);
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_En_Rg/func_80BF43FC.s")
-#endif
 
 s32 func_80BF4560(EnRg* this, GlobalContext* globalCtx) {
     s32 temp_v0 = SurfaceType_GetSceneExitIndex(&globalCtx->colCtx, this->actor.floorPoly, this->actor.floorBgId);

--- a/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.c
+++ b/src/overlays/actors/ovl_Obj_Driftice/z_obj_driftice.c
@@ -148,7 +148,6 @@ f32 func_80A667F0(ObjDrifticeStruct3* arg0, ObjDriftice* this) {
     return temp_f20;
 }
 
-#ifdef NON_MATCHING
 void func_80A66930(ObjDrifticeStruct2* arg0, ObjDriftice* this, s16* arg2, s16* arg3) {
     ObjDrifticeStruct3* temp_s0;
     f32 temp_f22 = 0.0f;
@@ -195,12 +194,8 @@ void func_80A66930(ObjDrifticeStruct2* arg0, ObjDriftice* this, s16* arg2, s16* 
 
     temp_f22 *= arg0->unk_08;
 
-    *arg2 = (s32)temp_f22 + arg0->unk_00[2];
+    *arg2 = arg0->unk_00[2] + (s32)((void)0, temp_f22);
 }
-#else
-void func_80A66930(ObjDrifticeStruct2* arg0, ObjDriftice* this, s16* arg2, s16* arg3);
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Driftice/func_80A66930.s")
-#endif
 
 void func_80A66C4C(ObjDrifticeStruct4* arg0, ObjDriftice* this, s16* arg2, s16* arg3) {
     ObjDrifticeStruct3* temp_s0;
@@ -340,8 +335,6 @@ void func_80A671CC(ObjDriftice* this) {
     this->actionFunc = func_80A671E0;
 }
 
-#ifdef NON_MATCHING
-// stack
 void func_80A671E0(ObjDriftice* this, GlobalContext* globalCtx) {
     f32 phi_f0;
     Vec3f sp40;
@@ -349,12 +342,12 @@ void func_80A671E0(ObjDriftice* this, GlobalContext* globalCtx) {
     f32 phi_f12;
     Vec3s* points;
     s32 sp30;
-    Vec3s* points2;
+    Actor* thisx = &this->dyna.actor;
 
     Math_Vec3s_ToVec3f(&sp40, &(&this->unk_16C[this->unk_164])[this->unk_168]);
-    Math_Vec3f_Diff(&sp40, &this->dyna.actor.world.pos, &this->dyna.actor.velocity);
+    Math_Vec3f_Diff(&sp40, &this->dyna.actor.world.pos, &thisx->velocity);
 
-    sp3C = Math3D_Vec3fMagnitude(&this->dyna.actor.velocity);
+    sp3C = Math3D_Vec3fMagnitude(&thisx->velocity);
     if (sp3C < (this->unk_23C * 8.0f)) {
         phi_f0 = this->unk_23C * 0.4f;
         phi_f12 = this->unk_23C * 0.05f;
@@ -391,8 +384,8 @@ void func_80A671E0(ObjDriftice* this, GlobalContext* globalCtx) {
                     this->unk_164 = this->unk_160;
                 }
 
-                points2 = &this->unk_16C[0];
-                if ((points2->x != points->x) || (points2->y != points->y) || (points2->z != points->z)) {
+                if ((this->unk_16C[0].x != points->x) || (this->unk_16C[0].y != points->y) ||
+                    (this->unk_16C[0].z != points->z)) {
                     func_80A6743C(this);
                     func_800C62BC(globalCtx, &globalCtx->colCtx.dyna, this->dyna.bgId);
                     sp30 = false;
@@ -405,9 +398,6 @@ void func_80A671E0(ObjDriftice* this, GlobalContext* globalCtx) {
         }
     }
 }
-#else
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Driftice/func_80A671E0.s")
-#endif
 
 void func_80A6743C(ObjDriftice* this) {
     this->actionFunc = func_80A67450;

--- a/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.c
+++ b/src/overlays/actors/ovl_Obj_Spidertent/z_obj_spidertent.c
@@ -557,7 +557,8 @@ void ObjSpidertent_Init(Actor* thisx, GlobalContext* globalCtx) {
     ColliderTrisElementInit* element;
     Vec3f sp70[3];
     Vec3f sp64;
-    s32 i, j;
+    s32 i;
+    s32 j;
 
     Actor_ProcessInitChain(&this->dyna.actor, sInitChain);
     DynaPolyActor_Init(&this->dyna, 0);
@@ -698,8 +699,9 @@ void func_80B30AD4(ObjSpidertent* this) {
 void func_80B30AF8(ObjSpidertent* this, GlobalContext* globalCtx) {
     ObjSpidertentStruct* temp_s0 = &D_80B31350[OBJSPIDERTENT_GET_1(&this->dyna.actor)];
     TriNorm* triNorm;
-    s32 i, j;
-    ObjSpidertentStruct2* ptr;
+    s32 i;
+    s32 j;
+    s32 pad;
     Vec3f sp60;
     f32 sp5C;
 

--- a/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
+++ b/src/overlays/actors/ovl_Obj_Switch/z_obj_switch.c
@@ -397,7 +397,8 @@ void ObjSwitch_Init(Actor* thisx, GlobalContext* globalCtx) {
     }
     if (type == OBJSWITCH_TYPE_EYE) {
         if (sIsSegmentTableInit == false) {
-            s32 i, j;
+            s32 i;
+            s32 j;
 
             sIsSegmentTableInit = true;
 

--- a/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
+++ b/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.c
@@ -141,15 +141,15 @@ void func_80A3C7E8(ObjVspinyroll* this) {
     s32 index = D_80A3D450[OBJVSPINYROLL_GET_4000(&this->dyna.actor)] * 120.0f * (1.0f / 58.0f);
 
     index += 2;
-    this->unk_38C = index * 4;
+    this->unk_1A8.unk_1E4 = index * 4;
 
     tempf = ((D_80A3D450[OBJVSPINYROLL_GET_4000(&this->dyna.actor)] * 120.0f) - 2.0f) / (index - 1);
     phi_f2 = 1.0f;
 
-    for (i = 0, j = 0; i < this->unk_38C; i++) {
-        this->unk_1A8[i].unk_00.x = D_80A3D4C4[j];
-        this->unk_1A8[i].unk_00.y = phi_f2;
-        this->unk_1A8[i].unk_00.z = D_80A3D4B4[j];
+    for (i = 0, j = 0; i < this->unk_1A8.unk_1E4; i++) {
+        this->unk_1A8.unk_000[i].unk_00.x = D_80A3D4C4[j];
+        this->unk_1A8.unk_000[i].unk_00.y = phi_f2;
+        this->unk_1A8.unk_000[i].unk_00.z = D_80A3D4B4[j];
 
         j++;
         if (j >= 4) {
@@ -159,11 +159,10 @@ void func_80A3C7E8(ObjVspinyroll* this) {
     }
 }
 
-#ifdef NON_MATCHING
 s32 func_80A3C8D8(ObjVspinyroll* this, GlobalContext* globalCtx, Vec3f* arg2, s32 arg3) {
     s32 pad;
-    ObjVspinyrollStruct2* ptr = &this->unk_1A8[0];
-    s32 pad2;
+    ObjVspinyrollStruct3* unk_1A8 = &this->unk_1A8;
+    ObjVspinyrollStruct2* ptr;
     s32 i;
     Vec3f spE4;
     Vec3f spD8;
@@ -177,9 +176,11 @@ s32 func_80A3C8D8(ObjVspinyroll* this, GlobalContext* globalCtx, Vec3f* arg2, s3
 
     spE4.z = 0.0f;
     sp9C = false;
-    this->unk_388 = NULL;
+    unk_1A8->unk_1E0 = NULL;
 
-    for (i = 0; i < this->unk_38C; i++, ptr++) {
+    for (i = 0; i < unk_1A8->unk_1E4; i++) {
+        ptr = &unk_1A8->unk_000[i];
+
         spE4.x = ptr->unk_00.x;
         spE4.y = ptr->unk_00.y;
         func_80A3C4E0(&spD8, &spE4, this->dyna.actor.world.rot.y);
@@ -193,8 +194,8 @@ s32 func_80A3C8D8(ObjVspinyroll* this, GlobalContext* globalCtx, Vec3f* arg2, s3
         spCC.x += 30.0f * this->unk_3B4.x;
         spCC.z += 30.0f * this->unk_3B4.z;
 
-        if (BgCheck_EntityLineTest3(&globalCtx->colCtx, &spD8, &spCC, &spC0, &this->unk_1A8[i].collisionPoly, true,
-                                    false, false, true, &this->unk_1A8[i].bgId, &this->dyna.actor, 0.0f)) {
+        if (BgCheck_EntityLineTest3(&globalCtx->colCtx, &spD8, &spCC, &spC0, &unk_1A8->unk_000[i].collisionPoly, true,
+                                    false, false, true, &unk_1A8->unk_000[i].bgId, &this->dyna.actor, 0.0f)) {
             if ((arg3 != 0) && (this->dyna.actor.flags & ACTOR_FLAG_40)) {
                 spA8.x = ptr->unk_00.x * 0.2f;
                 spA8.y = ptr->unk_00.y;
@@ -215,17 +216,13 @@ s32 func_80A3C8D8(ObjVspinyroll* this, GlobalContext* globalCtx, Vec3f* arg2, s3
                 temp_f20 = temp_f0;
                 sp9C = true;
                 Math_Vec3f_Diff(&spC0, &spCC, arg2);
-                this->unk_388 = ptr;
+                unk_1A8->unk_1E0 = ptr;
             }
         }
     }
 
     return sp9C;
 }
-#else
-s32 func_80A3C8D8(ObjVspinyroll* this, GlobalContext* globalCtx, Vec3f* arg2, s32 arg3);
-#pragma GLOBAL_ASM("asm/non_matchings/overlays/ovl_Obj_Vspinyroll/func_80A3C8D8.s")
-#endif
 
 s32 func_80A3CB94(ObjVspinyroll* this, GlobalContext* globalCtx, s32 arg2) {
     Vec3f sp1C;
@@ -239,8 +236,8 @@ s32 func_80A3CB94(ObjVspinyroll* this, GlobalContext* globalCtx, s32 arg2) {
 }
 
 DynaPolyActor* func_80A3CBF0(ObjVspinyroll* this, GlobalContext* globalCtx) {
-    if (this->unk_388 != NULL) {
-        return DynaPoly_GetActor(&globalCtx->colCtx, this->unk_388->bgId);
+    if (this->unk_1A8.unk_1E0 != NULL) {
+        return DynaPoly_GetActor(&globalCtx->colCtx, this->unk_1A8.unk_1E0->bgId);
     }
     return NULL;
 }

--- a/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.h
+++ b/src/overlays/actors/ovl_Obj_Vspinyroll/z_obj_vspinyroll.h
@@ -21,12 +21,16 @@ typedef struct {
     /* 0x10 */ s32 bgId;
 } ObjVspinyrollStruct2; // size = 0x14
 
+typedef struct {
+    /* 0x000 */ ObjVspinyrollStruct2 unk_000[24];
+    /* 0x1E0 */ ObjVspinyrollStruct2* unk_1E0;
+    /* 0x1E4 */ s32 unk_1E4;
+} ObjVspinyrollStruct3; // size = 0x1E8
+
 typedef struct ObjVspinyroll {
     /* 0x0000 */ DynaPolyActor dyna;
     /* 0x015C */ ColliderCylinder collider;
-    /* 0x01A8 */ ObjVspinyrollStruct2 unk_1A8[24];
-    /* 0x0388 */ ObjVspinyrollStruct2* unk_388;
-    /* 0x038C */ s32 unk_38C;
+    /* 0x01A8 */ ObjVspinyrollStruct3 unk_1A8;
     /* 0x0390 */ ObjVspinyrollActionFunc actionFunc;
     /* 0x0394 */ f32 unk_394;
     /* 0x0398 */ s32 unk_398;


### PR DESCRIPTION
Before opening this PR, ensure the following:
- `./format.sh` was run to apply standard formatting.
- `make` successfully builds a matching ROM.
- No new compiler warnings were introduced during the build process.
    - Can be verified locally by running `tools/warnings_count/check_new_warnings.sh`
- New variables & functions should follow standard naming conventions.
- Comments and variables have correct spelling.
---
<!-- Leave the text above intact. Add additional comments below. -->

Some good memes in here.

- `z_en_horse` OK (Match `EnHorse_Init` + `EnHorse_FleePlayer` + `EnHorse_Update`)
- `z_en_goroiwa` OK (Match `func_80940588`)
- `z_obj_vspinyroll` OK (Match `func_80A3C8D8`)
- `z_obj_driftice` OK (Match `func_80A66930` + `func_80A671E0`)
- `z_en_rg` OK (Match `func_80BF43FC`)