### PR TITLE
Document Elegy of Emptiness shell assets in gameplay_keep

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -881,14 +881,17 @@
         <Texture Name="gameplay_keep_Tex_01A8B0" OutName="tex_01A8B0" Format="i8" Width="16" Height="32" Offset="0x1A8B0" />
         <Texture Name="gameplay_keep_Tex_01AAB0" OutName="tex_01AAB0" Format="i8" Width="16" Height="32" Offset="0x1AAB0" />
         <DList Name="gameplay_keep_DL_01ACF0" Offset="0x1ACF0" />
-        <DList Name="gameplay_keep_DL_01C430" Offset="0x1C430" />
-        <Texture Name="gameplay_keep_Tex_01CAF8" OutName="tex_01CAF8" Format="rgba16" Width="32" Height="32" Offset="0x1CAF8" />
-        <Texture Name="gameplay_keep_Tex_01D2F8" OutName="tex_01D2F8" Format="rgba16" Width="32" Height="64" Offset="0x1D2F8" />
-        <Texture Name="gameplay_keep_Tex_01E2F8" OutName="tex_01E2F8" Format="rgba16" Width="16" Height="8" Offset="0x1E2F8" />
-        <Texture Name="gameplay_keep_Tex_01E3F8" OutName="tex_01E3F8" Format="rgba16" Width="16" Height="16" Offset="0x1E3F8" />
-        <Texture Name="gameplay_keep_Tex_01E5F8" OutName="tex_01E5F8" Format="rgba16" Width="8" Height="16" Offset="0x1E5F8" />
-        <Texture Name="gameplay_keep_Tex_01E6F8" OutName="tex_01E6F8" Format="rgba16" Width="32" Height="16" Offset="0x1E6F8" />
-        <Texture Name="gameplay_keep_Tex_01EAF8" OutName="tex_01EAF8" Format="rgba16" Width="16" Height="16" Offset="0x1EAF8" />
+
+        <!-- Human Elegy of Emptiness Shell -->
+        <DList Name="gElegyShellHumanDL" Offset="0x1C430" /> <!-- Original name is "pls_zo_model" -->
+        <Texture Name="gElegyShellHumanMouthTex" OutName="elegy_shell_human_mouth" Format="rgba16" Width="32" Height="32" Offset="0x1CAF8" />
+        <Texture Name="gElegyShellHumanEyeAndNoseTex" OutName="elegy_shell_human_eye_and_nose" Format="rgba16" Width="32" Height="64" Offset="0x1D2F8" />
+        <Texture Name="gElegyShellHumanNostrilsAndSkinTex" OutName="elegy_shell_human_nostrils_and_skin" Format="rgba16" Width="16" Height="8" Offset="0x1E2F8" />
+        <Texture Name="gElegyShellHumanBootsTex" OutName="elegy_shell_human_boots" Format="rgba16" Width="16" Height="16" Offset="0x1E3F8" />
+        <Texture Name="gElegyShellHumanPlatformTex" OutName="elegy_shell_human_platform" Format="rgba16" Width="8" Height="16" Offset="0x1E5F8" />
+        <Texture Name="gElegyShellBeltAndTunicTex" OutName="elegy_shell_human_belt_and_tunic" Format="rgba16" Width="32" Height="16" Offset="0x1E6F8" />
+        <Texture Name="gElegyShellHumanHairTex" OutName="elegy_shell_human_hair" Format="rgba16" Width="16" Height="16" Offset="0x1EAF8" />
+
         <DList Name="gameplay_keep_DL_01ED00" Offset="0x1ED00" />
         <DList Name="gameplay_keep_DL_01ED90" Offset="0x1ED90" />
         <DList Name="gZTargetArrowDL" Offset="0x1F0F0" />
@@ -1116,26 +1119,29 @@
         <Texture Name="gameplay_keep_Tex_044BB0" OutName="tex_044BB0" Format="i8" Width="32" Height="32" Offset="0x44BB0" />
         <Texture Name="gEffIceFragmentTex" OutName="eff_ice_fragment" Format="i8" Width="32" Height="32" Offset="0x44FB0" />
         <Texture Name="gameplay_keep_Tex_0453B0" OutName="tex_0453B0" Format="i8" Width="32" Height="32" Offset="0x453B0" />
