### PR TITLE
Document object_bdoor (Boss Doors)

### DIFF
--- a/assets/xml/objects/gameplay_dangeon_keep.xml
+++ b/assets/xml/objects/gameplay_dangeon_keep.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="gameplay_dangeon_keep" Segment="5">
-        <DList Name="gDoorLockDL" Offset="0x140" />
-        <DList Name="gDoorChainsDL" Offset="0x230" />
-        <Texture Name="gameplay_dangeon_keep_Tex_0002C0" OutName="tex_0002C0" Format="rgba16" Width="32" Height="32" Offset="0x2C0" />
-        <Texture Name="gameplay_dangeon_keep_Tex_000AC0" OutName="tex_000AC0" Format="rgba16" Width="32" Height="32" Offset="0xAC0" />
-        <Texture Name="gameplay_dangeon_keep_Tex_0012C0" OutName="tex_0012C0" Format="rgba16" Width="16" Height="128" Offset="0x12C0" />
+        <DList Name="gDoorLockDL" Offset="0x140" /> <!-- Original name is "doorkagi_model" ("lock") -->
+        <DList Name="gDoorChainDL" Offset="0x230" /> <!-- Original name is "doorkusari_model" ("chain") -->
+        <Texture Name="gDoorLockTex" OutName="door_lock" Format="rgba16" Width="32" Height="32" Offset="0x2C0" />
+        <Texture Name="gBossDoorLockTex" OutName="boss_door_lock" Format="rgba16" Width="32" Height="32" Offset="0xAC0" />
+        <Texture Name="gDoorChainTex" OutName="door_chain" Format="rgba16" Width="16" Height="128" Offset="0x12C0" />
         <Blob Name="gameplay_dangeon_keep_Blob_0022C0" Size="0x5000" Offset="0x22C0" />
         <DList Name="gameplay_dangeon_keep_DL_007300" Offset="0x7300" />
         <Collision Name="gameplay_dangeon_keep_Colheader_007498" Offset="0x7498" />

--- a/assets/xml/objects/object_bdoor.xml
+++ b/assets/xml/objects/object_bdoor.xml
@@ -1,18 +1,31 @@
 ﻿<Root>
+    <!-- Dependencies -->
+    <ExternalFile XmlPath="objects/gameplay_dangeon_keep.xml" OutPath="assets/objects/gameplay_dangeon_keep/"/>
+
+    <!-- Assets for Boss Doors -->
     <File Name="object_bdoor" Segment="6">
-        <DList Name="object_bdoor_DL_0000C0" Offset="0xC0" />
-        <DList Name="object_bdoor_DL_000400" Offset="0x400" />
-        <DList Name="object_bdoor_DL_000530" Offset="0x530" />
-        <Texture Name="object_bdoor_Tex_0005C0" OutName="tex_0005C0" Format="rgba16" Width="32" Height="64" Offset="0x5C0" />
-        <DList Name="object_bdoor_DL_001790" Offset="0x1790" />
-        <DList Name="object_bdoor_DL_001850" Offset="0x1850" />
-        <Texture Name="object_bdoor_Tex_001910" OutName="tex_001910" Format="rgba16" Width="32" Height="64" Offset="0x1910" />
-        <DList Name="object_bdoor_DL_002A50" Offset="0x2A50" />
-        <DList Name="object_bdoor_DL_002AF8" Offset="0x2AF8" />
-        <Texture Name="object_bdoor_Tex_002BA0" OutName="tex_002BA0" Format="rgba16" Width="32" Height="64" Offset="0x2BA0" />
-        <Texture Name="object_bdoor_Tex_003BA0" OutName="tex_003BA0" Format="rgba16" Width="32" Height="64" Offset="0x3BA0" />
-        <Texture Name="object_bdoor_Tex_004BA0" OutName="tex_004BA0" Format="rgba16" Width="32" Height="64" Offset="0x4BA0" />
-        <Texture Name="object_bdoor_Tex_005BA0" OutName="tex_005BA0" Format="rgba16" Width="32" Height="64" Offset="0x5BA0" />
-        <Texture Name="object_bdoor_Tex_006BA0" OutName="tex_006BA0" Format="rgba16" Width="32" Height="64" Offset="0x6BA0" />
+        <!-- Boss Door, Lock, and Chain DisplayLists -->
+        <DList Name="gBossDoorDL" Offset="0xC0" /> <!-- Original name is "bossdoor_model" -->
+        <DList Name="gBossDoorLockDL" Offset="0x400" /> <!-- Original name is "doorkagiboss_model" ("lock") -->
+        <DList Name="gBossDoorChainDL" Offset="0x530" /> <!-- Original name is "doorkusariboss_model" ("chain") -->
+
+        <!-- One of the Boss Door Textures -->
+        <Texture Name="gBossDoorSnowheadTex" OutName="boss_door_snowhead" Format="rgba16" Width="32" Height="64" Offset="0x5C0" />
+
+        <!-- Assets for an unused set of doors -->
+        <DList Name="gBossDoorUnusedDoor1LeftDL" Offset="0x1790" /> <!-- Original name is "i2_L_d1_model" -->
+        <DList Name="gBossDoorUnusedDoor1RightDL" Offset="0x1850" /> <!-- Original name is "i2_L_d1_2_model" -->
+        <Texture Name="gBossDoorUnusedDoor1Tex" OutName="boss_door_unused_door_1" Format="rgba16" Width="32" Height="64" Offset="0x1910" />
+        <DList Name="gBossDoorUnusedDoor2LeftDL" Offset="0x2A50" /> <!-- Original name is "i2_L_d2_model" -->
+        <DList Name="gBossDoorUnusedDoor2RightDL" Offset="0x2AF8" /> <!-- Original name is "i2_L_d2_2_model" -->
+        <Texture Name="gBossDoorUnusedDoor2Tex" OutName="boss_door_unused_door_2" Format="rgba16" Width="32" Height="64" Offset="0x2BA0" />
+
+        <!-- The rest of the Boss Door Textures -->
+        <Texture Name="gBossDoorStoneTowerTex" OutName="boss_door_stone_tower" Format="rgba16" Width="32" Height="64" Offset="0x3BA0" />
+        <Texture Name="gBossDoorGreatBayTex" OutName="boss_door_great_bay" Format="rgba16" Width="32" Height="64" Offset="0x4BA0" />
+        <Texture Name="gBossDoorWoodfallTex" OutName="boss_door_woodfall" Format="rgba16" Width="32" Height="64" Offset="0x5BA0" />
+
+        <!-- A default texture only used if a Boss Door is present outside of the four main dungeons, which is never the case in the final game. -->
+        <Texture Name="gBossDoorDefaultTex" OutName="boss_door_unused" Format="rgba16" Width="32" Height="64" Offset="0x6BA0" />
     </File>
 </Root>

