### PR TITLE
Cleanup some "raw" actor flags

### DIFF
--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -164,7 +164,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
 
         grabbed = this->grabbed;
         if (grabbed != NULL) {
-            if ((grabbed->update == NULL) || (grabbed->flags & ACTOR_FLAG_2000) != ACTOR_FLAG_2000) {
+            if ((grabbed->update == NULL) || !CHECK_FLAG_ALL(grabbed->flags, ACTOR_FLAG_2000)) {
                 grabbed = NULL;
                 this->grabbed = NULL;
             } else {

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -69,7 +69,7 @@ void ArmsHook_Destroy(Actor* thisx, PlayState* play) {
     ArmsHook* this = THIS;
 
     if (this->grabbed != NULL) {
-        this->grabbed->flags &= ~0x2000;
+        this->grabbed->flags &= ~ACTOR_FLAG_2000;
     }
     Collider_DestroyQuad(play, &this->collider);
 }
@@ -100,7 +100,7 @@ s32 ArmsHook_AttachToPlayer(ArmsHook* this, Player* player) {
 
 void ArmsHook_DetachHookFromActor(ArmsHook* this) {
     if (this->grabbed != NULL) {
-        this->grabbed->flags &= ~0x2000;
+        this->grabbed->flags &= ~ACTOR_FLAG_2000;
         this->grabbed = NULL;
     }
 }
@@ -120,7 +120,7 @@ s32 ArmsHook_CheckForCancel(ArmsHook* this) {
 }
 
 void ArmsHook_AttachHookToActor(ArmsHook* this, Actor* actor) {
-    actor->flags |= 0x2000;
+    actor->flags |= ACTOR_FLAG_2000;
     this->grabbed = actor;
     Math_Vec3f_Diff(&actor->world.pos, &this->actor.world.pos, &this->unk1FC);
 }
@@ -140,10 +140,10 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
     if (this->timer != 0 && (this->collider.base.atFlags & AT_HIT) &&
         (this->collider.info.atHitInfo->elemType != ELEMTYPE_UNK4)) {
         Actor* touchedActor = this->collider.base.at;
-        if ((touchedActor->update != NULL) && (touchedActor->flags & 0x600)) {
+        if ((touchedActor->update != NULL) && (touchedActor->flags & (ACTOR_FLAG_200 | ACTOR_FLAG_400))) {
             if (this->collider.info.atHitInfo->bumperFlags & BUMP_HOOKABLE) {
                 ArmsHook_AttachHookToActor(this, touchedActor);
-                if ((touchedActor->flags & 0x400) == 0x400) {
+                if ((touchedActor->flags & ACTOR_FLAG_400) == ACTOR_FLAG_400) {
                     func_808C1154(this);
                 }
             }
@@ -164,7 +164,7 @@ void ArmsHook_Shoot(ArmsHook* this, PlayState* play) {
 
         grabbed = this->grabbed;
         if (grabbed != NULL) {
-            if ((grabbed->update == NULL) || (grabbed->flags & 0x2000) != 0x2000) {
+            if ((grabbed->update == NULL) || (grabbed->flags & ACTOR_FLAG_2000) != ACTOR_FLAG_2000) {
                 grabbed = NULL;
                 this->grabbed = NULL;
             } else {

--- a/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
+++ b/src/overlays/actors/ovl_En_Arrow/z_en_arrow.c
@@ -389,11 +389,12 @@ void func_8088ACE0(EnArrow* this, PlayState* play) {
             if (sp50 && (this->collider.info.atHitInfo->elemType != ELEMTYPE_UNK4)) {
                 sp7C = this->collider.base.at;
 
-                if ((sp7C->update != NULL) && !(this->collider.base.atFlags & AT_BOUNCED) && (sp7C->flags & 0x4000)) {
+                if ((sp7C->update != NULL) && !(this->collider.base.atFlags & AT_BOUNCED) &&
+                    (sp7C->flags & ACTOR_FLAG_4000)) {
                     this->unk_264 = sp7C;
                     func_8088A894(this, play);
                     Math_Vec3f_Diff(&sp7C->world.pos, &this->actor.world.pos, &this->unk_268);
-                    sp7C->flags |= 0x8000;
+                    sp7C->flags |= ACTOR_FLAG_8000;
                     this->collider.base.atFlags &= ~AT_HIT;
                     this->actor.speedXZ *= 0.5f;
                     this->actor.velocity.y *= 0.5f;

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -219,7 +219,7 @@ void EnBigpo_Init(Actor* thisx, PlayState* play2) {
     }
 
     if (thisx->params == ENBIGPO_REGULAR) { // the well poe, starts immediately
-        thisx->flags &= ~0x10;              // always update OFF
+        thisx->flags &= ~ACTOR_FLAG_10;     // always update OFF
         this->unkBool204 = true;
         EnBigpo_InitWellBigpo(this);
     } else if (thisx->params == ENBIGPO_SUMMONED) { // dampe type

--- a/src/overlays/actors/ovl_En_Bom/z_en_bom.c
+++ b/src/overlays/actors/ovl_En_Bom/z_en_bom.c
@@ -541,7 +541,7 @@ void EnBom_Update(Actor* thisx, PlayState* play) {
                 Camera_AddQuake(&play->mainCamera, 2, 11, 8);
                 thisx->params = ENBOM_1;
                 this->timer = 10;
-                thisx->flags |= (0x100000 | 0x20);
+                thisx->flags |= (ACTOR_FLAG_20 | ACTOR_FLAG_100000);
                 this->actionFunc = func_808715B8;
                 if (this->isPowderKeg) {
                     gSaveContext.powderKegTimer = 0;

--- a/src/overlays/actors/ovl_En_Boom/z_en_boom.c
+++ b/src/overlays/actors/ovl_En_Boom/z_en_boom.c
@@ -219,7 +219,7 @@ void func_808A2918(EnBoom* this, PlayState* play) {
                                                    (this->collider.base.at->id == ACTOR_EN_SI))) {
         this->unk_1C8 = this->collider.base.at;
         if (this->collider.base.at->id == ACTOR_EN_SI) {
-            this->collider.base.at->flags |= 0x2000;
+            this->collider.base.at->flags |= ACTOR_FLAG_2000;
         }
     }
 
@@ -264,7 +264,7 @@ void func_808A2918(EnBoom* this, PlayState* play) {
                     sp7C->gravity = -0.9f;
                     sp7C->bgCheckFlags &= ~3;
                 } else {
-                    sp7C->flags &= -0x2001;
+                    sp7C->flags &= ~ACTOR_FLAG_2000;
                 }
             }
             Actor_MarkForDeath(&this->actor);

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -1464,7 +1464,7 @@ void func_8089010C(Actor* thisx, PlayState* play) {
     }
 
     if (player->tatlTextId < 0) {
-        thisx->flags |= 0x10000;
+        thisx->flags |= ACTOR_FLAG_10000;
     }
 
     if (Actor_ProcessTalkRequest(thisx, &play->state)) {
@@ -1481,7 +1481,7 @@ void func_8089010C(Actor* thisx, PlayState* play) {
         thisx->update = func_8088FE64;
         func_8088C51C(this, 3);
         if (this->elfMsg != NULL) {
-            this->elfMsg->flags |= 0x100;
+            this->elfMsg->flags |= ACTOR_FLAG_100;
             thisx->cutscene = this->elfMsg->cutscene;
             if (thisx->cutscene != -1) {
                 func_8088FD04(this);
@@ -1493,7 +1493,7 @@ void func_8089010C(Actor* thisx, PlayState* play) {
         } else {
             thisx->cutscene = -1;
         }
-        thisx->flags &= ~0x10000;
+        thisx->flags &= ~ACTOR_FLAG_10000;
     } else if (this->unk_264 & 4) {
         thisx->focus.pos = thisx->world.pos;
         this->fairyFlags |= 0x10;

--- a/src/overlays/actors/ovl_En_Fishing/z_en_fishing.c
+++ b/src/overlays/actors/ovl_En_Fishing/z_en_fishing.c
@@ -830,7 +830,7 @@ void EnFishing_Init(Actor* thisx, PlayState* play2) {
 
         thisx->focus.pos = thisx->world.pos;
         thisx->focus.pos.y += 75.0f;
-        thisx->flags |= 9;
+        thisx->flags |= (ACTOR_FLAG_1 | ACTOR_FLAG_8);
 
         if (sLinkAge != 1) {
             // HIGH_SCORE(HS_FISHING) from OoT
@@ -960,7 +960,7 @@ void EnFishing_Init(Actor* thisx, PlayState* play2) {
         this->unk_150 = 100;
         func_800BC154(play, &play->actorCtx, thisx, ACTORCAT_PROP);
         thisx->targetMode = 0;
-        thisx->flags |= 9;
+        thisx->flags |= (ACTOR_FLAG_1 | ACTOR_FLAG_8);
         this->lightNode = LightContext_InsertLight(play, &play->lightCtx, &this->lightInfo);
     } else {
         this->unk_150 = 10;

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -788,7 +788,7 @@ void EnPeehat_Update(Actor* thisx, PlayState* play2) {
     }
 
     if (this->colliderTris.base.atFlags & AT_ON) {
-        thisx->flags |= 0x1000000;
+        thisx->flags |= ACTOR_FLAG_1000000;
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->colliderTris.base);
         if (thisx->params == 0) {
             Vec3f sp74;

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.c
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.c
@@ -1110,7 +1110,7 @@ void EnPp_Mask_SetupDetach(EnPp* this, PlayState* play) {
  * Moves the mask through the air and eventually makes it burst into flames.
  */
 void EnPp_Mask_Detach(EnPp* this, PlayState* play) {
-    if (((this->actor.flags & ACTOR_FLAG_2000) != ACTOR_FLAG_2000) || (this->action == EN_PP_ACTION_MASK_DEAD)) {
+    if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_2000) || (this->action == EN_PP_ACTION_MASK_DEAD)) {
         switch (this->actionVar.maskDetachState) {
             case EN_PP_MASK_DETACH_STATE_START:
                 this->action = EN_PP_ACTION_MASK_DEAD;

--- a/src/overlays/actors/ovl_En_Rat/z_en_rat.c
+++ b/src/overlays/actors/ovl_En_Rat/z_en_rat.c
@@ -822,7 +822,7 @@ void EnRat_Update(Actor* thisx, PlayState* play) {
             if (this->damageReaction.hookedState == EN_RAT_HOOK_STARTED) {
                 // The player just hit the Real Bombchu with the Hookshot.
                 this->damageReaction.hookedState = EN_RAT_HOOKED;
-            } else if ((this->actor.flags & ACTOR_FLAG_2000) != ACTOR_FLAG_2000) {
+            } else if (!CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_2000)) {
                 // The player has hooked the Real Bombchu for more than one frame, but
                 // the actor flag indicating that the Hookshot is attached is *not* set.
                 EnRat_Explode(this, play);

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -364,7 +364,7 @@ void EnWood02_Update(Actor* thisx, PlayState* play2) {
 
     // Despawn extra trees in a group if out of range
     if ((this->spawnType == WOOD_SPAWN_SPAWNED) && (thisx->parent != NULL)) {
-        if (!(thisx->flags & 0x40) && (this->unk_151 != 2)) {
+        if (!(thisx->flags & ACTOR_FLAG_40) && (this->unk_151 != 2)) {
             s32 index = this->unk_14A[0];
             s32 phi_v0 = 0;
 


### PR DESCRIPTION
I was looking at ArmsHook recently, and I noticed that instead of using `ACTOR_FLAG_2000`, they used 0x2000 in some places. This PR tries to clean up cases like this and use `ACTOR_FLAG_X` whenever possible. I may have missed something, but at least it's a start.