-        <DList Name="gameplay_keep_DL_048DF0" Offset="0x48DF0" />
-        <Texture Name="gameplay_keep_TLUT_04A460" OutName="tlut_04A460" Format="rgba16" Width="16" Height="16" Offset="0x4A460" />
-        <Texture Name="gameplay_keep_Tex_04A660" OutName="tex_04A660" Format="ci8" Width="16" Height="16" Offset="0x4A660" />
-        <Texture Name="gameplay_keep_Tex_04A760" OutName="tex_04A760" Format="ci8" Width="16" Height="32" Offset="0x4A760" />
-        <Texture Name="gameplay_keep_Tex_04A960" OutName="tex_04A960" Format="ci8" Width="16" Height="16" Offset="0x4A960" />
-        <Texture Name="gameplay_keep_Tex_04AA60" OutName="tex_04AA60" Format="ci8" Width="8" Height="8" Offset="0x4AA60" />
-        <Texture Name="gameplay_keep_Tex_04AAA0" OutName="tex_04AAA0" Format="ci8" Width="8" Height="8" Offset="0x4AAA0" />
-        <Texture Name="gameplay_keep_Tex_04AAE0" OutName="tex_04AAE0" Format="ci8" Width="16" Height="16" Offset="0x4AAE0" />
-        <Texture Name="gameplay_keep_Tex_04ABE0" OutName="tex_04ABE0" Format="ci8" Width="8" Height="16" Offset="0x4ABE0" />
-        <Texture Name="gameplay_keep_Tex_04AC60" OutName="tex_04AC60" Format="ci8" Width="8" Height="16" Offset="0x4AC60" />
-        <Texture Name="gameplay_keep_Tex_04ACE0" OutName="tex_04ACE0" Format="ci8" Width="8" Height="8" Offset="0x4ACE0" />
-        <Texture Name="gameplay_keep_Tex_04AD20" OutName="tex_04AD20" Format="ci8" Width="32" Height="32" Offset="0x4AD20" />
-        <Texture Name="gameplay_keep_Tex_04B120" OutName="tex_04B120" Format="ci8" Width="32" Height="64" Offset="0x4B120" />
-        <Texture Name="gameplay_keep_Tex_04B920" OutName="tex_04B920" Format="ci8" Width="32" Height="64" Offset="0x4B920" />
-        <Texture Name="gameplay_keep_Tex_04C120" OutName="tex_04C120" Format="ci8" Width="32" Height="64" Offset="0x4C120" />
-        <Texture Name="gameplay_keep_Tex_04C920" OutName="tex_04C920" Format="ci8" Width="8" Height="16" Offset="0x4C920" />
-        <Texture Name="gameplay_keep_Tex_04C9A0" OutName="tex_04C9A0" Format="ci8" Width="32" Height="32" Offset="0x4C9A0" />
-        <Texture Name="gameplay_keep_Tex_04CDA0" OutName="tex_04CDA0" Format="rgba16" Width="32" Height="64" Offset="0x4CDA0" />
-        <Texture Name="gameplay_keep_Tex_04DDA0" OutName="tex_04DDA0" Format="i8" Width="32" Height="32" Offset="0x4DDA0" />
-        <Texture Name="gameplay_keep_Tex_04E1A0" OutName="tex_04E1A0" Format="ci8" Width="8" Height="16" Offset="0x4E1A0" />
+
+        <!-- Goron Elegy of Emptiness Shell -->
+        <DList Name="gElegyShellGoronDL" Offset="0x48DF0" /> <!-- Original name is "pgs_zo_model" -->
+        <Texture Name="gElegyShellGoronTLUT" OutName="elegy_shell_goron_tlut" Format="rgba16" Width="16" Height="16" Offset="0x4A460" />
+        <Texture Name="gElegyShellGoronSkinTex" OutName="elegy_shell_goron_skin" Format="ci8" Width="16" Height="16" Offset="0x4A660" />
+        <Texture Name="gElegyShellGoronHairTex" OutName="elegy_shell_goron_hair" Format="ci8" Width="16" Height="32" Offset="0x4A760" />
+        <Texture Name="gElegyShellGoronSideburnsAndBeardTex" OutName="elegy_shell_goron_sideburns_and_beard" Format="ci8" Width="16" Height="16" Offset="0x4A960" />
+        <Texture Name="gElegyShellGoronNostrilTex" OutName="elegy_shell_goron_nostril" Format="ci8" Width="8" Height="8" Offset="0x4AA60" />
+        <Texture Name="gElegyShellGoronLipsTex" OutName="elegy_shell_goron_lips" Format="ci8" Width="8" Height="8" Offset="0x4AAA0" />
+        <Texture Name="gElegyShellGoronGlovePalmTex" OutName="elegy_shell_goron_glove_palm" Format="ci8" Width="16" Height="16" Offset="0x4AAE0" />
+        <Texture Name="gElegyShellGoronGloveBackTex" OutName="elegy_shell_goron_glove_back" Format="ci8" Width="8" Height="16" Offset="0x4ABE0" />
+        <Texture Name="gElegyShellGoronFingerAndToeTex" OutName="elegy_shell_goron_finger_and_toe" Format="ci8" Width="8" Height="16" Offset="0x4AC60" />
+        <Texture Name="gElegyShellGoronSandalTopAndSideTex" OutName="elegy_shell_goron_sandal_top_and_side" Format="ci8" Width="8" Height="8" Offset="0x4ACE0" />
+        <Texture Name="gElegyShellGoronChestTex" OutName="elegy_shell_goron_chest" Format="ci8" Width="32" Height="32" Offset="0x4AD20" />
+        <Texture Name="gElegyShellGoronBackTex" OutName="elegy_shell_goron_back" Format="ci8" Width="32" Height="64" Offset="0x4B120" />
+        <Texture Name="gElegyShellGoronGoronsRubyTattooTex" OutName="elegy_shell_goron_gorons_ruby_tattoo" Format="ci8" Width="32" Height="64" Offset="0x4B920" />
+        <Texture Name="gElegyShellGoronTribalTattooTex" OutName="elegy_shell_goron_tribal_tattoo" Format="ci8" Width="32" Height="64" Offset="0x4C120" />
+        <Texture Name="gElegyShellGoronLoinclothTex" OutName="elegy_shell_goron_loincloth" Format="ci8" Width="8" Height="16" Offset="0x4C920" />
+        <Texture Name="gElegyShellGoronEyeTex" OutName="elegy_shell_goron_eye" Format="ci8" Width="32" Height="32" Offset="0x4C9A0" />
+        <Texture Name="gElegyShellGoronScarTex" OutName="elegy_shell_goron_scar" Format="rgba16" Width="32" Height="64" Offset="0x4CDA0" />
+        <Texture Name="gElegyShellGoronNecklaceTex" OutName="elegy_shell_goron_necklace" Format="i8" Width="32" Height="32" Offset="0x4DDA0" />
+        <Texture Name="gElegyShellGoronPlatformTex" OutName="elegy_shell_goron_platform" Format="ci8" Width="8" Height="16" Offset="0x4E1A0" />
+
         <Texture Name="gameplay_keep_Tex_04E220" OutName="tex_04E220" Format="i8" Width="64" Height="64" Offset="0x4E220" />
         <DList Name="gameplay_keep_DL_04F250" Offset="0x4F250" />
         <Texture Name="gameplay_keep_Tex_04F2C0" OutName="tex_04F2C0" Format="ia16" Width="32" Height="64" Offset="0x4F2C0" />