--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -3814,9 +3814,9 @@ typedef struct {
 } DoorLockInfo; // size = 0x1C
 
 DoorLockInfo sDoorLocksInfo[DOORLOCK_MAX] = {
-    /* DOORLOCK_NORMAL */ { 0.54f, 6000.0f, 5000.0, 1.0f, 0.0f, gDoorChainsDL, gDoorLockDL },
-    /* DOORLOCK_BOSS */ { 0.644f, 12000.0f, 8000.0f, 1.0f, 0.0f, object_bdoor_DL_000530, object_bdoor_DL_000400 },
-    /* DOORLOCK_2 */ { 0.6400000453f, 8500.0f, 8000.0f, 1.75f, 0.1f, gDoorChainsDL, gDoorLockDL },
+    /* DOORLOCK_NORMAL */ { 0.54f, 6000.0f, 5000.0, 1.0f, 0.0f, gDoorChainDL, gDoorLockDL },
+    /* DOORLOCK_BOSS */ { 0.644f, 12000.0f, 8000.0f, 1.0f, 0.0f, gBossDoorChainDL, gBossDoorLockDL },
+    /* DOORLOCK_2 */ { 0.6400000453f, 8500.0f, 8000.0f, 1.75f, 0.1f, gDoorChainDL, gDoorLockDL },
 };
 
 /**

--- a/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
+++ b/src/overlays/actors/ovl_Door_Shutter/z_door_shutter.c
@@ -74,7 +74,7 @@ typedef struct {
 } ShutterInfo; // size = 0xC
 
 ShutterInfo D_808A21B0[] = {
-    { object_bdoor_DL_0000C0, NULL, 130, 12, 50, 15 },
+    { gBossDoorDL, NULL, 130, 12, 50, 15 },
     { gameplay_keep_DL_077990, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
     { object_numa_obj_DL_007150, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
     { object_hakugin_obj_DL_000128, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
@@ -129,8 +129,7 @@ Vec3f D_808A22C4 = { 120.0f, 0.0f, 0.0f };
 Vec3f D_808A22D0 = { -90.0f, 0.0f, 0.0f };
 
 TexturePtr D_808A22DC[] = {
-    object_bdoor_Tex_006BA0, object_bdoor_Tex_005BA0, object_bdoor_Tex_0005C0,
-    object_bdoor_Tex_004BA0, object_bdoor_Tex_003BA0,
+    gBossDoorDefaultTex, gBossDoorWoodfallTex, gBossDoorSnowheadTex, gBossDoorGreatBayTex, gBossDoorStoneTowerTex,
 };
 
 void DoorShutter_SetupAction(DoorShutter* this, DoorShutterActionFunc actionFunc) {


### PR DESCRIPTION
Did some very minor cleanup on gameplay_dangeon_keep too; I renamed `gDoorChainsDL` to `gDoorChainDL` because the DisplayList is only a single chain, and it's the actor that's responsible for drawing multiple chains:
![image](https://user-images.githubusercontent.com/12245827/191214354-08ee3aa1-eea5-4d06-8b9e-b3150d895376.png)
