### PR TITLE
Document object_gs (Gossip Stone)

### DIFF
--- a/assets/xml/objects/object_gs.xml
+++ b/assets/xml/objects/object_gs.xml
@@ -1,8 +1,9 @@
 ﻿<Root>
+    <!-- Assets for the Gossip Stones. -->
     <File Name="object_gs" Segment="6">
-        <Texture Name="object_gs_Tex_000000" OutName="tex_000000" Format="i8" Width="32" Height="64" Offset="0x0" />
-        <DList Name="object_gs_DL_000950" Offset="0x950" />
-        <DList Name="object_gs_DL_0009D0" Offset="0x9D0" />
-        <DList Name="object_gs_DL_000A60" Offset="0xA60" />
+        <Texture Name="gGossipStoneTex" OutName="gossip_stone" Format="i8" Width="32" Height="64" Offset="0x0" />
+        <DList Name="gGossipStoneBottomMaterialDL" Offset="0x950" />
+        <DList Name="gGossipStoneDL" Offset="0x9D0" />
+        <DList Name="gGossipStoneBottomModelDL" Offset="0xA60" />
     </File>
 </Root>

--- a/assets/xml/objects/object_gs.xml
+++ b/assets/xml/objects/object_gs.xml
@@ -2,7 +2,7 @@
     <!-- Assets for the Gossip Stones. -->
     <File Name="object_gs" Segment="6">
         <Texture Name="gGossipStoneTex" OutName="gossip_stone" Format="i8" Width="32" Height="64" Offset="0x0" />
-        <DList Name="gGossipStoneBottomMaterialDL" Offset="0x950" />
+        <DList Name="gGossipStoneMaterialDL" Offset="0x950" />
         <DList Name="gGossipStoneDL" Offset="0x9D0" />
         <DList Name="gGossipStoneBottomModelDL" Offset="0xA60" />
     </File>

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -1082,7 +1082,7 @@ void EnGs_Draw(Actor* thisx, PlayState* play) {
     }
 
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    gSPDisplayList(POLY_OPA_DISP++, gGossipStoneBottomMaterialDL);
+    gSPDisplayList(POLY_OPA_DISP++, gGossipStoneMaterialDL);
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->unk_1FA.r, this->unk_1FA.g, this->unk_1FA.b, 255);
     gSPDisplayList(POLY_OPA_DISP++, gGossipStoneDL);
     gSPDisplayList(POLY_OPA_DISP++, gGossipStoneBottomModelDL);

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -1082,10 +1082,10 @@ void EnGs_Draw(Actor* thisx, PlayState* play) {
     }
 
     gSPMatrix(POLY_OPA_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-    gSPDisplayList(POLY_OPA_DISP++, object_gs_DL_000950);
+    gSPDisplayList(POLY_OPA_DISP++, gGossipStoneBottomMaterialDL);
     gDPSetPrimColor(POLY_OPA_DISP++, 0, 0, this->unk_1FA.r, this->unk_1FA.g, this->unk_1FA.b, 255);
-    gSPDisplayList(POLY_OPA_DISP++, object_gs_DL_0009D0);
-    gSPDisplayList(POLY_OPA_DISP++, object_gs_DL_000A60);
+    gSPDisplayList(POLY_OPA_DISP++, gGossipStoneDL);
+    gSPDisplayList(POLY_OPA_DISP++, gGossipStoneBottomModelDL);
 
     Matrix_Pop();
 


### PR DESCRIPTION
I needed an easy one to cool down after object_dblue_object. Despite the object being identical to its OoT counterpart, I deliberately deviated on one of the names. In OoT, they call this `gGossipStoneSquishedDL`:
![image](https://user-images.githubusercontent.com/12245827/190604460-69970184-1b9a-49eb-a880-320150e4a242.png)

What I found out in testing is that it's *actually* the bottom of the Gossip Stone. In Z64Utils, you can see the "main" Gossip Stone DL has no bottom like so:
![image](https://user-images.githubusercontent.com/12245827/190604623-7c7a61b7-4a89-4ceb-96c9-0b94c2e58e40.png)

You don't usually see the bottom of the Gossip Stone, but you can spot it when it launches into the air after being hit by an explosive. If I had to speculate, I'm guessing the original DL was made first, and then when they added the ability to launch it into the air, they quickly patched the hole at the bottom with the other DL. I'll port these names over to OoT when this gets merged.