### PR TITLE
Document Song of Time Clock assets in gameplay_keep

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1347,10 +1347,13 @@
         <DList Name="gameplay_keep_DL_07AB58" Offset="0x7AB58" />
         <DList Name="gSunDL" Offset="0x7AB70" />
         <DList Name="gZTargetLockOnTriangleDL" Offset="0x7AE00" />
-        <DList Name="gameplay_keep_DL_07AFB0" Offset="0x7AFB0" />
-        <DList Name="gameplay_keep_DL_07B0B8" Offset="0x7B0B8" />
-        <Texture Name="gameplay_keep_Tex_07B0C0" OutName="tex_07B0C0" Format="i8" Width="64" Height="64" Offset="0x7B0C0" />
-        <Texture Name="gameplay_keep_Tex_07C0C0" OutName="tex_07C0C0" Format="i8" Width="64" Height="64" Offset="0x7C0C0" />
+
+        <!-- The clock that appears when the player is moving through, slowing down, or speeding up time with the Song of Time -->
+        <DList Name="gSongOfTimeClockDL" Offset="0x7AFB0" /> <!-- Original name is "disk_modelT" -->
+        <DList Name="gSongOfTimeClockEmptyDL" Offset="0x7B0B8" /> <!-- Probably was the opaque component for the above DL -->
+        <Texture Name="gSongOfTimeClockTopTex" OutName="song_of_time_clock_top" Format="i8" Width="64" Height="64" Offset="0x7B0C0" />
+        <Texture Name="gSongOfTimeClockBottomTex" OutName="song_of_time_clock_bottom" Format="i8" Width="64" Height="64" Offset="0x7C0C0" />
+
         <DList Name="gameplay_keep_DL_07D260" Offset="0x7D260" />
         <DList Name="gameplay_keep_DL_07D348" Offset="0x7D348" />
         <Texture Name="gameplay_keep_Tex_07D350" OutName="tex_07D350" Format="i8" Width="16" Height="32" Offset="0x7D350" />

--- a/src/overlays/actors/ovl_En_Test6/z_en_test6.c
+++ b/src/overlays/actors/ovl_En_Test6/z_en_test6.c
@@ -1126,7 +1126,7 @@ void func_80A93298(EnTest6* this, PlayState* play) {
         gDPSetPrimColor(this->unk_148++, 0, 0xFF, 28, 28, 28, 255);
         gDPSetEnvColor(this->unk_148++, 255, 255, 255, 255);
         gDPSetRenderMode(this->unk_148++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2);
-        gSPDisplayList(this->unk_148++, gameplay_keep_DL_07AFB0);
+        gSPDisplayList(this->unk_148++, gSongOfTimeClockDL);
 
         temp_s4 += 0x1000;
         cos = Math_CosS(temp_s4) * this->unk_150;
@@ -1140,7 +1140,7 @@ void func_80A93298(EnTest6* this, PlayState* play) {
         gDPSetPrimColor(this->unk_148++, 0, 0xFF, 28, 28, 28, 255);
         gDPSetEnvColor(this->unk_148++, 255, 255, 255, 255);
         gDPSetRenderMode(this->unk_148++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2);
-        gSPDisplayList(this->unk_148++, gameplay_keep_DL_07AFB0);
+        gSPDisplayList(this->unk_148++, gSongOfTimeClockDL);
 
         phi_f24 -= this->unk_14C;
         phi_s2 += this->unk_27E;
@@ -1213,7 +1213,7 @@ void func_80A9369C(Actor* thisx, PlayState* play2) {
         gDPSetPrimColor(this->unk_148++, 0, 0xFF, this->unk_280, this->unk_280, this->unk_280, 255);
         gDPSetEnvColor(this->unk_148++, 235, 238, 235, 255);
         gDPSetRenderMode(this->unk_148++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_OPA_SURF2);
-        gSPDisplayList(this->unk_148++, gameplay_keep_DL_07AFB0);
+        gSPDisplayList(this->unk_148++, gSongOfTimeClockDL);
 
         phi_s2 += 0x505;
     }
@@ -1257,7 +1257,7 @@ void func_80A939E8(EnTest6* this, PlayState* play2) {
                 gDPSetPrimColor(this->unk_148++, 0, 0xFF, 28, 28, 28, 255);
                 gDPSetEnvColor(this->unk_148++, 245, 245, 200, this->unk_282);
                 gDPSetRenderMode(this->unk_148++, G_RM_FOG_SHADE_A, G_RM_AA_ZB_XLU_SURF2);
-                gSPDisplayList(this->unk_148++, gameplay_keep_DL_07AFB0);
+                gSPDisplayList(this->unk_148++, gSongOfTimeClockDL);
 
                 POLY_XLU_DISP = this->unk_148;
             }


### PR DESCRIPTION
I was talking about EnTest6 with someone in discord today and noticed that the assets for the clock when you play Song of Time were not documented. They were pretty easy to figure out, so I just quickly knocked them out.