@@ -1221,11 +1227,14 @@
         <DList Name="gameplay_keep_DL_055628" Offset="0x55628" />
         <Texture Name="gameplay_keep_Tex_0557F0" OutName="tex_0557F0" Format="rgba16" Width="32" Height="32" Offset="0x557F0" />
         <Texture Name="gameplay_keep_Tex_055FF0" OutName="tex_055FF0" Format="i4" Width="64" Height="64" Offset="0x55FF0" />
-        <DList Name="gameplay_keep_DL_057B10" Offset="0x57B10" />
-        <Texture Name="gameplay_keep_Tex_057FE8" OutName="tex_057FE8" Format="rgba16" Width="8" Height="16" Offset="0x57FE8" />
-        <Texture Name="gameplay_keep_Tex_0580E8" OutName="tex_0580E8" Format="rgba16" Width="16" Height="16" Offset="0x580E8" />
-        <Texture Name="gameplay_keep_Tex_0582E8" OutName="tex_0582E8" Format="rgba16" Width="32" Height="32" Offset="0x582E8" />
-        <Texture Name="gameplay_keep_Tex_058AE8" OutName="tex_058AE8" Format="rgba16" Width="8" Height="8" Offset="0x58AE8" />
+
+        <!-- Deku Elegy of Emptiness Shell -->
+        <DList Name="gElegyShellDekuDL" Offset="0x57B10" /> <!-- Original name is "pns_zo_model" -->
+        <Texture Name="gElegyShellDekuPlatformTex" OutName="elegy_shell_deku_platform" Format="rgba16" Width="8" Height="16" Offset="0x57FE8" />
+        <Texture Name="gElegyShellDekuSkinTex" OutName="elegy_shell_deku_skin" Format="rgba16" Width="16" Height="16" Offset="0x580E8" />
+        <Texture Name="gElegyShellDekuLeafTex" OutName="elegy_shell_deku_leaf" Format="rgba16" Width="32" Height="32" Offset="0x582E8" />
+        <Texture Name="gElegyShellDekuEyeTex" OutName="elegy_shell_deku_eye" Format="rgba16" Width="8" Height="8" Offset="0x58AE8" />
+
         <DList Name="gameplay_keep_DL_058BA0" Offset="0x58BA0" />
         <Texture Name="gameplay_keep_Tex_058C30" OutName="tex_058C30" Format="rgba16" Width="16" Height="16" Offset="0x58C30" />
         <Collision Name="gameplay_keep_Colheader_058F30" Offset="0x58F30" />
