### PR TITLE
README.md "How to Contribute" wrong path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please refer to the following for more information:
 
 - [Website](https://zelda64.dev/)
 - [Discord](https://discord.zelda64.dev/)
-- [How to Contribute](CONTRIBUTING.md)
+- [How to Contribute](docs/CONTRIBUTING.md)
 
 ## Installation
 


### PR DESCRIPTION
Noticed the link was pointing to the original `CONTRIBUTING.md` path when trying to get back into decomp after a break. Updated it to match the link further down in the README.