### PR TITLE
Add `pyelftools` back to `requirements.txt`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ colorama>=0.4.3
 # disasm
 rabbitizer>=1.0.0,<2.0.0
 
+# Compression
+pyelftools>=0.26
+
 # diff
 watchdog>=0.10.2
 argcomplete


### PR DESCRIPTION
`pyelftools` is needed by `z64compress_wrapper.py`. Without this package, the compression step would fail.

