### PR TITLE
object_thiefbird (Takkuri) documented

### DIFF
--- a/assets/xml/objects/object_thiefbird.xml
+++ b/assets/xml/objects/object_thiefbird.xml
@@ -1,66 +1,84 @@
 ﻿<Root>
+    <!-- Assets for Takkuri -->
     <File Name="object_thiefbird" Segment="6">
-        <Animation Name="object_thiefbird_Anim_000088" Offset="0x88" />
-        <Animation Name="object_thiefbird_Anim_000278" Offset="0x278" />
-        <Animation Name="object_thiefbird_Anim_000604" Offset="0x604" />
-        <DList Name="object_thiefbird_DL_0016D0" Offset="0x16D0" />
-        <DList Name="object_thiefbird_DL_001800" Offset="0x1800" />
-        <DList Name="object_thiefbird_DL_0018A8" Offset="0x18A8" />
-        <DList Name="object_thiefbird_DL_0019D0" Offset="0x19D0" />
-        <DList Name="object_thiefbird_DL_001A18" Offset="0x1A18" />
-        <DList Name="object_thiefbird_DL_001CF0" Offset="0x1CF0" />
-        <DList Name="object_thiefbird_DL_001DA8" Offset="0x1DA8" />
-        <DList Name="object_thiefbird_DL_001FE0" Offset="0x1FE0" />
-        <DList Name="object_thiefbird_DL_002070" Offset="0x2070" />
-        <DList Name="object_thiefbird_DL_002100" Offset="0x2100" />
-        <DList Name="object_thiefbird_DL_0021D0" Offset="0x21D0" />
-        <DList Name="object_thiefbird_DL_0022C0" Offset="0x22C0" />
-        <DList Name="object_thiefbird_DL_0023B0" Offset="0x23B0" />
-        <DList Name="object_thiefbird_DL_0024A0" Offset="0x24A0" />
-        <DList Name="object_thiefbird_DL_002590" Offset="0x2590" />
-        <DList Name="object_thiefbird_DL_002680" Offset="0x2680" />
-        <Texture Name="object_thiefbird_Tex_002770" OutName="tex_002770" Format="rgba16" Width="8" Height="16" Offset="0x2770" />
-        <Texture Name="object_thiefbird_Tex_002870" OutName="tex_002870" Format="rgba16" Width="16" Height="16" Offset="0x2870" />
-        <Texture Name="object_thiefbird_Tex_002A70" OutName="tex_002A70" Format="rgba16" Width="16" Height="16" Offset="0x2A70" />
-        <Texture Name="object_thiefbird_Tex_002C70" OutName="tex_002C70" Format="i8" Width="16" Height="16" Offset="0x2C70" />
-        <Texture Name="object_thiefbird_Tex_002D70" OutName="tex_002D70" Format="rgba16" Width="8" Height="8" Offset="0x2D70" />
-        <Texture Name="object_thiefbird_Tex_002DF0" OutName="tex_002DF0" Format="rgba16" Width="4" Height="8" Offset="0x2DF0" />
-        <Texture Name="object_thiefbird_Tex_002E30" OutName="tex_002E30" Format="rgba16" Width="16" Height="16" Offset="0x2E30" />
-        <DList Name="object_thiefbird_DL_003060" Offset="0x3060" />
-        <DList Name="object_thiefbird_DL_0030D8" Offset="0x30D8" />
-        <Texture Name="object_thiefbird_Tex_0030F0" OutName="tex_0030F0" Format="rgba16" Width="8" Height="16" Offset="0x30F0" />
-        <DList Name="object_thiefbird_DL_0033B0" Offset="0x33B0" />
-        <DList Name="object_thiefbird_DL_003D58" Offset="0x3D58" />
-        <DList Name="object_thiefbird_DL_004348" Offset="0x4348" />
-        <DList Name="object_thiefbird_DL_004B88" Offset="0x4B88" />
-        <DList Name="object_thiefbird_DL_0055E0" Offset="0x55E0" />
-        <Texture Name="object_thiefbird_Tex_0059A0" OutName="tex_0059A0" Format="rgba16" Width="32" Height="8" Offset="0x59A0" />
-        <Texture Name="object_thiefbird_Tex_005BA0" OutName="tex_005BA0" Format="rgba16" Width="8" Height="8" Offset="0x5BA0" />
-        <Texture Name="object_thiefbird_Tex_005C20" OutName="tex_005C20" Format="rgba16" Width="8" Height="8" Offset="0x5C20" />
-        <Texture Name="object_thiefbird_Tex_005CA0" OutName="tex_005CA0" Format="rgba16" Width="8" Height="8" Offset="0x5CA0" />
-        <Texture Name="object_thiefbird_Tex_005D20" OutName="tex_005D20" Format="i8" Width="8" Height="8" Offset="0x5D20" />
-        <Texture Name="object_thiefbird_Tex_005D60" OutName="tex_005D60" Format="rgba16" Width="8" Height="16" Offset="0x5D60" />
-        <Texture Name="object_thiefbird_Tex_005E60" OutName="tex_005E60" Format="rgba16" Width="8" Height="16" Offset="0x5E60" />
-        <Texture Name="object_thiefbird_Tex_005F60" OutName="tex_005F60" Format="rgba16" Width="8" Height="8" Offset="0x5F60" />
-        <Texture Name="object_thiefbird_Tex_005FE0" OutName="tex_005FE0" Format="i8" Width="8" Height="8" Offset="0x5FE0" />
-        <Texture Name="object_thiefbird_Tex_006020" OutName="tex_006020" Format="i4" Width="16" Height="16" Offset="0x6020" />
-        <Limb Name="object_thiefbird_Standardlimb_0060A0" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_01" Offset="0x60A0" />
-        <Limb Name="object_thiefbird_Standardlimb_0060AC" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_02" Offset="0x60AC" />
-        <Limb Name="object_thiefbird_Standardlimb_0060B8" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_03" Offset="0x60B8" />
-        <Limb Name="object_thiefbird_Standardlimb_0060C4" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_04" Offset="0x60C4" />
-        <Limb Name="object_thiefbird_Standardlimb_0060D0" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_05" Offset="0x60D0" />
-        <Limb Name="object_thiefbird_Standardlimb_0060DC" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_06" Offset="0x60DC" />
-        <Limb Name="object_thiefbird_Standardlimb_0060E8" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_07" Offset="0x60E8" />
-        <Limb Name="object_thiefbird_Standardlimb_0060F4" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_08" Offset="0x60F4" />
-        <Limb Name="object_thiefbird_Standardlimb_006100" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_09" Offset="0x6100" />
-        <Limb Name="object_thiefbird_Standardlimb_00610C" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0A" Offset="0x610C" />
-        <Limb Name="object_thiefbird_Standardlimb_006118" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0B" Offset="0x6118" />
-        <Limb Name="object_thiefbird_Standardlimb_006124" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0C" Offset="0x6124" />
-        <Limb Name="object_thiefbird_Standardlimb_006130" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0D" Offset="0x6130" />
-        <Limb Name="object_thiefbird_Standardlimb_00613C" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0E" Offset="0x613C" />
-        <Limb Name="object_thiefbird_Standardlimb_006148" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_0F" Offset="0x6148" />
-        <Limb Name="object_thiefbird_Standardlimb_006154" Type="Standard" EnumName="OBJECT_THIEFBIRD_LIMB_10" Offset="0x6154" />
-        <Skeleton Name="object_thiefbird_Skel_0061A0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_THIEFBIRD_LIMB_NONE" LimbMax="OBJECT_THIEFBIRD_LIMB_MAX" EnumName="object_thiefbird_Limbs" Offset="0x61A0" />
-        <Animation Name="object_thiefbird_Anim_0063C4" Offset="0x63C4" />
+        <!-- Takkuri Animations -->
+        <Animation Name="gTakkuriDeathAnim" Offset="0x88" /> <!-- Original name is "hnt_damage" -->
+        <Animation Name="gTakkuriFlyWithItemAnim" Offset="0x278" /> <!-- Original name is "hnt_escape" -->
+        <Animation Name="gTakkuriFlyAnim" Offset="0x604" /> <!-- Original name is "hnt_fly" -->
+
+        <!-- Takkuri Limb DisplayLists -->
+        <DList Name="gTakkuriBodyDL" Offset="0x16D0" />
+        <DList Name="gTakkuriLegsDL" Offset="0x1800" />
+        <DList Name="gTakkuriFeetDL" Offset="0x18A8" />
+        <DList Name="gTakkuriStolenItemDL" Offset="0x19D0" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <DList Name="gTakkuriHeadDL" Offset="0x1A18" />
+        <DList Name="gTakkuriEyesDL" Offset="0x1CF0" />
+        <DList Name="gTakkuriLowerBeakDL" Offset="0x1DA8" />
+        <DList Name="gTakkuriLeftEarDL" Offset="0x1FE0" />
+        <DList Name="gTakkuriRightEarDL" Offset="0x2070" />
+        <DList Name="gTakkuriNeckDL" Offset="0x2100" />
+        <DList Name="gTakkuriRightWingTipDL" Offset="0x21D0" />
+        <DList Name="gTakkuriRightWingMiddleDL" Offset="0x22C0" />
+        <DList Name="gTakkuriRightWingBaseDL" Offset="0x23B0" />
+        <DList Name="gTakkuriLeftWingTipDL" Offset="0x24A0" />
+        <DList Name="gTakkuriLeftWingMiddleDL" Offset="0x2590" />
+        <DList Name="gTakkuriLeftWingBaseDL" Offset="0x2680" />
+
+        <!-- Takkuri Textures -->
+        <Texture Name="gTakkuriFeathersTex" OutName="takkuri_feathers" Format="rgba16" Width="8" Height="16" Offset="0x2770" />
+        <Texture Name="gTakkuriWingTipTex" OutName="takkuri_wing_tip" Format="rgba16" Width="16" Height="16" Offset="0x2870" />
+        <Texture Name="gTakkuriEyeTex" OutName="takkuri_eye" Format="rgba16" Width="16" Height="16" Offset="0x2A70" />
+        <Texture Name="gTakkuriHeadAndNeckTex" OutName="takkuri_head_and_neck" Format="i8" Width="16" Height="16" Offset="0x2C70" />
+        <Texture Name="gTakkuriBeakAndLegsTex" OutName="takkuri_beak_and_legs" Format="rgba16" Width="8" Height="8" Offset="0x2D70" />
+        <Texture Name="gTakkuriInnerBeakTex" OutName="takkuri_inner_beak" Format="rgba16" Width="4" Height="8" Offset="0x2DF0" />
+        <Texture Name="gTakkuriEarTex" OutName="takkuri_ear" Format="rgba16" Width="16" Height="16" Offset="0x2E30" />
+
+        <!-- DisplayLists and Texture for Takkuri's feather effect -->
+        <DList Name="gTakkuriFeatherMaterialDL" Offset="0x3060" />
+        <DList Name="gTakkuriFeatherModelDL" Offset="0x30D8" />
+        <Texture Name="gTakkuriFeatherTex" OutName="takkuri_feather" Format="rgba16" Width="8" Height="16" Offset="0x30F0" />
+        
+        <!-- DisplayLists for stolen items -->
+        <DList Name="gTakkuriStolenBottleDL" Offset="0x33B0" />
+        <DList Name="gTakkuriStolenGreatFairySwordDL" Offset="0x3D58" />
+        <DList Name="gTakkuriStolenKokiriSwordDL" Offset="0x4348" />
+        <DList Name="gTakkuriStolenRazorSwordDL" Offset="0x4B88" />
+        <DList Name="gTakkuriStolenGildedSwordDL" Offset="0x55E0" />
+
+        <!-- Textures for stolen items -->
+        <Texture Name="gTakkuriStolenGreatFairySwordCenterAndHiltTex" OutName="takkuri_stolen_great_fairy_sword_center_and_hilt" Format="rgba16" Width="32" Height="8" Offset="0x59A0" />
+        <Texture Name="gTakkuriStolenKokiriSwordPommelTex" OutName="takkuri_stolen_kokiri_sword_pommel" Format="rgba16" Width="8" Height="8" Offset="0x5BA0" />
+        <Texture Name="gTakkuriStolenKokiriAndRazorSwordScabbardTex" OutName="takkuri_stolen_kokiri_and_razor_sword_scabbard" Format="rgba16" Width="8" Height="8" Offset="0x5C20" />
+        <Texture Name="gTakkuriStolenKokiriSwordGuardTex" OutName="takkuri_stolen_kokiri_sword_guard" Format="rgba16" Width="8" Height="8" Offset="0x5CA0" />
+        <Texture Name="gTakkuriStolenKokiriSwordGripTex" OutName="takkuri_stolen_kokiri_sword_grip" Format="i8" Width="8" Height="8" Offset="0x5D20" />
+        <Texture Name="gTakkuriStolenRazorSwordHiltAndScabbardTex" OutName="takkuri_stolen_razor_sword_hilt_and_scabbard" Format="rgba16" Width="8" Height="16" Offset="0x5D60" />
+        <Texture Name="gTakkuriStolenGildedSwordScabbardTex" OutName="takkuri_stolen_gilded_sword_scabbard" Format="rgba16" Width="8" Height="16" Offset="0x5E60" />
+        <Texture Name="gTakkuriStolenGildedSwordGripAndScabbardTopTex" OutName="takkuri_stolen_gilded_sword_grip_and_scabbard_top" Format="rgba16" Width="8" Height="8" Offset="0x5F60" />
+        <Texture Name="gTakkuriStolenBottleAndGildedSwordGemTex" OutName="takkuri_stolen_bottle_and_gilded_sword_gem" Format="i8" Width="8" Height="8" Offset="0x5FE0" />
+        <Texture Name="gTakkuriStolenGreatFairySwordBladeGildedSwordPommelAndGuardTex" OutName="takkuri_stolen_great_fairy_sword_blade_gilded_sword_pommel_and_guard" Format="i4" Width="16" Height="16" Offset="0x6020" />
+
+        <!-- Takkuri Limbs -->
+        <Limb Name="gTakkuriBodyLimb" Type="Standard" EnumName="TAKKURI_LIMB_BODY" Offset="0x60A0" />
+        <Limb Name="gTakkuriLeftWingBaseLimb" Type="Standard" EnumName="TAKKURI_LIMB_LEFT_WING_BASE" Offset="0x60AC" />
+        <Limb Name="gTakkuriLeftWingMiddleLimb" Type="Standard" EnumName="TAKKURI_LIMB_LEFT_WING_MIDDLE" Offset="0x60B8" />
+        <Limb Name="gTakkuriLeftWingTipLimb" Type="Standard" EnumName="TAKKURI_LIMB_LEFT_WING_TIP" Offset="0x60C4" />
+        <Limb Name="gTakkuriRightWingBaseLimb" Type="Standard" EnumName="TAKKURI_LIMB_RIGHT_WING_BASE" Offset="0x60D0" />
+        <Limb Name="gTakkuriRightWingMiddleLimb" Type="Standard" EnumName="TAKKURI_LIMB_RIGHT_WING_MIDDLE" Offset="0x60DC" />
+        <Limb Name="gTakkuriRightWingTipLimb" Type="Standard" EnumName="TAKKURI_LIMB_RIGHT_WING_TIP" Offset="0x60E8" />
+        <Limb Name="gTakkuriNeckLimb" Type="Standard" EnumName="TAKKURI_LIMB_NECK" Offset="0x60F4" />
+        <Limb Name="gTakkuriHeadLimb" Type="Standard" EnumName="TAKKURI_LIMB_HEAD" Offset="0x6100" />
+        <Limb Name="gTakkuriRightEarLimb" Type="Standard" EnumName="TAKKURI_LIMB_RIGHT_EAR" Offset="0x610C" />
+        <Limb Name="gTakkuriLeftEarLimb" Type="Standard" EnumName="TAKKURI_LIMB_LEFT_EAR" Offset="0x6118" />
+        <Limb Name="gTakkuriLowerBeakLimb" Type="Standard" EnumName="TAKKURI_LIMB_LOWER_BEAK" Offset="0x6124" />
+        <Limb Name="gTakkuriEyesLimb" Type="Standard" EnumName="TAKKURI_LIMB_EYES" Offset="0x6130" />
+        <Limb Name="gTakkuriLegsLimb" Type="Standard" EnumName="TAKKURI_LIMB_LEGS" Offset="0x613C" />
+        <Limb Name="gTakkuriFeetLimb" Type="Standard" EnumName="TAKKURI_LIMB_FEET" Offset="0x6148" />
+        <Limb Name="gTakkuriStolenItemLimb" Type="Standard" EnumName="TAKKURI_LIMB_STOLEN_ITEM" Offset="0x6154" />
+
+        <!-- Takkuri Skeleton -->
+        <Skeleton Name="gTakkuriSkel" Type="Flex" LimbType="Standard" LimbNone="TAKKURI_LIMB_NONE" LimbMax="TAKKURI_LIMB_MAX" EnumName="TakkuriLimb" Offset="0x61A0" />
+
+        <!-- Takkuri Animation -->
+        <Animation Name="gTakkuriAttackAnim" Offset="0x63C4" /> <!-- Original name is "hnt_ikaku" ("threat, intimidation") -->
     </File>
 </Root>