@@ -1442,25 +1451,28 @@
         <DList Name="gameplay_keep_DL_085490" Offset="0x85490" />
         <Blob Name="gameplay_keep_Blob_085510" Size="0x130" Offset="0x85510" />
         <Blob Name="gameplay_keep_Blob_085640" Size="0x3A30" Offset="0x85640" />
-        <DList Name="gameplay_keep_DL_089070" Offset="0x89070" />
-        <Texture Name="gameplay_keep_TLUT_08A420" OutName="tlut_08A420" Format="rgba16" Width="16" Height="16" Offset="0x8A420" />
-        <Texture Name="gameplay_keep_Tex_08A620" OutName="tex_08A620" Format="rgba16" Width="16" Height="16" Offset="0x8A620" />
-        <Texture Name="gameplay_keep_Tex_08A820" OutName="tex_08A820" Format="rgba16" Width="16" Height="16" Offset="0x8A820" />
-        <Texture Name="gameplay_keep_Tex_08AA20" OutName="tex_08AA20" Format="rgba16" Width="16" Height="16" Offset="0x8AA20" />
-        <Texture Name="gameplay_keep_Tex_08AC20" OutName="tex_08AC20" Format="rgba16" Width="16" Height="32" Offset="0x8AC20" />
-        <Texture Name="gameplay_keep_Tex_08B020" OutName="tex_08B020" Format="rgba16" Width="16" Height="32" Offset="0x8B020" />
-        <Texture Name="gameplay_keep_Tex_08B420" OutName="tex_08B420" Format="ci8" Width="8" Height="8" Offset="0x8B420" />
-        <Texture Name="gameplay_keep_Tex_08B460" OutName="tex_08B460" Format="ci8" Width="32" Height="32" Offset="0x8B460" />
-        <Texture Name="gameplay_keep_Tex_08B860" OutName="tex_08B860" Format="ci8" Width="16" Height="16" Offset="0x8B860" />
-        <Texture Name="gameplay_keep_Tex_08B960" OutName="tex_08B960" Format="ci8" Width="32" Height="64" Offset="0x8B960" />
-        <Texture Name="gameplay_keep_Tex_08C160" OutName="tex_08C160" Format="ci8" Width="8" Height="16" Offset="0x8C160" />
-        <Texture Name="gameplay_keep_Tex_08C1E0" OutName="tex_08C1E0" Format="ci8" Width="16" Height="16" Offset="0x8C1E0" />
-        <Texture Name="gameplay_keep_Tex_08C2E0" OutName="tex_08C2E0" Format="ci8" Width="32" Height="32" Offset="0x8C2E0" />
-        <Texture Name="gameplay_keep_Tex_08C6E0" OutName="tex_08C6E0" Format="ci8" Width="32" Height="32" Offset="0x8C6E0" />
-        <Texture Name="gameplay_keep_Tex_08CAE0" OutName="tex_08CAE0" Format="ci8" Width="16" Height="32" Offset="0x8CAE0" />
-        <Texture Name="gameplay_keep_Tex_08CCE0" OutName="tex_08CCE0" Format="ci8" Width="16" Height="32" Offset="0x8CCE0" />
-        <Texture Name="gameplay_keep_Tex_08CEE0" OutName="tex_08CEE0" Format="ci8" Width="32" Height="32" Offset="0x8CEE0" />
-        <Texture Name="gameplay_keep_Tex_08D2E0" OutName="tex_08D2E0" Format="rgba16" Width="8" Height="16" Offset="0x8D2E0" />
+
+        <!-- Zora Elegy of Emptiness Shell -->
+        <DList Name="gElegyShellZoraDL" Offset="0x89070" /> <!-- Original name is "pzs_zo_model" -->
+        <Texture Name="gElegyShellZoraTLUT" OutName="elegy_shell_zora_tlut" Format="rgba16" Width="16" Height="16" Offset="0x8A420" />
+        <Texture Name="gElegyShellZoraGuitarJawTex" OutName="elegy_shell_zora_guitar_jaw" Format="rgba16" Width="16" Height="16" Offset="0x8A620" />
+        <Texture Name="gElegyShellZoraGuitarEyeTex" OutName="elegy_shell_zora_guitar_eye" Format="rgba16" Width="16" Height="16" Offset="0x8A820" />
+        <Texture Name="gElegyShellZoraGuitarTeethTex" OutName="elegy_shell_zora_guitar_teeth" Format="rgba16" Width="16" Height="16" Offset="0x8AA20" />
+        <Texture Name="gElegyShellZoraGuitarSpinousTex" OutName="elegy_shell_zora_guitar_spinous" Format="rgba16" Width="16" Height="32" Offset="0x8AC20" />
+        <Texture Name="gElegyShellZoraGuitarBoneTex" OutName="elegy_shell_zora_guitar_bone" Format="rgba16" Width="16" Height="32" Offset="0x8B020" />
+        <Texture Name="gElegyShellZoraSkinTex" OutName="elegy_shell_zora_skin" Format="ci8" Width="8" Height="8" Offset="0x8B420" />
+        <Texture Name="gElegyShellZoraSpottedSkinTex" OutName="elegy_shell_zora_spotted_skin" Format="ci8" Width="32" Height="32" Offset="0x8B460" />
+        <Texture Name="gElegyShellZoraFingersTex" OutName="elegy_shell_zora_fingers" Format="ci8" Width="16" Height="16" Offset="0x8B860" />
+        <Texture Name="gElegyShellZoraBackAndHipSpottedSkinTex" OutName="elegy_shell_zora_back_and_hip_spotted_skin" Format="ci8" Width="32" Height="64" Offset="0x8B960" />
+        <Texture Name="gElegyShellZoraWristbandTex" OutName="elegy_shell_zora_wristband" Format="ci8" Width="8" Height="16" Offset="0x8C160" />
+        <Texture Name="gElegyShellZoraFinTex" OutName="elegy_shell_zora_fin" Format="ci8" Width="16" Height="16" Offset="0x8C1E0" />
+        <Texture Name="gElegyShellZoraEyeTex" OutName="elegy_shell_zora_eye" Format="ci8" Width="32" Height="32" Offset="0x8C2E0" />
+        <Texture Name="gElegyShellZoraMouthTex" OutName="elegy_shell_zora_mouth" Format="ci8" Width="32" Height="32" Offset="0x8C6E0" />
+        <Texture Name="gElegyShellZoraRibsTattoo" OutName="elegy_shell_zora_ribs_tattoo" Format="ci8" Width="16" Height="32" Offset="0x8CAE0" />
+        <Texture Name="gElegyShellZoraArrowTattoo" OutName="elegy_shell_zora_arrow_tattoo" Format="ci8" Width="16" Height="32" Offset="0x8CCE0" />
+        <Texture Name="gElegyShellZoraRightShoulderTattoo" OutName="elegy_shell_zora_right_shoulder_tattoo" Format="ci8" Width="32" Height="32" Offset="0x8CEE0" />
+        <Texture Name="gElegyShellZoraPlatformTex" OutName="elegy_shell_zora_platform" Format="rgba16" Width="8" Height="16" Offset="0x8D2E0" />
+
         <Texture Name="gameplay_keep_Tex_08D3E0" OutName="tex_08D3E0" Format="i8" Width="64" Height="32" Offset="0x8D3E0" />
         
         <!-- Dust Textures -->

