### PR TITLE
set LANG variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ N_THREADS ?= $(shell nproc)
 
 #### Setup ####
 
+# Ensure the map file being created using English localization
+export LANG := C
+
 ifeq ($(NON_MATCHING),1)
   CFLAGS := -DNON_MATCHING
   CPPFLAGS := -DNON_MATCHING


### PR DESCRIPTION
On non-english system, the `diff.py` script could not be able to work due to the map file being created using the system localization.

As the `search_map_file()` function of the script is searching for "_load address_" words, map files created using non-english localization will not be read correctly, causing the script to fail with `Not able to find .o file for function.`.

A workaround is then to set the `LANG` environnement variable to `en_US` or `C` to ensure the map files being created in english.