### PR TITLE
Remove a dummy label match in BgHakuginBombwall

### DIFF
--- a/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
@@ -20,8 +20,8 @@ void func_80ABBFC0(BgHakuginBombwall* this, PlayState* play);
 void func_80ABC2E0(BgHakuginBombwall* this, PlayState* play);
 void func_80ABC58C(BgHakuginBombwall* this, PlayState* play);
 void func_80ABC7FC(BgHakuginBombwall* this, PlayState* play);
-s32 func_80ABCB5C(Actor* thisx, PlayState* play);
-s32 func_80ABCC00(Actor* thisx, PlayState* play);
+s32 func_80ABCB5C(BgHakuginBombwall* this, PlayState* play);
+s32 func_80ABCC00(BgHakuginBombwall* this, PlayState* play);
 void func_80ABCCE4(BgHakuginBombwall* this, PlayState* play);
 void func_80ABCD98(BgHakuginBombwall* this, PlayState* play);
 void func_80ABCE60(BgHakuginBombwall* this, PlayState* play);
@@ -342,15 +342,14 @@ void BgHakuginBombwall_Destroy(Actor* thisx, PlayState* play) {
     Collider_DestroyCylinder(play, &this->collider);
 }
 
-s32 func_80ABCB5C(Actor* thisx, PlayState* play) {
-    BgHakuginBombwall* this = THIS;
-    s32 pad;
+s32 func_80ABCB5C(BgHakuginBombwall* this, PlayState* play) {
+    Actor* thisx = &this->dyna.actor;
 
     if (this->collider.base.acFlags & AC_HIT) {
         if (this->collider.base.ac != NULL) {
-            if (Math3D_Vec3fDistSq(&this->dyna.actor.world.pos, &this->collider.base.ac->world.pos) <
-                D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(&this->dyna.actor)].unk_1C) {
-                SoundSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 60, NA_SE_EV_WALL_BROKEN);
+            if (Math3D_Vec3fDistSq(&thisx->world.pos, &this->collider.base.ac->world.pos) <
+                D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(thisx)].unk_1C) {
+                SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 60, NA_SE_EV_WALL_BROKEN);
                 return true;
             }
         }
@@ -358,13 +357,12 @@ s32 func_80ABCB5C(Actor* thisx, PlayState* play) {
     return false;
 }
 
-s32 func_80ABCC00(Actor* thisx, PlayState* play) {
-    BgHakuginBombwall* this = THIS;
-    s32 pad;
-
+s32 func_80ABCC00(BgHakuginBombwall* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         if (this->collider.info.acHitInfo->toucher.dmgFlags & 8) {
             if (this->collider.base.ac != NULL) {
+                s32 requiredScopeTemp;
+
                 if (Math3D_Vec3fDistSq(&this->dyna.actor.world.pos, &this->collider.base.ac->world.pos) <
                     D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(&this->dyna.actor)].unk_1C) {
                     SoundSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 50, NA_SE_EV_WALL_BROKEN);
@@ -372,7 +370,6 @@ s32 func_80ABCC00(Actor* thisx, PlayState* play) {
                 }
             }
         } else if (DynaPolyActor_IsInRidingMovingState(&this->dyna)) {
-        label:;
             SoundSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 50, NA_SE_EV_WALL_BROKEN);
             return true;
         }
@@ -383,7 +380,7 @@ s32 func_80ABCC00(Actor* thisx, PlayState* play) {
 void func_80ABCCE4(BgHakuginBombwall* this, PlayState* play) {
     BgHakuginBombwallStruct* ptr = &D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(&this->dyna.actor)];
 
-    if (ptr->unk_20(&this->dyna.actor, play)) {
+    if (ptr->unk_20(this, play)) {
         this->dyna.actor.flags |= ACTOR_FLAG_10;
         ActorCutscene_SetIntentToPlay(this->dyna.actor.cutscene);
         this->actionFunc = func_80ABCD98;

--- a/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.h
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.h
@@ -6,7 +6,7 @@
 struct BgHakuginBombwall;
 
 typedef void (*BgHakuginBombwallActionFunc)(struct BgHakuginBombwall*, PlayState*);
-typedef s32 (*BgHakuginBombwallUnkFunc)(Actor*, PlayState*);
+typedef s32 (*BgHakuginBombwallUnkFunc)(struct BgHakuginBombwall*, PlayState*);
 typedef void (*BgHakuginBombwallUnkFunc2)(struct BgHakuginBombwall*, PlayState*);
 
 #define BGHAKUGIN_BOMBWALL_SWITCHFLAG(thisx) ((thisx)->params & 0x7F)


### PR DESCRIPTION
After removing a dummy label match in EnInvadepoh, I thought that most of them were gone, but one snuck in without me noticing. This was a fun one to solve. My thought process went like this:
- `BgHakuginBombwallUnkFunc` almost certainly takes `this`, not `thisx`, since both `func_80ABCB5C` and `func_80ABCC00` immediately made a `this` temp anyways.
- Just doing that + introducing the right `requiredScopeTemp` removes the dummy label and fixes `func_80ABCC00`, but at this point `func_80ABCB5C` was pretty messed up.
- I solved that by using a pattern that OoT3D taught me: the lowly `thisx` temp. In OoT3D, this is required in a bunch of different places to match, so I think it was simply a common pattern they used. It works perfectly to solve the problem I was seeing in `func_80ABCB5C`.