### PR TITLE
Effect Sbn Asset Docs

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1285,12 +1285,18 @@
         <Texture Name="gameplay_keep_Tex_0700B0" OutName="tex_0700B0" Format="rgba16" Width="16" Height="32" Offset="0x700B0" />
         <Texture Name="gameplay_keep_Tex_0704B0" OutName="tex_0704B0" Format="rgba16" Width="16" Height="16" Offset="0x704B0" />
         <DList Name="gameplay_keep_DL_0706E0" Offset="0x706E0" />
-        <DList Name="gameplay_keep_DL_070730" Offset="0x70730" />
-        <Texture Name="gameplay_keep_Tex_0707F0" OutName="tex_0707F0" Format="i4" Width="32" Height="32" Offset="0x707F0" />
-        <Texture Name="gameplay_keep_Tex_0709F0" OutName="tex_0709F0" Format="i4" Width="64" Height="64" Offset="0x709F0" />
-        <TextureAnimation Name="gameplay_keep_Matanimheader_0711F8" Offset="0x711F8" />
+
+        <!-- Popped Deku Bubbles (EffSsSbn) -->
+
+        <!-- Static Popped Bubbles, can't swap out textures (unused) -->
+        <DList Name="gEffPoppedDekuBubbleStaticDL" Offset="0x70730" />
+        <Texture Name="gEffPoppedDekuBubbleStaticMaskTex" OutName="eff_popped_deku_bubble_static_mask" Format="i4" Width="32" Height="32" Offset="0x707F0" />
+        <Texture Name="gEffPoppedDekuBubbleStaticTex" OutName="eff_popped_deku_bubble_static" Format="i4" Width="64" Height="64" Offset="0x709F0" />
+        <TextureAnimation Name="gEffPoppedDekuBubbleStaticTexAnim" Offset="0x711F8" />
+
+        <!-- Sliding Popped Deku Bubbles -->
         <DList Name="gEffPoppedDekuBubbleSlidingDL" Offset="0x71230" />
-        <TextureAnimation Name="gameplay_keep_Matanimheader_0712F8" Offset="0x712F8" />
+        <TextureAnimation Name="gEffPoppedDekuBubbleSlidingTexAnim" Offset="0x712F8" /> <!-- Unused -->
         <Texture Name="gEffPoppedDekuBubbleSliding1Tex" OutName="eff_popped_deku_bubble_sliding_1" Format="i4" Width="32" Height="64" Offset="0x71300" />
         <Texture Name="gEffPoppedDekuBubbleSliding2Tex" OutName="eff_popped_deku_bubble_sliding_2" Format="i4" Width="32" Height="64" Offset="0x71700" />
         <Texture Name="gEffPoppedDekuBubbleSliding3Tex" OutName="eff_popped_deku_bubble_sliding_3" Format="i4" Width="32" Height="64" Offset="0x71B00" />
@@ -1303,14 +1309,17 @@
         <Texture Name="gEffPoppedDekuBubbleSliding10Tex" OutName="eff_popped_deku_bubble_sliding_10" Format="i4" Width="32" Height="64" Offset="0x73700" />
         <Texture Name="gEffPoppedDekuBubbleSliding11Tex" OutName="eff_popped_deku_bubble_sliding_11" Format="i4" Width="32" Height="64" Offset="0x73B00" />
         <Texture Name="gEffPoppedDekuBubbleSliding12Tex" OutName="eff_popped_deku_bubble_sliding_12" Format="i4" Width="32" Height="64" Offset="0x73F00" />
+
+        <!-- Regular Popped Deku Bubbles -->
         <DList Name="gEffPoppedDekuBubbleDL" Offset="0x74330" />
-        <Blob Name="gameplay_keep_DL_0743F0" Size="0x10" Offset="0x743F0" />
+        <TextureAnimation Name="gEffPoppedDekuBubbleTexAnim" Offset="0x743F0" /> <!-- Empty and unused -->
         <Texture Name="gEffPoppedDekuBubble1Tex" OutName="eff_popped_deku_bubble_1" Format="i4" Width="32" Height="64" Offset="0x74400" />
         <Texture Name="gEffPoppedDekuBubble2Tex" OutName="eff_popped_deku_bubble_2" Format="i4" Width="32" Height="64" Offset="0x74800" />
         <Texture Name="gEffPoppedDekuBubble3Tex" OutName="eff_popped_deku_bubble_3" Format="i4" Width="32" Height="64" Offset="0x74C00" />
         <Texture Name="gEffPoppedDekuBubble4Tex" OutName="eff_popped_deku_bubble_4" Format="i4" Width="32" Height="64" Offset="0x75000" />
         <Texture Name="gEffPoppedDekuBubble5Tex" OutName="eff_popped_deku_bubble_5" Format="i4" Width="32" Height="64" Offset="0x75400" />
-        <Texture Name="gameplay_keep_Tex_075800" OutName="tex_075800" Format="i4" Width="32" Height="32" Offset="0x75800" />
+        <Texture Name="gEffPoppedDekuBubbleMaskTex" OutName="eff_popped_deku_bubble_mask" Format="i4" Width="32" Height="32" Offset="0x75800" /> <!-- Mask used for both normal and sliding bubbles -->
+
         <DList Name="gSquareShadowDL" Offset="0x75A40" />
         <Texture Name="gameplay_keep_Tex_075AA8" OutName="tex_075AA8" Format="i4" Width="16" Height="16" Offset="0x75AA8" />
         <DList Name="gFootShadowDL" Offset="0x75B30" />


### PR DESCRIPTION
Documents the rest of the assets in gameplaykeep used by EffectSbn, including ones that look unused.