--- a/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.c
+++ b/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.c
@@ -5,7 +5,6 @@
  */
 
 #include "z_en_thiefbird.h"
-#include "objects/object_thiefbird/object_thiefbird.h"
 
 #define FLAGS (ACTOR_FLAG_1 | ACTOR_FLAG_4 | ACTOR_FLAG_200 | ACTOR_FLAG_1000 | ACTOR_FLAG_80000000)
 
@@ -150,8 +149,8 @@ void EnThiefbird_Init(Actor* thisx, PlayState* play) {
     ColliderJntSphElementDim* dim;
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
-    SkelAnime_InitFlex(play, &this->skelAnime, &object_thiefbird_Skel_0061A0, &object_thiefbird_Anim_000604,
-                       this->jointTable, this->morphTable, 17);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gTakkuriSkel, &gTakkuriFlyAnim, this->jointTable, this->morphTable,
+                       TAKKURI_LIMB_MAX);
     Collider_InitAndSetJntSph(play, &this->collider, &this->actor, &sJntSphInit, this->colliderElements);
 
     for (i = 0; i < ARRAY_COUNT(this->colliderElements); i++) {
@@ -206,7 +205,7 @@ void func_80C10984(EnThiefbird* this, s32 arg1) {
 }
 
 s32 func_80C10B0C(EnThiefbird* this, PlayState* play) {
-    static Gfx* D_80C13680[] = { object_thiefbird_DL_004348, object_thiefbird_DL_004B88, object_thiefbird_DL_0055E0 };
+    static Gfx* D_80C13680[] = { gTakkuriStolenKokiriSwordDL, gTakkuriStolenRazorSwordDL, gTakkuriStolenGildedSwordDL };
     s32 isItemFound = false;
     s32 phi_a3 = 0;
     s32 slotId = SLOT_BOTTLE_1;
@@ -239,7 +238,7 @@ s32 func_80C10B0C(EnThiefbird* this, PlayState* play) {
 
     if (isItemFound) {
         Inventory_DeleteItem(itemId2, slotId);
-        this->unk_3E8 = object_thiefbird_DL_0033B0;
+        this->unk_3E8 = gTakkuriStolenBottleDL;
         if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
             Message_StartTextbox(play, 0xF4, NULL);
         }
@@ -256,7 +255,7 @@ s32 func_80C10B0C(EnThiefbird* this, PlayState* play) {
         itemId1 = phi_a3 + (ITEM_SWORD_KOKIRI - 1);
         if (phi_a3 == 4) {
             Inventory_DeleteItem(ITEM_SWORD_GREAT_FAIRY, SLOT_SWORD_GREAT_FAIRY);
-            this->unk_3E8 = object_thiefbird_DL_003D58;
+            this->unk_3E8 = gTakkuriStolenGreatFairySwordDL;
             itemId1 = ITEM_SWORD_GREAT_FAIRY;
         } else {
             CUR_FORM_EQUIP(EQUIP_SLOT_B) = ITEM_NONE;
@@ -461,7 +460,7 @@ void func_80C114C0(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C11538(EnThiefbird* this) {
-    Animation_MorphToLoop(&this->skelAnime, &object_thiefbird_Anim_000604, -4.0f);
+    Animation_MorphToLoop(&this->skelAnime, &gTakkuriFlyAnim, -4.0f);
     this->unk_18E = 60;
     this->collider.base.acFlags |= AC_ON;
     this->actionFunc = func_80C11590;
@@ -525,7 +524,7 @@ void func_80C11590(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C118E4(EnThiefbird* this) {
-    Animation_MorphToLoop(&this->skelAnime, &object_thiefbird_Anim_0063C4, -10.0f);
+    Animation_MorphToLoop(&this->skelAnime, &gTakkuriAttackAnim, -10.0f);
     this->unk_18E = 300;
     this->actionFunc = func_80C1193C;
     this->actor.speedXZ = 5.0f;
@@ -591,7 +590,7 @@ void func_80C1193C(EnThiefbird* this, PlayState* play) {
 void func_80C11C60(EnThiefbird* this) {
     this->actor.speedXZ = 0.0f;
     this->actor.velocity.y = 0.0f;
-    Animation_PlayOnce(&this->skelAnime, &object_thiefbird_Anim_000088);
+    Animation_PlayOnce(&this->skelAnime, &gTakkuriDeathAnim);
     this->actor.bgCheckFlags &= ~1;
     this->actor.shape.rot.x = 0;
     this->unk_18E = 40;
@@ -663,7 +662,7 @@ void func_80C11DF0(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C11F6C(EnThiefbird* this, PlayState* play) {
-    Animation_MorphToLoop(&this->skelAnime, &object_thiefbird_Anim_000278, -4.0f);
+    Animation_MorphToLoop(&this->skelAnime, &gTakkuriFlyWithItemAnim, -4.0f);
     func_80C10984(this, 15);
     if (this->actor.colChkInfo.damageEffect != 3) {
         this->actor.speedXZ = 4.0f;
@@ -747,7 +746,7 @@ void func_80C1215C(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C12308(EnThiefbird* this) {
-    Animation_MorphToLoop(&this->skelAnime, &object_thiefbird_Anim_000278, -4.0f);
+    Animation_MorphToLoop(&this->skelAnime, &gTakkuriFlyWithItemAnim, -4.0f);
     func_80C10984(this, 15);
     this->unk_190 = -0x1000;
     this->unk_192 = BINANG_ROT180(this->actor.yawTowardsPlayer);
@@ -776,7 +775,7 @@ void func_80C12378(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C1242C(EnThiefbird* this) {
-    Animation_Change(&this->skelAnime, &object_thiefbird_Anim_000278, 2.0f, 0.0f, 0.0f, ANIMMODE_LOOP, -4.0f);
+    Animation_Change(&this->skelAnime, &gTakkuriFlyWithItemAnim, 2.0f, 0.0f, 0.0f, ANIMMODE_LOOP, -4.0f);
     this->actor.flags |= ACTOR_FLAG_10;
     this->collider.base.acFlags |= AC_ON;
     this->actionFunc = func_80C124B0;
@@ -836,8 +835,8 @@ void func_80C126D8(EnThiefbird* this, PlayState* play) {
 }
 
 void func_80C12744(EnThiefbird* this) {
-    Animation_MorphToLoop(&this->skelAnime, &object_thiefbird_Anim_000604, -4.0f);
-    Animation_Change(&this->skelAnime, &object_thiefbird_Anim_000604, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP_INTERP, -4.0f);
+    Animation_MorphToLoop(&this->skelAnime, &gTakkuriFlyAnim, -4.0f);
+    Animation_Change(&this->skelAnime, &gTakkuriFlyAnim, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP_INTERP, -4.0f);
     this->unk_190 = 0;
     this->collider.base.acFlags |= AC_ON;
     this->actor.flags |= ACTOR_FLAG_10;
@@ -1030,8 +1029,8 @@ void EnThiefbird_Update(Actor* thisx, PlayState* play2) {
     }
 
     func_80C12D00(this);
-    if (((this->skelAnime.animation == &object_thiefbird_Anim_000604) && Animation_OnFrame(&this->skelAnime, 13.0f)) ||
-        ((this->skelAnime.animation == &object_thiefbird_Anim_000278) && Animation_OnFrame(&this->skelAnime, 1.0f))) {
+    if (((this->skelAnime.animation == &gTakkuriFlyAnim) && Animation_OnFrame(&this->skelAnime, 13.0f)) ||
+        ((this->skelAnime.animation == &gTakkuriFlyWithItemAnim) && Animation_OnFrame(&this->skelAnime, 1.0f))) {
         Actor_PlaySfxAtPos(&this->actor, NA_SE_EN_KAICHO_FLUTTER);
     }
 }
@@ -1039,12 +1038,12 @@ void EnThiefbird_Update(Actor* thisx, PlayState* play2) {
 s32 EnThiefbird_OverrideLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3f* pos, Vec3s* rot, Actor* thisx) {
     EnThiefbird* this = THIS;
 
-    if ((limbIndex == 10) || (limbIndex == 11)) {
+    if ((limbIndex == TAKKURI_LIMB_RIGHT_EAR) || (limbIndex == TAKKURI_LIMB_LEFT_EAR)) {
         this->unk_3E4 = *dList;
         *dList = NULL;
-    } else if (limbIndex == 16) {
+    } else if (limbIndex == TAKKURI_LIMB_STOLEN_ITEM) {
         *dList = NULL;
-    } else if (limbIndex == 8) {
+    } else if (limbIndex == TAKKURI_LIMB_NECK) {
         rot->z += this->unk_194;
     }
 
@@ -1061,7 +1060,7 @@ void EnThiefbird_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s
     s8 idx;
 
     Collider_UpdateSpheres(limbIndex, &this->collider);
-    if ((limbIndex == 10) || (limbIndex == 11)) {
+    if ((limbIndex == TAKKURI_LIMB_RIGHT_EAR) || (limbIndex == TAKKURI_LIMB_LEFT_EAR)) {
         OPEN_DISPS(play->state.gfxCtx);
 
         gfx = POLY_OPA_DISP;
@@ -1071,11 +1070,11 @@ void EnThiefbird_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s
         POLY_OPA_DISP = &gfx[2];
 
         CLOSE_DISPS(play->state.gfxCtx);
-    } else if (limbIndex == 16) {
+    } else if (limbIndex == TAKKURI_LIMB_STOLEN_ITEM) {
         if (this->unk_3E8 != NULL) {
             OPEN_DISPS(play->state.gfxCtx);
 
-            if (this->unk_3E8 == object_thiefbird_DL_0033B0) {
+            if (this->unk_3E8 == gTakkuriStolenBottleDL) {
                 gfx = POLY_XLU_DISP;
             } else {
                 gfx = POLY_OPA_DISP;
@@ -1084,7 +1083,7 @@ void EnThiefbird_PostLimbDraw(PlayState* play, s32 limbIndex, Gfx** dList, Vec3s
             gSPMatrix(&gfx[0], Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
             gSPDisplayList(&gfx[1], this->unk_3E8);
 
-            if (this->unk_3E8 == object_thiefbird_DL_0033B0) {
+            if (this->unk_3E8 == gTakkuriStolenBottleDL) {
                 POLY_XLU_DISP = &gfx[2];
             } else {
                 POLY_OPA_DISP = &gfx[2];
@@ -1117,7 +1116,7 @@ void func_80C13354(EnThiefbird* this, PlayState* play2) {
 
     gfx = POLY_OPA_DISP;
     gSPDisplayList(&gfx[0], &sSetupDL[6 * 25]);
-    gSPDisplayList(&gfx[1], object_thiefbird_DL_003060);
+    gSPDisplayList(&gfx[1], gTakkuriFeatherMaterialDL);
     gfx = &gfx[2];
 
     for (i = 0; i < ARRAY_COUNT(this->unk_3F0); i++, ptr++) {
@@ -1130,7 +1129,7 @@ void func_80C13354(EnThiefbird* this, PlayState* play2) {
             Matrix_Scale(ptr->unk_18, ptr->unk_18, 1.0f, MTXMODE_APPLY);
 
             gSPMatrix(&gfx[0], Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gSPDisplayList(&gfx[1], object_thiefbird_DL_0030D8);
+            gSPDisplayList(&gfx[1], gTakkuriFeatherModelDL);
             gfx = &gfx[2];
         }
     }

--- a/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.h
+++ b/src/overlays/actors/ovl_En_Thiefbird/z_en_thiefbird.h
@@ -2,6 +2,7 @@
 #define Z_EN_THIEFBIRD_H
 
 #include "global.h"
+#include "objects/object_thiefbird/object_thiefbird.h"
 
 struct EnThiefbird;
 
@@ -27,8 +28,8 @@ typedef struct EnThiefbird {
     /* 0x192 */ s16 unk_192;
     /* 0x194 */ s16 unk_194;
     /* 0x196 */ s16 unk_196[6];
-    /* 0x1A2 */ Vec3s jointTable[17];
-    /* 0x208 */ Vec3s morphTable[17];
+    /* 0x1A2 */ Vec3s jointTable[TAKKURI_LIMB_MAX];
+    /* 0x208 */ Vec3s morphTable[TAKKURI_LIMB_MAX];
     /* 0x270 */ ColliderJntSph collider;
     /* 0x290 */ ColliderJntSphElement colliderElements[3];
     /* 0x350 */ Vec3f limbPos[11];


### PR DESCRIPTION
`gTakkuriStolenGreatFairySwordBladeGildedSwordPommelAndGuardTex` is just *barely* below the max number of characters a symbol can have. It, along with some of the other textures used by stolen items, is hard to name because of a surprising amount of reuse.