--- a/assets/xml/objects/object_zog.xml
+++ b/assets/xml/objects/object_zog.xml
@@ -16,7 +16,7 @@
         <Texture Name="gMikauGraveEyeTex" OutName="mikau_grave_eye" Format="rgba16" Width="16" Height="16" Offset="0x75D0" />
         <Texture Name="gMikauGraveTeethTex" OutName="mikau_grave_teeth" Format="rgba16" Width="16" Height="16" Offset="0x77D0" />
         <Texture Name="gMikauGraveSpinousTex" OutName="mikau_grave_spinous" Format="rgba16" Width="16" Height="32" Offset="0x79D0" />
-        <Texture Name="gMikauGraveBonesTex" OutName="mikau_grave_bones" Format="rgba16" Width="16" Height="32" Offset="0x7DD0" />
+        <Texture Name="gMikauGraveBoneTex" OutName="mikau_grave_bone" Format="rgba16" Width="16" Height="32" Offset="0x7DD0" />
         <Texture Name="gMikauGraveWoodenStickTex" OutName="mikau_grave_wooden_stick" Format="rgba16" Width="32" Height="8" Offset="0x81D0" />
         <Texture Name="gMikauGraveCordTex" OutName="mikau_grave_cord" Format="rgba16" Width="16" Height="8" Offset="0x83D0" />
         <Collision Name="gObjectZogCol" Offset="0x8670" />

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -58,11 +58,11 @@ static InitChainEntry sInitChain[] = {
 // Shells for each of Link's different forms
 // (Playing elegy as Fierce Deity puts down a human shell)
 static Gfx* sShellDLists[] = {
-    gameplay_keep_DL_01C430, // Human
-    gameplay_keep_DL_048DF0, // Zora
-    gameplay_keep_DL_089070, // Deku
-    gameplay_keep_DL_057B10, // Goron
-    gameplay_keep_DL_01C430, // Human
+    gElegyShellHumanDL,
+    gElegyShellGoronDL,
+    gElegyShellZoraDL,
+    gElegyShellDekuDL,
+    gElegyShellHumanDL,
 };
 
 void EnTorch2_Init(Actor* thisx, PlayState* play) {
@@ -163,7 +163,7 @@ void EnTorch2_UpdateDeath(Actor* thisx, PlayState* play) {
 void EnTorch2_Draw(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     EnTorch2* this = THIS;
-    Gfx* gfx = sShellDLists[thisx->params];
+    Gfx* gfx = sShellDLists[this->actor.params];
 
     OPEN_DISPS(play->state.gfxCtx);
     if (this->alpha == 0xFF) {

--- a/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
+++ b/src/overlays/actors/ovl_En_Torch2/z_en_torch2.c
@@ -58,11 +58,7 @@ static InitChainEntry sInitChain[] = {
 // Shells for each of Link's different forms
 // (Playing elegy as Fierce Deity puts down a human shell)
 static Gfx* sShellDLists[] = {
-    gElegyShellHumanDL,
-    gElegyShellGoronDL,
-    gElegyShellZoraDL,
-    gElegyShellDekuDL,
-    gElegyShellHumanDL,
+    gElegyShellHumanDL, gElegyShellGoronDL, gElegyShellZoraDL, gElegyShellDekuDL, gElegyShellHumanDL,
 };
 
 void EnTorch2_Init(Actor* thisx, PlayState* play) {


### PR DESCRIPTION
To get in the spooky spirit, I decided to take a look at some of MM's creepier assets; the shells left behind when you play the Elegy of Emptiness. Note that the Zora shell's guitar shares textures with Mikau's grave, so the two should share names as well.