### PR TITLE
Document object_boss01 (Odolwa)

### DIFF
--- a/assets/xml/objects/object_boss01.xml
+++ b/assets/xml/objects/object_boss01.xml
@@ -9,15 +9,15 @@
         <!-- Odolwa Limb DisplayLists -->
         <DList Name="gOdolwaPelvisDL" Offset="0x5E80" />
         <DList Name="gOdolwaHeadDL" Offset="0x5F98" />
-        <DList Name="gOdolwaCenterHairTipDL" Offset="0x61E8" />
-        <DList Name="gOdolwaCenterHairMiddleDL" Offset="0x62A8" />
-        <DList Name="gOdolwaCenterHairBaseDL" Offset="0x6368" />
-        <DList Name="gOdolwaLeftHairTipDL" Offset="0x6408" />
-        <DList Name="gOdolwaLeftHairMiddleDL" Offset="0x64C8" />
-        <DList Name="gOdolwaLeftHairBaseDL" Offset="0x6588" />
-        <DList Name="gOdolwaRightHairTipDL" Offset="0x6628" />
-        <DList Name="gOdolwaRightHairMiddleDL" Offset="0x66E8" />
-        <DList Name="gOdolwaRightHairBaseDL" Offset="0x67A8" />
+        <DList Name="gOdolwaCenterPlumeTipDL" Offset="0x61E8" />
+        <DList Name="gOdolwaCenterPlumeMiddleDL" Offset="0x62A8" />
+        <DList Name="gOdolwaCenterPlumeBaseDL" Offset="0x6368" />
+        <DList Name="gOdolwaLeftPlumeTipDL" Offset="0x6408" />
+        <DList Name="gOdolwaLeftPlumeMiddleDL" Offset="0x64C8" />
+        <DList Name="gOdolwaLeftPlumeBaseDL" Offset="0x6588" />
+        <DList Name="gOdolwaRightPlumeTipDL" Offset="0x6628" />
+        <DList Name="gOdolwaRightPlumeMiddleDL" Offset="0x66E8" />
+        <DList Name="gOdolwaRightPlumeBaseDL" Offset="0x67A8" />
         <DList Name="gOdolwaLeftEarringDL" Offset="0x6848" />
         <DList Name="gOdolwaRightEarringDL" Offset="0x68F8" />
         <DList Name="gOdolwaSwordDL" Offset="0x69A8" />
@@ -50,7 +50,7 @@
         <Texture Name="gOdolwaSkinTex" OutName="odolwa_skin" Format="ci4" Width="64" Height="64" Offset="0x9738" />
         <Texture Name="gOdolwaEarBangleAndShieldTex" OutName="odolwa_ear_bangle_and_shield" Format="ci4" Width="64" Height="64" Offset="0x9F38" />
         <Texture Name="gOdolwaEarringTex" OutName="odolwa_earring" Format="rgba16" Width="16" Height="16" Offset="0xA738" />
-        <Texture Name="gOdolwaHairTex" OutName="odolwa_hair" Format="rgba16" Width="16" Height="16" Offset="0xA938" />
+        <Texture Name="gOdolwaPlumeTex" OutName="odolwa_plume" Format="rgba16" Width="16" Height="16" Offset="0xA938" />
         <Texture Name="gOdolwaClothTex" OutName="odolwa_cloth" Format="ci4" Width="64" Height="64" Offset="0xAB38" />
         <Texture Name="gOdolwaTorsoTex" OutName="odolwa_torso" Format="ci4" Width="64" Height="64" Offset="0xB338" />
         <Texture Name="gOdolwaSwordBladeTex" OutName="odolwa_sword_blade" Format="rgba16" Width="16" Height="16" Offset="0xBB38" />
@@ -121,27 +121,27 @@
         <Limb Name="gOdolwaRightEarringLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_EARRING" Offset="0xEF04" />
         <Limb Name="gOdolwaLeftEarringRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_EARRING_ROOT" Offset="0xEF10" />
         <Limb Name="gOdolwaLeftEarringLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_EARRING" Offset="0xEF1C" />
-        <Limb Name="gOdolwaRightHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_ROOT" Offset="0xEF28" />
-        <Limb Name="gOdolwaRightHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_BASE" Offset="0xEF34" />
-        <Limb Name="gOdolwaRightLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LOWER_HAIR_ROOT" Offset="0xEF40" />
-        <Limb Name="gOdolwaRightHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_MIDDLE" Offset="0xEF4C" />
-        <Limb Name="gOdolwaRightHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_TIP" Offset="0xEF58" />
-        <Limb Name="gOdolwaLeftHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_ROOT" Offset="0xEF64" />
-        <Limb Name="gOdolwaLeftHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_BASE" Offset="0xEF70" />
-        <Limb Name="gOdolwaLeftLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LOWER_HAIR_ROOT" Offset="0xEF7C" />
-        <Limb Name="gOdolwaLeftHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_MIDDLE" Offset="0xEF88" />
-        <Limb Name="gOdolwaLeftHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_TIP" Offset="0xEF94" />
-        <Limb Name="gOdolwaCenterHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_ROOT" Offset="0xEFA0" />
-        <Limb Name="gOdolwaCenterHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_BASE" Offset="0xEFAC" />
-        <Limb Name="gOdolwaCenterLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_LOWER_HAIR_ROOT" Offset="0xEFB8" />
-        <Limb Name="gOdolwaCenterHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_MIDDLE" Offset="0xEFC4" />
-        <Limb Name="gOdolwaCenterHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_TIP" Offset="0xEFD0" />
+        <Limb Name="gOdolwaRightPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_PLUME_ROOT" Offset="0xEF28" />
+        <Limb Name="gOdolwaRightPlumeBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_PLUME_BASE" Offset="0xEF34" />
+        <Limb Name="gOdolwaRightLowerPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LOWER_PLUME_ROOT" Offset="0xEF40" />
+        <Limb Name="gOdolwaRightPlumeMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_PLUME_MIDDLE" Offset="0xEF4C" />
+        <Limb Name="gOdolwaRightPlumeTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_PLUME_TIP" Offset="0xEF58" />
+        <Limb Name="gOdolwaLeftPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_PLUME_ROOT" Offset="0xEF64" />
+        <Limb Name="gOdolwaLeftPlumeBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_PLUME_BASE" Offset="0xEF70" />
+        <Limb Name="gOdolwaLeftLowerPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LOWER_PLUME_ROOT" Offset="0xEF7C" />
+        <Limb Name="gOdolwaLeftPlumeMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_PLUME_MIDDLE" Offset="0xEF88" />
+        <Limb Name="gOdolwaLeftPlumeTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_PLUME_TIP" Offset="0xEF94" />
+        <Limb Name="gOdolwaCenterPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_PLUME_ROOT" Offset="0xEFA0" />
+        <Limb Name="gOdolwaCenterPlumeBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_PLUME_BASE" Offset="0xEFAC" />
+        <Limb Name="gOdolwaCenterLowerPlumeRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_LOWER_PLUME_ROOT" Offset="0xEFB8" />
+        <Limb Name="gOdolwaCenterPlumeMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_PLUME_MIDDLE" Offset="0xEFC4" />
+        <Limb Name="gOdolwaCenterPlumeTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_PLUME_TIP" Offset="0xEFD0" />
 
         <!-- Odolwa Skeleton -->
         <Skeleton Name="gOdolwaSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_LIMB_NONE" LimbMax="ODOLWA_LIMB_MAX" EnumName="OdolwaLimb" Offset="0xF0A8" />
 
         <!-- Odolwa Animations -->
-        <Animation Name="gOdolwaGlitchyFlailAnim" Offset="0xF918" /> <!-- Unused and glitchy. Original name might be "jmp_crym" -->
+        <Animation Name="gOdolwaClimbAnim" Offset="0xF918" /> <!-- Unused and glitchy. Original name might be "jmp_crym" -->
         <Animation Name="gOdolwaDamageStartAnim" Offset="0xFDEC" /> <!-- Original name is "jmp_dam02" -->
         <Animation Name="gOdolwaShieldGuardAnim" Offset="0xFF94" /> <!-- Original name is "jmp_def" -->
         <Animation Name="gOdolwaSwordGuardAnim" Offset="0x10150" /> <!-- Original name is "jmp_def02" -->
@@ -178,18 +178,18 @@
         <!-- Odolwa Bug Limb DisplayLists -->
         <DList Name="gOdolwaBugLightBodyDL" Offset="0x21230" />
         <DList Name="gOdolwaBugDarkBodyDL" Offset="0x213A8" />
-        <DList Name="gOdolwaBugFrontLeftLegUpperDL" Offset="0x21518" />
-        <DList Name="gOdolwaBugFrontLeftLegLowerDL" Offset="0x21538" />
-        <DList Name="gOdolwaBugBackRightLegUpperDL" Offset="0x21570" />
-        <DList Name="gOdolwaBugBackRightLegLowerDL" Offset="0x21590" />
-        <DList Name="gOdolwaBugBackLeftLegUpperDL" Offset="0x215C0" />
-        <DList Name="gOdolwaBugBackLeftLegLowerDL" Offset="0x215E0" />
-        <DList Name="gOdolwaBugMiddleRightLegUpperDL" Offset="0x21608" />
-        <DList Name="gOdolwaBugMiddleRightLegLowerDL" Offset="0x21628" />
-        <DList Name="gOdolwaBugMiddleLeftLegUpperDL" Offset="0x21658" />
-        <DList Name="gOdolwaBugMiddleLeftLegLowerDL" Offset="0x21678" />
-        <DList Name="gOdolwaBugFrontRightLegUpperDL" Offset="0x216A8" />
-        <DList Name="gOdolwaBugFrontRightLegLowerDL" Offset="0x216C8" />
+        <DList Name="gOdolwaBugFrontLeftUpperLegDL" Offset="0x21518" />
+        <DList Name="gOdolwaBugFrontLeftLowerLegDL" Offset="0x21538" />
+        <DList Name="gOdolwaBugBackRightUpperLegDL" Offset="0x21570" />
+        <DList Name="gOdolwaBugBackRightLowerLegDL" Offset="0x21590" />
+        <DList Name="gOdolwaBugBackLeftUpperLegDL" Offset="0x215C0" />
+        <DList Name="gOdolwaBugBackLeftLowerLegDL" Offset="0x215E0" />
+        <DList Name="gOdolwaBugMiddleRightUpperLegDL" Offset="0x21608" />
+        <DList Name="gOdolwaBugMiddleRightLowerLegDL" Offset="0x21628" />
+        <DList Name="gOdolwaBugMiddleLeftUpperLegDL" Offset="0x21658" />
+        <DList Name="gOdolwaBugMiddleLeftLowerLegDL" Offset="0x21678" />
+        <DList Name="gOdolwaBugFrontRightUpperLegDL" Offset="0x216A8" />
+        <DList Name="gOdolwaBugFrontRightLowerLegDL" Offset="0x216C8" />
 
         <!-- Odolwa Bug Textures -->
         <Texture Name="gOdolwaBugUndersideTLUT" OutName="odolwa_bug_underside_tlut" Format="rgba16" Width="4" Height="4" Offset="0x21700" />
@@ -205,23 +205,23 @@
         <Limb Name="gOdolwaBugRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_ROOT" Offset="0x22190" />
         <Limb Name="gOdolwaBugBodyLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BODY" Offset="0x2219C" />
         <Limb Name="gOdolwaBugFrontRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_ROOT" Offset="0x221A8" />
-        <Limb Name="gOdolwaBugFrontRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_UPPER" Offset="0x221B4" />
-        <Limb Name="gOdolwaBugFrontRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_LOWER" Offset="0x221C0" />
+        <Limb Name="gOdolwaBugFrontRightUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_UPPER_LEG" Offset="0x221B4" />
+        <Limb Name="gOdolwaBugFrontRightLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LOWER_LEG" Offset="0x221C0" />
         <Limb Name="gOdolwaBugMiddleLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_ROOT" Offset="0x221CC" />
-        <Limb Name="gOdolwaBugMiddleLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_UPPER" Offset="0x221D8" />
-        <Limb Name="gOdolwaBugMiddleLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_LOWER" Offset="0x221E4" />
+        <Limb Name="gOdolwaBugMiddleLeftUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_UPPER_LEG" Offset="0x221D8" />
+        <Limb Name="gOdolwaBugMiddleLeftLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LOWER_LEG" Offset="0x221E4" />
         <Limb Name="gOdolwaBugMiddleRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_ROOT" Offset="0x221F0" />
-        <Limb Name="gOdolwaBugMiddleRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_UPPER" Offset="0x221FC" />
-        <Limb Name="gOdolwaBugMiddleRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_LOWER" Offset="0x22208" />
+        <Limb Name="gOdolwaBugMiddleRightUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_UPPER_LEG" Offset="0x221FC" />
+        <Limb Name="gOdolwaBugMiddleRightLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LOWER_LEG" Offset="0x22208" />
         <Limb Name="gOdolwaBugBackLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_ROOT" Offset="0x22214" />
-        <Limb Name="gOdolwaBugBackLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_UPPER" Offset="0x22220" />
-        <Limb Name="gOdolwaBugBackLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_LOWER" Offset="0x2222C" />
+        <Limb Name="gOdolwaBugBackLeftUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_UPPER_LEG" Offset="0x22220" />
+        <Limb Name="gOdolwaBugBackLeftLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LOWER_LEG" Offset="0x2222C" />
         <Limb Name="gOdolwaBugBackRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_ROOT" Offset="0x22238" />
-        <Limb Name="gOdolwaBugBackRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_UPPER" Offset="0x22244" />
-        <Limb Name="gOdolwaBugBackRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_LOWER" Offset="0x22250" />
+        <Limb Name="gOdolwaBugBackRightUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_UPPER_LEG" Offset="0x22244" />
+        <Limb Name="gOdolwaBugBackRightLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LOWER_LEG" Offset="0x22250" />
         <Limb Name="gOdolwaBugFrontLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_ROOT" Offset="0x2225C" />
-        <Limb Name="gOdolwaBugFrontLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_UPPER" Offset="0x22268" />
-        <Limb Name="gOdolwaBugFrontLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_LOWER" Offset="0x22274" />
+        <Limb Name="gOdolwaBugFrontLeftUpperLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_UPPER_LEG" Offset="0x22268" />
+        <Limb Name="gOdolwaBugFrontLeftLowerLegLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LOWER_LEG" Offset="0x22274" />
 
         <!-- Odolwa Bug Skeleton -->
         <Skeleton Name="gOdolwaBugSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_BUG_LIMB_NONE" LimbMax="ODOLWA_BUG_LIMB_MAX" EnumName="OdolwaBugLimb" Offset="0x222D0" />

--- a/assets/xml/objects/object_boss01.xml
+++ b/assets/xml/objects/object_boss01.xml
@@ -1,9 +1,10 @@
 ﻿<Root>
+    <!-- Assets for the Odolwa boss fight (Odolwa itself, its bugs and moths, its title card, etc.) -->
     <File Name="object_boss01" Segment="6">
         <!-- Odolwa Animations -->
-        <Animation Name="object_boss01_Anim_000C44" Offset="0xC44" />
-        <Animation Name="object_boss01_Anim_001884" Offset="0x1884" />
-        <Animation Name="object_boss01_Anim_001A14" Offset="0x1A14" />
+        <Animation Name="gOdolwaVerticalSlashAnim" Offset="0xC44" /> <!-- Original name is "jmp_at01" -->
+        <Animation Name="gOdolwaHorizontalSlashAnim" Offset="0x1884" /> <!-- Original name is "jmp_at02" -->
+        <Animation Name="gOdolwaAtAttentionAnim" Offset="0x1A14" /> <!-- Unused. Original name is "jmp_base" -->
 
         <!-- Odolwa Limb DisplayLists -->
         <DList Name="gOdolwaPelvisDL" Offset="0x5E80" />
@@ -38,36 +39,50 @@
         <DList Name="gOdolwaRightThighDL" Offset="0x8500" />
 
         <!-- Odolwa Textures -->
-        <Texture Name="object_boss01_TLUT_008678" OutName="tlut_008678" Format="rgba16" Width="4" Height="4" Offset="0x8678" />
-        <Texture Name="object_boss01_TLUT_008698" OutName="tlut_008698" Format="rgba16" Width="4" Height="4" Offset="0x8698" />
-        <Texture Name="object_boss01_TLUT_0086B8" OutName="tlut_0086B8" Format="rgba16" Width="4" Height="4" Offset="0x86B8" />
-        <Texture Name="object_boss01_TLUT_0086D8" OutName="tlut_0086D8" Format="rgba16" Width="4" Height="4" Offset="0x86D8" />
-        <Texture Name="object_boss01_TLUT_0086F8" OutName="tlut_0086F8" Format="rgba16" Width="4" Height="4" Offset="0x86F8" />
-        <Texture Name="object_boss01_TLUT_008718" OutName="tlut_008718" Format="rgba16" Width="4" Height="4" Offset="0x8718" />
-        <Texture Name="object_boss01_Tex_008738" OutName="tex_008738" Format="ci4" Width="64" Height="64" Offset="0x8738" />
-        <Texture Name="object_boss01_Tex_008F38" OutName="tex_008F38" Format="ci4" Width="64" Height="64" Offset="0x8F38" />
-        <Texture Name="object_boss01_Tex_009738" OutName="tex_009738" Format="ci4" Width="64" Height="64" Offset="0x9738" />
-        <Texture Name="object_boss01_Tex_009F38" OutName="tex_009F38" Format="ci4" Width="64" Height="64" Offset="0x9F38" />
-        <Texture Name="object_boss01_Tex_00A738" OutName="tex_00A738" Format="rgba16" Width="16" Height="16" Offset="0xA738" />
-        <Texture Name="object_boss01_Tex_00A938" OutName="tex_00A938" Format="rgba16" Width="16" Height="16" Offset="0xA938" />
-        <Texture Name="object_boss01_Tex_00AB38" OutName="tex_00AB38" Format="ci4" Width="64" Height="64" Offset="0xAB38" />
-        <Texture Name="object_boss01_Tex_00B338" OutName="tex_00B338" Format="ci4" Width="64" Height="64" Offset="0xB338" />
-        <Texture Name="object_boss01_Tex_00BB38" OutName="tex_00BB38" Format="rgba16" Width="16" Height="16" Offset="0xBB38" />
-        <Texture Name="object_boss01_Tex_00BD38" OutName="tex_00BD38" Format="i8" Width="32" Height="32" Offset="0xBD38" />
-        <Texture Name="object_boss01_Tex_00C138" OutName="tex_00C138" Format="i4" Width="32" Height="32" Offset="0xC138" />
+        <Texture Name="gOdolwaPantsAndSwordHiltTLUT" OutName="odolwa_pants_and_sword_hilt_tlut" Format="rgba16" Width="4" Height="4" Offset="0x8678" />
+        <Texture Name="gOdolwaFaceAndShoeTLUT" OutName="odolwa_face_and_shoe_tlut" Format="rgba16" Width="4" Height="4" Offset="0x8698" />
+        <Texture Name="gOdolwaSkinTLUT" OutName="odolwa_skin_tlut" Format="rgba16" Width="4" Height="4" Offset="0x86B8" />
+        <Texture Name="gOdolwaEarBangleAndShieldTLUT" OutName="odolwa_ear_bangle_and_shield_tlut" Format="rgba16" Width="4" Height="4" Offset="0x86D8" />
+        <Texture Name="gOdolwaClothTLUT" OutName="odolwa_cloth_tlut" Format="rgba16" Width="4" Height="4" Offset="0x86F8" />
+        <Texture Name="gOdolwaTorsoTLUT" OutName="odolwa_torso_tlut" Format="rgba16" Width="4" Height="4" Offset="0x8718" />
+        <Texture Name="gOdolwaPantsAndSwordHiltTex" OutName="odolwa_pants_and_sword_hilt" Format="ci4" Width="64" Height="64" Offset="0x8738" />
+        <Texture Name="gOdolwaFaceAndShoeTex" OutName="odolwa_face_and_shoe" Format="ci4" Width="64" Height="64" Offset="0x8F38" />
+        <Texture Name="gOdolwaSkinTex" OutName="odolwa_skin" Format="ci4" Width="64" Height="64" Offset="0x9738" />
+        <Texture Name="gOdolwaEarBangleAndShieldTex" OutName="odolwa_ear_bangle_and_shield" Format="ci4" Width="64" Height="64" Offset="0x9F38" />
+        <Texture Name="gOdolwaEarringTex" OutName="odolwa_earring" Format="rgba16" Width="16" Height="16" Offset="0xA738" />
+        <Texture Name="gOdolwaHairTex" OutName="odolwa_hair" Format="rgba16" Width="16" Height="16" Offset="0xA938" />
+        <Texture Name="gOdolwaClothTex" OutName="odolwa_cloth" Format="ci4" Width="64" Height="64" Offset="0xAB38" />
+        <Texture Name="gOdolwaTorsoTex" OutName="odolwa_torso" Format="ci4" Width="64" Height="64" Offset="0xB338" />
+        <Texture Name="gOdolwaSwordBladeTex" OutName="odolwa_sword_blade" Format="rgba16" Width="16" Height="16" Offset="0xBB38" />
 
-        <DList Name="object_boss01_DL_00C498" Offset="0xC498" />
-        <DList Name="object_boss01_DL_00C5E0" Offset="0xC5E0" />
-        <Texture Name="object_boss01_Tex_00C668" OutName="tex_00C668" Format="i8" Width="16" Height="16" Offset="0xC668" />
-        <DList Name="object_boss01_DL_00C7A8" Offset="0xC7A8" />
-        <DList Name="object_boss01_DL_00C7C8" Offset="0xC7C8" />
-        <!-- <Blob Name="object_boss01_Blob_00C7F8" Size="0x1400" Offset="0xC7F8" /> -->
-        <DList Name="object_boss01_DL_00DC58" Offset="0xDC58" />
-        <DList Name="object_boss01_DL_00DCD0" Offset="0xDCD0" />
-        <Texture Name="object_boss01_Tex_00DCE8" OutName="tex_00DCE8" Format="rgba16" Width="16" Height="32" Offset="0xDCE8" />
-        <DList Name="object_boss01_DL_00E3E8" Offset="0xE3E8" />
-        <Texture Name="object_boss01_TLUT_00E558" OutName="tlut_00E558" Format="rgba16" Width="4" Height="4" Offset="0xE558" />
-        <Texture Name="object_boss01_Tex_00E578" OutName="tex_00E578" Format="ci4" Width="64" Height="64" Offset="0xE578" />
+        <!-- Assets for the trail that follows Odolwa's sword when he slashes -->
+        <Texture Name="gOdolwaSwordTrailTex" OutName="odolwa_sword_trail" Format="i8" Width="32" Height="32" Offset="0xBD38" />
+        <Texture Name="gOdolwaSwordTrailMaskTex" OutName="odolwa_sword_trail_mask" Format="i4" Width="32" Height="32" Offset="0xC138" />
+        <Array Name="gOdolwaSwordTrailVtx" Count="22" Offset="0xC338">
+            <Vtx/>
+        </Array>
+        <DList Name="gOdolwaSwordTrailDL" Offset="0xC498" />
+
+        <!-- Assets for Odolwa's glowing eyes -->
+        <DList Name="gOdolwaEyeDL" Offset="0xC5E0" />
+        <Texture Name="gOdolwaEyeTex" OutName="odolwa_eye" Format="i8" Width="16" Height="16" Offset="0xC668" />
+
+        <!-- DisplayLists for Odolwa's dynamic shadow -->
+        <DList Name="gOdolwaShadowMaterialDL" Offset="0xC7A8" />
+        <DList Name="gOdolwaShadowModelDL" Offset="0xC7C8" />
+
+        <!-- Odolwa Title Card -->
+        <Texture Name="gOdolwaTitleCardTex" OutName="odolwa_title_card" Format="ia8" Width="128" Height="40" Offset="0xC7F8" />
+
+        <!-- Assets for the moths Odolwa can summon -->
+        <DList Name="gOdolwaMothMaterialDL" Offset="0xDC58" />
+        <DList Name="gOdolwaMothModelDL" Offset="0xDCD0" />
+        <Texture Name="gOdolwaMothTex" OutName="odolwa_moth" Format="rgba16" Width="16" Height="32" Offset="0xDCE8" />
+
+        <!-- Assets for the blocks that fall from the ceiling during the Odolwa fight -->
+        <DList Name="gOdolwaFallingBlockDL" Offset="0xE3E8" /> <!-- Original name is "iwa01_model" ("rock; boulder") -->
+        <Texture Name="gOdolwaFallingBlockTLUT" OutName="odolwa_falling_block_tlut" Format="rgba16" Width="4" Height="4" Offset="0xE558" />
+        <Texture Name="gOdolwaFallingBlockTex" OutName="odolwa_falling_block" Format="ci4" Width="64" Height="64" Offset="0xE578" />
         
         <!-- Odolwa Limbs -->
         <Limb Name="gOdolwaRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_ROOT" Offset="0xED78" />
@@ -125,35 +140,42 @@
         <!-- Odolwa Skeleton -->
         <Skeleton Name="gOdolwaSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_LIMB_NONE" LimbMax="ODOLWA_LIMB_MAX" EnumName="OdolwaLimb" Offset="0xF0A8" />
 
-        <Animation Name="object_boss01_Anim_00F918" Offset="0xF918" />
-        <Animation Name="object_boss01_Anim_00FDEC" Offset="0xFDEC" />
-        <Animation Name="object_boss01_Anim_00FF94" Offset="0xFF94" />
-        <Animation Name="object_boss01_Anim_010150" Offset="0x10150" />
-        <Animation Name="object_boss01_Anim_010980" Offset="0x10980" />
-        <Animation Name="object_boss01_Anim_0124CC" Offset="0x124CC" />
-        <Animation Name="object_boss01_Anim_012B70" Offset="0x12B70" />
-        <Animation Name="object_boss01_Anim_012D10" Offset="0x12D10" />
-        <Animation Name="object_boss01_Anim_012EBC" Offset="0x12EBC" />
-        <Animation Name="object_boss01_Anim_013480" Offset="0x13480" />
-        <Animation Name="object_boss01_Anim_01407C" Offset="0x1407C" />
-        <Animation Name="object_boss01_Anim_014F14" Offset="0x14F14" />
-        <Animation Name="object_boss01_Anim_015A30" Offset="0x15A30" />
-        <Animation Name="object_boss01_Anim_016168" Offset="0x16168" />
-        <Animation Name="object_boss01_Anim_0164CC" Offset="0x164CC" />
-        <Animation Name="object_boss01_Anim_018438" Offset="0x18438" />
-        <Animation Name="object_boss01_Anim_019C10" Offset="0x19C10" />
-        <Animation Name="object_boss01_Anim_01AAF4" Offset="0x1AAF4" />
-        <Animation Name="object_boss01_Anim_01AF18" Offset="0x1AF18" />
-        <Animation Name="object_boss01_Anim_01BA94" Offset="0x1BA94" />
-        <Animation Name="object_boss01_Anim_01C700" Offset="0x1C700" />
-        <Animation Name="object_boss01_Anim_01CE88" Offset="0x1CE88" />
-        <Animation Name="object_boss01_Anim_01D8C8" Offset="0x1D8C8" />
-        <Animation Name="object_boss01_Anim_01E68C" Offset="0x1E68C" />
-        <Animation Name="object_boss01_Anim_01EEA8" Offset="0x1EEA8" />
-        <Animation Name="object_boss01_Anim_01F6A4" Offset="0x1F6A4" />
-        <Animation Name="object_boss01_Anim_01FC10" Offset="0x1FC10" />
-        <Animation Name="object_boss01_Anim_0204AC" Offset="0x204AC" />
-        <!-- <Blob Name="object_boss01_Blob_0206F0" Size="0x100" Offset="0x206F0" /> -->
+        <!-- Odolwa Animations -->
+        <Animation Name="gOdolwaGlitchyFlailAnim" Offset="0xF918" /> <!-- Unused and glitchy. Original name might be "jmp_crym" -->
+        <Animation Name="gOdolwaDamageStartAnim" Offset="0xFDEC" /> <!-- Original name is "jmp_dam02" -->
+        <Animation Name="gOdolwaShieldGuardAnim" Offset="0xFF94" /> <!-- Original name is "jmp_def" -->
+        <Animation Name="gOdolwaSwordGuardAnim" Offset="0x10150" /> <!-- Original name is "jmp_def02" -->
+        <Animation Name="gOdolwaDamageLoopAnim" Offset="0x10980" /> <!-- Original name is "jmp_dm01" -->
+        <Animation Name="gOdolwaDeathAnim" Offset="0x124CC" /> <!-- Original name is "jmp_down" -->
+        <Animation Name="gOdolwaMothSummonDanceAnim" Offset="0x12B70" /> <!-- Named "dance_bug" in MM3D, but it was probably renamed by Grezzo, since it doesn't fit with other names. -->
+        <Animation Name="gOdolwaCrouchAnim" Offset="0x12D10" /> <!-- Original name is "jmp_jmp01" -->
+        <Animation Name="gOdolwaJumpAnim" Offset="0x12EBC" /> <!-- Original name is "jmp_jmp02" -->
+        <Animation Name="gOdolwaFallingSlashAnim" Offset="0x13480" /> <!-- Original name is "jmp_jmp03" -->
+        <Animation Name="gOdolwaKickAnim" Offset="0x1407C" /> <!-- Original name is "jmp_kick" -->
+        <Animation Name="gOdolwaStunAnim" Offset="0x14F14" /> <!-- Original name is "jmp_piyo" -->
+        <Animation Name="gOdolwaShieldBashAnim" Offset="0x15A30" /> <!-- Original name is "jmp_punch" -->
+        <Animation Name="gOdolwaRunAnim" Offset="0x16168" /> <!-- Original name is "jmp_run" -->
+        <Animation Name="gOdolwaSpinAttackAnim" Offset="0x164CC" /> <!-- Original name is "jmp_spin" -->
+        <Animation Name="gOdolwaReadyAnim" Offset="0x18438" /> <!-- Original name is "jmp_stop" -->
+        <Animation Name="gOdolwaIntroSlashAnim" Offset="0x19C10" /> <!-- Original name is "jmp_stop02" -->
+        <Animation Name="gOdolwaSpinSwordAnim" Offset="0x1AAF4" /> <!-- MM3D name is "dance_roll", but it was probably renamed. Might have originally been "jmp_stop03" from surrounding context. -->
+        <Animation Name="gOdolwaVerticalHopAnim" Offset="0x1AF18" /> <!-- MM3D name is "dance_jump", but it was probably renamed. Might have originally been "jmp_stop04" from surrounding context. -->
+        <Animation Name="gOdolwaHipShakeDanceAnim" Offset="0x1BA94" /> <!-- MM3D name is "dance_moth", but it was probably renamed. Might have originally been "jmp_stop05" from surrounding context. -->
+        <Animation Name="gOdolwaUpAndDownDanceAnim" Offset="0x1C700" /> <!-- MM3D name is "dance_fire", but it was probably renamed. Might have originally been "jmp_stop06" from surrounding context. -->
+        <Animation Name="gOdolwaArmSwingDanceAnim" Offset="0x1CE88" /> <!-- Original name is "jmp_stop07" -->
+        <Animation Name="gOdolwaThurstAttackAnim" Offset="0x1D8C8" /> <!-- Original name is "jmp_stop08" -->
+        <Animation Name="gOdolwaDoubleSlashAnim" Offset="0x1E68C" /> <!-- Original name is "jmp_stop09" -->
+        <Animation Name="gOdolwaSideToSideHopAnim" Offset="0x1EEA8" /> <!-- Original name is "jmp_stop10" -->
+        <Animation Name="gOdolwaSideToSideDanceAnim" Offset="0x1F6A4" /> <!-- Not present in MM3D, but might have been originally named "jmp_stop11" from surrounding context. -->
+        <Animation Name="gOdolwaSpinDanceAnim" Offset="0x1FC10" /> <!-- Original name is "jmp_stop12" -->
+        <Animation Name="gOdolwaJumpDanceAnim" Offset="0x204AC" /> <!-- Not present in MM3D, but might have been originally named "jmp_stop13" from surrounding context. -->
+
+        <!-- Unused vertices of unknown purpose. They seem similar to the vertices used for the bug's body. -->
+        <Array Name="gOdolwaUnusedVtx" Count="16" Offset="0x206F0">
+            <Vtx/>
+        </Array>
+
+        <!-- Odolwa Bug Limb DisplayLists -->
         <DList Name="gOdolwaBugLightBodyDL" Offset="0x21230" />
         <DList Name="gOdolwaBugDarkBodyDL" Offset="0x213A8" />
         <DList Name="gOdolwaBugFrontLeftLegUpperDL" Offset="0x21518" />
@@ -168,12 +190,18 @@
         <DList Name="gOdolwaBugMiddleLeftLegLowerDL" Offset="0x21678" />
         <DList Name="gOdolwaBugFrontRightLegUpperDL" Offset="0x216A8" />
         <DList Name="gOdolwaBugFrontRightLegLowerDL" Offset="0x216C8" />
-        <Texture Name="object_boss01_TLUT_021700" OutName="tlut_021700" Format="rgba16" Width="4" Height="4" Offset="0x21700" />
-        <Texture Name="object_boss01_Tex_021720" OutName="tex_021720" Format="ci4" Width="16" Height="32" Offset="0x21720" />
-        <Texture Name="object_boss01_Tex_021820" OutName="tex_021820" Format="rgba16" Width="32" Height="32" Offset="0x21820" />
-        <Texture Name="object_boss01_Tex_022020" OutName="tex_022020" Format="rgba16" Width="8" Height="8" Offset="0x22020" />
-        <DList Name="object_boss01_DL_0220A0" Offset="0x220A0" />
-        <DList Name="object_boss01_DL_022118" Offset="0x22118" />
+
+        <!-- Odolwa Bug Textures -->
+        <Texture Name="gOdolwaBugUndersideTLUT" OutName="odolwa_bug_underside_tlut" Format="rgba16" Width="4" Height="4" Offset="0x21700" />
+        <Texture Name="gOdolwaBugUndersideTex" OutName="odolwa_bug_underside" Format="ci4" Width="16" Height="32" Offset="0x21720" />
+        <Texture Name="gOdolwaBugBodyTex" OutName="odolwa_bug_body" Format="rgba16" Width="32" Height="32" Offset="0x21820" />
+        <Texture Name="gOdolwaBugLegTex" OutName="odolwa_bug_leg" Format="rgba16" Width="8" Height="8" Offset="0x22020" />
+
+        <!-- Material DisplayLists for the bug's legs. The bright one is only used for the cutscene where the bugs first fall down. -->
+        <DList Name="gOdolwaBugDullLegMaterialDL" Offset="0x220A0" />
+        <DList Name="gOdolwaBugBrightLegMaterialDL" Offset="0x22118" />
+
+        <!-- Odolwa Bug Limbs -->
         <Limb Name="gOdolwaBugRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_ROOT" Offset="0x22190" />
         <Limb Name="gOdolwaBugBodyLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BODY" Offset="0x2219C" />
         <Limb Name="gOdolwaBugFrontRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_ROOT" Offset="0x221A8" />
@@ -194,7 +222,11 @@
         <Limb Name="gOdolwaBugFrontLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_ROOT" Offset="0x2225C" />
         <Limb Name="gOdolwaBugFrontLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_UPPER" Offset="0x22268" />
         <Limb Name="gOdolwaBugFrontLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_LOWER" Offset="0x22274" />
+
+        <!-- Odolwa Bug Skeleton -->
         <Skeleton Name="gOdolwaBugSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_BUG_LIMB_NONE" LimbMax="ODOLWA_BUG_LIMB_MAX" EnumName="OdolwaBugLimb" Offset="0x222D0" />
-        <Animation Name="object_boss01_Anim_022550" Offset="0x22550" />
+
+        <!-- Odolwa Bug Animation -->
+        <Animation Name="gOdolwaBugCrawlAnim" Offset="0x22550" /> <!-- Original name is "mbug_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_boss01.xml
+++ b/assets/xml/objects/object_boss01.xml
@@ -152,7 +152,7 @@
         <Animation Name="gOdolwaJumpAnim" Offset="0x12EBC" /> <!-- Original name is "jmp_jmp02" -->
         <Animation Name="gOdolwaFallingSlashAnim" Offset="0x13480" /> <!-- Original name is "jmp_jmp03" -->
         <Animation Name="gOdolwaKickAnim" Offset="0x1407C" /> <!-- Original name is "jmp_kick" -->
-        <Animation Name="gOdolwaStunAnim" Offset="0x14F14" /> <!-- Original name is "jmp_piyo" -->
+        <Animation Name="gOdolwaStunAnim" Offset="0x14F14" /> <!-- Original name is "jmp_piyo" ("weakly moving") -->
         <Animation Name="gOdolwaShieldBashAnim" Offset="0x15A30" /> <!-- Original name is "jmp_punch" -->
         <Animation Name="gOdolwaRunAnim" Offset="0x16168" /> <!-- Original name is "jmp_run" -->
         <Animation Name="gOdolwaSpinAttackAnim" Offset="0x164CC" /> <!-- Original name is "jmp_spin" -->

--- a/assets/xml/objects/object_boss01.xml
+++ b/assets/xml/objects/object_boss01.xml
@@ -1,38 +1,43 @@
 ﻿<Root>
     <File Name="object_boss01" Segment="6">
+        <!-- Odolwa Animations -->
         <Animation Name="object_boss01_Anim_000C44" Offset="0xC44" />
         <Animation Name="object_boss01_Anim_001884" Offset="0x1884" />
         <Animation Name="object_boss01_Anim_001A14" Offset="0x1A14" />
-        <DList Name="object_boss01_DL_005E80" Offset="0x5E80" />
-        <DList Name="object_boss01_DL_005F98" Offset="0x5F98" />
-        <DList Name="object_boss01_DL_0061E8" Offset="0x61E8" />
-        <DList Name="object_boss01_DL_0062A8" Offset="0x62A8" />
-        <DList Name="object_boss01_DL_006368" Offset="0x6368" />
-        <DList Name="object_boss01_DL_006408" Offset="0x6408" />
-        <DList Name="object_boss01_DL_0064C8" Offset="0x64C8" />
-        <DList Name="object_boss01_DL_006588" Offset="0x6588" />
-        <DList Name="object_boss01_DL_006628" Offset="0x6628" />
-        <DList Name="object_boss01_DL_0066E8" Offset="0x66E8" />
-        <DList Name="object_boss01_DL_0067A8" Offset="0x67A8" />
-        <DList Name="object_boss01_DL_006848" Offset="0x6848" />
-        <DList Name="object_boss01_DL_0068F8" Offset="0x68F8" />
-        <DList Name="object_boss01_DL_0069A8" Offset="0x69A8" />
-        <DList Name="object_boss01_DL_006B20" Offset="0x6B20" />
-        <DList Name="object_boss01_DL_006CF8" Offset="0x6CF8" />
-        <DList Name="object_boss01_DL_006E50" Offset="0x6E50" />
-        <DList Name="object_boss01_DL_006F40" Offset="0x6F40" />
-        <DList Name="object_boss01_DL_0070D0" Offset="0x70D0" />
-        <DList Name="object_boss01_DL_0071C0" Offset="0x71C0" />
-        <DList Name="object_boss01_DL_007398" Offset="0x7398" />
-        <DList Name="object_boss01_DL_0074F0" Offset="0x74F0" />
-        <DList Name="object_boss01_DL_0075E0" Offset="0x75E0" />
-        <DList Name="object_boss01_DL_007770" Offset="0x7770" />
-        <DList Name="object_boss01_DL_007BD8" Offset="0x7BD8" />
-        <DList Name="object_boss01_DL_007E40" Offset="0x7E40" />
-        <DList Name="object_boss01_DL_007FB0" Offset="0x7FB0" />
-        <DList Name="object_boss01_DL_008128" Offset="0x8128" />
-        <DList Name="object_boss01_DL_008390" Offset="0x8390" />
-        <DList Name="object_boss01_DL_008500" Offset="0x8500" />
+
+        <!-- Odolwa Limb DisplayLists -->
+        <DList Name="gOdolwaPelvisDL" Offset="0x5E80" />
+        <DList Name="gOdolwaHeadDL" Offset="0x5F98" />
+        <DList Name="gOdolwaCenterHairTipDL" Offset="0x61E8" />
+        <DList Name="gOdolwaCenterHairMiddleDL" Offset="0x62A8" />
+        <DList Name="gOdolwaCenterHairBaseDL" Offset="0x6368" />
+        <DList Name="gOdolwaLeftHairTipDL" Offset="0x6408" />
+        <DList Name="gOdolwaLeftHairMiddleDL" Offset="0x64C8" />
+        <DList Name="gOdolwaLeftHairBaseDL" Offset="0x6588" />
+        <DList Name="gOdolwaRightHairTipDL" Offset="0x6628" />
+        <DList Name="gOdolwaRightHairMiddleDL" Offset="0x66E8" />
+        <DList Name="gOdolwaRightHairBaseDL" Offset="0x67A8" />
+        <DList Name="gOdolwaLeftEarringDL" Offset="0x6848" />
+        <DList Name="gOdolwaRightEarringDL" Offset="0x68F8" />
+        <DList Name="gOdolwaSwordDL" Offset="0x69A8" />
+        <DList Name="gOdolwaRightHandDL" Offset="0x6B20" />
+        <DList Name="gOdolwaRightForearmDL" Offset="0x6CF8" />
+        <DList Name="gOdolwaRightBangleDL" Offset="0x6E50" />
+        <DList Name="gOdolwaRightUpperArmDL" Offset="0x6F40" />
+        <DList Name="gOdolwaShieldDL" Offset="0x70D0" />
+        <DList Name="gOdolwaLeftHandDL" Offset="0x71C0" />
+        <DList Name="gOdolwaLeftForearmDL" Offset="0x7398" />
+        <DList Name="gOdolwaLeftBangleDL" Offset="0x74F0" />
+        <DList Name="gOdolwaLeftUpperArmDL" Offset="0x75E0" />
+        <DList Name="gOdolwaTorsoDL" Offset="0x7770" />
+        <DList Name="gOdolwaLeftFootDL" Offset="0x7BD8" />
+        <DList Name="gOdolwaLeftShinDL" Offset="0x7E40" />
+        <DList Name="gOdolwaLeftThighDL" Offset="0x7FB0" />
+        <DList Name="gOdolwaRightFootDL" Offset="0x8128" />
+        <DList Name="gOdolwaRightShinDL" Offset="0x8390" />
+        <DList Name="gOdolwaRightThighDL" Offset="0x8500" />
+
+        <!-- Odolwa Textures -->
         <Texture Name="object_boss01_TLUT_008678" OutName="tlut_008678" Format="rgba16" Width="4" Height="4" Offset="0x8678" />
         <Texture Name="object_boss01_TLUT_008698" OutName="tlut_008698" Format="rgba16" Width="4" Height="4" Offset="0x8698" />
         <Texture Name="object_boss01_TLUT_0086B8" OutName="tlut_0086B8" Format="rgba16" Width="4" Height="4" Offset="0x86B8" />
@@ -50,6 +55,7 @@
         <Texture Name="object_boss01_Tex_00BB38" OutName="tex_00BB38" Format="rgba16" Width="16" Height="16" Offset="0xBB38" />
         <Texture Name="object_boss01_Tex_00BD38" OutName="tex_00BD38" Format="i8" Width="32" Height="32" Offset="0xBD38" />
         <Texture Name="object_boss01_Tex_00C138" OutName="tex_00C138" Format="i4" Width="32" Height="32" Offset="0xC138" />
+
         <DList Name="object_boss01_DL_00C498" Offset="0xC498" />
         <DList Name="object_boss01_DL_00C5E0" Offset="0xC5E0" />
         <Texture Name="object_boss01_Tex_00C668" OutName="tex_00C668" Format="i8" Width="16" Height="16" Offset="0xC668" />
@@ -62,58 +68,63 @@
         <DList Name="object_boss01_DL_00E3E8" Offset="0xE3E8" />
         <Texture Name="object_boss01_TLUT_00E558" OutName="tlut_00E558" Format="rgba16" Width="4" Height="4" Offset="0xE558" />
         <Texture Name="object_boss01_Tex_00E578" OutName="tex_00E578" Format="ci4" Width="64" Height="64" Offset="0xE578" />
-        <Limb Name="object_boss01_Standardlimb_00ED78" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_01" Offset="0xED78" />
-        <Limb Name="object_boss01_Standardlimb_00ED84" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_02" Offset="0xED84" />
-        <Limb Name="object_boss01_Standardlimb_00ED90" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_03" Offset="0xED90" />
-        <Limb Name="object_boss01_Standardlimb_00ED9C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_04" Offset="0xED9C" />
-        <Limb Name="object_boss01_Standardlimb_00EDA8" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_05" Offset="0xEDA8" />
-        <Limb Name="object_boss01_Standardlimb_00EDB4" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_06" Offset="0xEDB4" />
-        <Limb Name="object_boss01_Standardlimb_00EDC0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_07" Offset="0xEDC0" />
-        <Limb Name="object_boss01_Standardlimb_00EDCC" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_08" Offset="0xEDCC" />
-        <Limb Name="object_boss01_Standardlimb_00EDD8" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_09" Offset="0xEDD8" />
-        <Limb Name="object_boss01_Standardlimb_00EDE4" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0A" Offset="0xEDE4" />
-        <Limb Name="object_boss01_Standardlimb_00EDF0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0B" Offset="0xEDF0" />
-        <Limb Name="object_boss01_Standardlimb_00EDFC" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0C" Offset="0xEDFC" />
-        <Limb Name="object_boss01_Standardlimb_00EE08" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0D" Offset="0xEE08" />
-        <Limb Name="object_boss01_Standardlimb_00EE14" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0E" Offset="0xEE14" />
-        <Limb Name="object_boss01_Standardlimb_00EE20" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_0F" Offset="0xEE20" />
-        <Limb Name="object_boss01_Standardlimb_00EE2C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_10" Offset="0xEE2C" />
-        <Limb Name="object_boss01_Standardlimb_00EE38" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_11" Offset="0xEE38" />
-        <Limb Name="object_boss01_Standardlimb_00EE44" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_12" Offset="0xEE44" />
-        <Limb Name="object_boss01_Standardlimb_00EE50" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_13" Offset="0xEE50" />
-        <Limb Name="object_boss01_Standardlimb_00EE5C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_14" Offset="0xEE5C" />
-        <Limb Name="object_boss01_Standardlimb_00EE68" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_15" Offset="0xEE68" />
-        <Limb Name="object_boss01_Standardlimb_00EE74" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_16" Offset="0xEE74" />
-        <Limb Name="object_boss01_Standardlimb_00EE80" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_17" Offset="0xEE80" />
-        <Limb Name="object_boss01_Standardlimb_00EE8C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_18" Offset="0xEE8C" />
-        <Limb Name="object_boss01_Standardlimb_00EE98" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_19" Offset="0xEE98" />
-        <Limb Name="object_boss01_Standardlimb_00EEA4" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1A" Offset="0xEEA4" />
-        <Limb Name="object_boss01_Standardlimb_00EEB0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1B" Offset="0xEEB0" />
-        <Limb Name="object_boss01_Standardlimb_00EEBC" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1C" Offset="0xEEBC" />
-        <Limb Name="object_boss01_Standardlimb_00EEC8" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1D" Offset="0xEEC8" />
-        <Limb Name="object_boss01_Standardlimb_00EED4" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1E" Offset="0xEED4" />
-        <Limb Name="object_boss01_Standardlimb_00EEE0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_1F" Offset="0xEEE0" />
-        <Limb Name="object_boss01_Standardlimb_00EEEC" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_20" Offset="0xEEEC" />
-        <Limb Name="object_boss01_Standardlimb_00EEF8" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_21" Offset="0xEEF8" />
-        <Limb Name="object_boss01_Standardlimb_00EF04" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_22" Offset="0xEF04" />
-        <Limb Name="object_boss01_Standardlimb_00EF10" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_23" Offset="0xEF10" />
-        <Limb Name="object_boss01_Standardlimb_00EF1C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_24" Offset="0xEF1C" />
-        <Limb Name="object_boss01_Standardlimb_00EF28" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_25" Offset="0xEF28" />
-        <Limb Name="object_boss01_Standardlimb_00EF34" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_26" Offset="0xEF34" />
-        <Limb Name="object_boss01_Standardlimb_00EF40" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_27" Offset="0xEF40" />
-        <Limb Name="object_boss01_Standardlimb_00EF4C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_28" Offset="0xEF4C" />
-        <Limb Name="object_boss01_Standardlimb_00EF58" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_29" Offset="0xEF58" />
-        <Limb Name="object_boss01_Standardlimb_00EF64" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2A" Offset="0xEF64" />
-        <Limb Name="object_boss01_Standardlimb_00EF70" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2B" Offset="0xEF70" />
-        <Limb Name="object_boss01_Standardlimb_00EF7C" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2C" Offset="0xEF7C" />
-        <Limb Name="object_boss01_Standardlimb_00EF88" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2D" Offset="0xEF88" />
-        <Limb Name="object_boss01_Standardlimb_00EF94" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2E" Offset="0xEF94" />
-        <Limb Name="object_boss01_Standardlimb_00EFA0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_2F" Offset="0xEFA0" />
-        <Limb Name="object_boss01_Standardlimb_00EFAC" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_30" Offset="0xEFAC" />
-        <Limb Name="object_boss01_Standardlimb_00EFB8" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_31" Offset="0xEFB8" />
-        <Limb Name="object_boss01_Standardlimb_00EFC4" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_32" Offset="0xEFC4" />
-        <Limb Name="object_boss01_Standardlimb_00EFD0" Type="Standard" EnumName="OBJECT_BOSS01_1_LIMB_33" Offset="0xEFD0" />
-        <Skeleton Name="object_boss01_Skel_00F0A8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BOSS01_1_LIMB_NONE" LimbMax="OBJECT_BOSS01_1_LIMB_MAX" EnumName="ObjectBoss011Limb" Offset="0xF0A8" />
+        
+        <!-- Odolwa Limbs -->
+        <Limb Name="gOdolwaRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_ROOT" Offset="0xED78" />
+        <Limb Name="gOdolwaPelvisLimb" Type="Standard" EnumName="ODOLWA_LIMB_PELVIS" Offset="0xED84" />
+        <Limb Name="gOdolwaRightLegRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LEG_ROOT" Offset="0xED90" />
+        <Limb Name="gOdolwaRightThighLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_THIGH" Offset="0xED9C" />
+        <Limb Name="gOdolwaRightLowerLegRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LOWER_LEG_ROOT" Offset="0xEDA8" />
+        <Limb Name="gOdolwaRightShinLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_SHIN" Offset="0xEDB4" />
+        <Limb Name="gOdolwaRightFootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_FOOT" Offset="0xEDC0" />
+        <Limb Name="gOdolwaLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LEG_ROOT" Offset="0xEDCC" />
+        <Limb Name="gOdolwaLeftThighLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_THIGH" Offset="0xEDD8" />
+        <Limb Name="gOdolwaLeftLowerLegRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LOWER_LEG_ROOT" Offset="0xEDE4" />
+        <Limb Name="gOdolwaLeftShinLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_SHIN" Offset="0xEDF0" />
+        <Limb Name="gOdolwaLeftFootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_FOOT" Offset="0xEDFC" />
+        <Limb Name="gOdolwaUpperBodyRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_UPPER_BODY_ROOT" Offset="0xEE08" />
+        <Limb Name="gOdolwaUpperBodyWrapperLimb" Type="Standard" EnumName="ODOLWA_LIMB_UPPER_BODY_WRAPPER" Offset="0xEE14" />
+        <Limb Name="gOdolwaTorsoLimb" Type="Standard" EnumName="ODOLWA_LIMB_TORSO" Offset="0xEE20" />
+        <Limb Name="gOdolwaLeftArmRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_ARM_ROOT" Offset="0xEE2C" />
+        <Limb Name="gOdolwaLeftUpperArmLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_UPPER_ARM" Offset="0xEE38" />
+        <Limb Name="gOdolwaLeftLowerArmRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LOWER_ARM_ROOT" Offset="0xEE44" />
+        <Limb Name="gOdolwaLeftForearmLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_FOREARM" Offset="0xEE50" />
+        <Limb Name="gOdolwaLeftBangleLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_BANGLE" Offset="0xEE5C" />
+        <Limb Name="gOdolwaLeftHandRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAND_ROOT" Offset="0xEE68" />
+        <Limb Name="gOdolwaLeftHandLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAND" Offset="0xEE74" />
+        <Limb Name="gOdolwaShieldLimb" Type="Standard" EnumName="ODOLWA_LIMB_SHIELD" Offset="0xEE80" />
+        <Limb Name="gOdolwaRightArmRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_ARM_ROOT" Offset="0xEE8C" />
+        <Limb Name="gOdolwaRightUpperArmLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_UPPER_ARM" Offset="0xEE98" />
+        <Limb Name="gOdolwaRightLowerArmRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LOWER_ARM_ROOT" Offset="0xEEA4" />
+        <Limb Name="gOdolwaRightForearmLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_FOREARM" Offset="0xEEB0" />
+        <Limb Name="gOdolwaRightBangleLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_BANGLE" Offset="0xEEBC" />
+        <Limb Name="gOdolwaRightHandRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAND_ROOT" Offset="0xEEC8" />
+        <Limb Name="gOdolwaRightHandLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAND" Offset="0xEED4" />
+        <Limb Name="gOdolwaSwordLimb" Type="Standard" EnumName="ODOLWA_LIMB_SWORD" Offset="0xEEE0" />
+        <Limb Name="gOdolwaHeadLimb" Type="Standard" EnumName="ODOLWA_LIMB_HEAD" Offset="0xEEEC" />
+        <Limb Name="gOdolwaRightEarringRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_EARRING_ROOT" Offset="0xEEF8" />
+        <Limb Name="gOdolwaRightEarringLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_EARRING" Offset="0xEF04" />
+        <Limb Name="gOdolwaLeftEarringRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_EARRING_ROOT" Offset="0xEF10" />
+        <Limb Name="gOdolwaLeftEarringLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_EARRING" Offset="0xEF1C" />
+        <Limb Name="gOdolwaRightHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_ROOT" Offset="0xEF28" />
+        <Limb Name="gOdolwaRightHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_BASE" Offset="0xEF34" />
+        <Limb Name="gOdolwaRightLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_LOWER_HAIR_ROOT" Offset="0xEF40" />
+        <Limb Name="gOdolwaRightHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_MIDDLE" Offset="0xEF4C" />
+        <Limb Name="gOdolwaRightHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_RIGHT_HAIR_TIP" Offset="0xEF58" />
+        <Limb Name="gOdolwaLeftHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_ROOT" Offset="0xEF64" />
+        <Limb Name="gOdolwaLeftHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_BASE" Offset="0xEF70" />
+        <Limb Name="gOdolwaLeftLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_LOWER_HAIR_ROOT" Offset="0xEF7C" />
+        <Limb Name="gOdolwaLeftHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_MIDDLE" Offset="0xEF88" />
+        <Limb Name="gOdolwaLeftHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_LEFT_HAIR_TIP" Offset="0xEF94" />
+        <Limb Name="gOdolwaCenterHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_ROOT" Offset="0xEFA0" />
+        <Limb Name="gOdolwaCenterHairBaseLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_BASE" Offset="0xEFAC" />
+        <Limb Name="gOdolwaCenterLowerHairRootLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_LOWER_HAIR_ROOT" Offset="0xEFB8" />
+        <Limb Name="gOdolwaCenterHairMiddleLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_MIDDLE" Offset="0xEFC4" />
+        <Limb Name="gOdolwaCenterHairTipLimb" Type="Standard" EnumName="ODOLWA_LIMB_CENTER_HAIR_TIP" Offset="0xEFD0" />
+
+        <!-- Odolwa Skeleton -->
+        <Skeleton Name="gOdolwaSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_LIMB_NONE" LimbMax="ODOLWA_LIMB_MAX" EnumName="OdolwaLimb" Offset="0xF0A8" />
+
         <Animation Name="object_boss01_Anim_00F918" Offset="0xF918" />
         <Animation Name="object_boss01_Anim_00FDEC" Offset="0xFDEC" />
         <Animation Name="object_boss01_Anim_00FF94" Offset="0xFF94" />
@@ -143,47 +154,47 @@
         <Animation Name="object_boss01_Anim_01FC10" Offset="0x1FC10" />
         <Animation Name="object_boss01_Anim_0204AC" Offset="0x204AC" />
         <!-- <Blob Name="object_boss01_Blob_0206F0" Size="0x100" Offset="0x206F0" /> -->
-        <DList Name="object_boss01_DL_021230" Offset="0x21230" />
-        <DList Name="object_boss01_DL_0213A8" Offset="0x213A8" />
-        <DList Name="object_boss01_DL_021518" Offset="0x21518" />
-        <DList Name="object_boss01_DL_021538" Offset="0x21538" />
-        <DList Name="object_boss01_DL_021570" Offset="0x21570" />
-        <DList Name="object_boss01_DL_021590" Offset="0x21590" />
-        <DList Name="object_boss01_DL_0215C0" Offset="0x215C0" />
-        <DList Name="object_boss01_DL_0215E0" Offset="0x215E0" />
-        <DList Name="object_boss01_DL_021608" Offset="0x21608" />
-        <DList Name="object_boss01_DL_021628" Offset="0x21628" />
-        <DList Name="object_boss01_DL_021658" Offset="0x21658" />
-        <DList Name="object_boss01_DL_021678" Offset="0x21678" />
-        <DList Name="object_boss01_DL_0216A8" Offset="0x216A8" />
-        <DList Name="object_boss01_DL_0216C8" Offset="0x216C8" />
+        <DList Name="gOdolwaBugLightBodyDL" Offset="0x21230" />
+        <DList Name="gOdolwaBugDarkBodyDL" Offset="0x213A8" />
+        <DList Name="gOdolwaBugFrontLeftLegUpperDL" Offset="0x21518" />
+        <DList Name="gOdolwaBugFrontLeftLegLowerDL" Offset="0x21538" />
+        <DList Name="gOdolwaBugBackRightLegUpperDL" Offset="0x21570" />
+        <DList Name="gOdolwaBugBackRightLegLowerDL" Offset="0x21590" />
+        <DList Name="gOdolwaBugBackLeftLegUpperDL" Offset="0x215C0" />
+        <DList Name="gOdolwaBugBackLeftLegLowerDL" Offset="0x215E0" />
+        <DList Name="gOdolwaBugMiddleRightLegUpperDL" Offset="0x21608" />
+        <DList Name="gOdolwaBugMiddleRightLegLowerDL" Offset="0x21628" />
+        <DList Name="gOdolwaBugMiddleLeftLegUpperDL" Offset="0x21658" />
+        <DList Name="gOdolwaBugMiddleLeftLegLowerDL" Offset="0x21678" />
+        <DList Name="gOdolwaBugFrontRightLegUpperDL" Offset="0x216A8" />
+        <DList Name="gOdolwaBugFrontRightLegLowerDL" Offset="0x216C8" />
         <Texture Name="object_boss01_TLUT_021700" OutName="tlut_021700" Format="rgba16" Width="4" Height="4" Offset="0x21700" />
         <Texture Name="object_boss01_Tex_021720" OutName="tex_021720" Format="ci4" Width="16" Height="32" Offset="0x21720" />
         <Texture Name="object_boss01_Tex_021820" OutName="tex_021820" Format="rgba16" Width="32" Height="32" Offset="0x21820" />
         <Texture Name="object_boss01_Tex_022020" OutName="tex_022020" Format="rgba16" Width="8" Height="8" Offset="0x22020" />
         <DList Name="object_boss01_DL_0220A0" Offset="0x220A0" />
         <DList Name="object_boss01_DL_022118" Offset="0x22118" />
-        <Limb Name="object_boss01_Standardlimb_022190" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_01" Offset="0x22190" />
-        <Limb Name="object_boss01_Standardlimb_02219C" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_02" Offset="0x2219C" />
-        <Limb Name="object_boss01_Standardlimb_0221A8" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_03" Offset="0x221A8" />
-        <Limb Name="object_boss01_Standardlimb_0221B4" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_04" Offset="0x221B4" />
-        <Limb Name="object_boss01_Standardlimb_0221C0" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_05" Offset="0x221C0" />
-        <Limb Name="object_boss01_Standardlimb_0221CC" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_06" Offset="0x221CC" />
-        <Limb Name="object_boss01_Standardlimb_0221D8" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_07" Offset="0x221D8" />
-        <Limb Name="object_boss01_Standardlimb_0221E4" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_08" Offset="0x221E4" />
-        <Limb Name="object_boss01_Standardlimb_0221F0" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_09" Offset="0x221F0" />
-        <Limb Name="object_boss01_Standardlimb_0221FC" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0A" Offset="0x221FC" />
-        <Limb Name="object_boss01_Standardlimb_022208" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0B" Offset="0x22208" />
-        <Limb Name="object_boss01_Standardlimb_022214" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0C" Offset="0x22214" />
-        <Limb Name="object_boss01_Standardlimb_022220" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0D" Offset="0x22220" />
-        <Limb Name="object_boss01_Standardlimb_02222C" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0E" Offset="0x2222C" />
-        <Limb Name="object_boss01_Standardlimb_022238" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_0F" Offset="0x22238" />
-        <Limb Name="object_boss01_Standardlimb_022244" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_10" Offset="0x22244" />
-        <Limb Name="object_boss01_Standardlimb_022250" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_11" Offset="0x22250" />
-        <Limb Name="object_boss01_Standardlimb_02225C" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_12" Offset="0x2225C" />
-        <Limb Name="object_boss01_Standardlimb_022268" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_13" Offset="0x22268" />
-        <Limb Name="object_boss01_Standardlimb_022274" Type="Standard" EnumName="OBJECT_BOSS01_2_LIMB_14" Offset="0x22274" />
-        <Skeleton Name="object_boss01_Skel_0222D0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BOSS01_2_LIMB_NONE" LimbMax="OBJECT_BOSS01_2_LIMB_MAX" EnumName="ObjectBoss012Limb" Offset="0x222D0" />
+        <Limb Name="gOdolwaBugRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_ROOT" Offset="0x22190" />
+        <Limb Name="gOdolwaBugBodyLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BODY" Offset="0x2219C" />
+        <Limb Name="gOdolwaBugFrontRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_ROOT" Offset="0x221A8" />
+        <Limb Name="gOdolwaBugFrontRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_UPPER" Offset="0x221B4" />
+        <Limb Name="gOdolwaBugFrontRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_RIGHT_LEG_LOWER" Offset="0x221C0" />
+        <Limb Name="gOdolwaBugMiddleLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_ROOT" Offset="0x221CC" />
+        <Limb Name="gOdolwaBugMiddleLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_UPPER" Offset="0x221D8" />
+        <Limb Name="gOdolwaBugMiddleLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_LEFT_LEG_LOWER" Offset="0x221E4" />
+        <Limb Name="gOdolwaBugMiddleRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_ROOT" Offset="0x221F0" />
+        <Limb Name="gOdolwaBugMiddleRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_UPPER" Offset="0x221FC" />
+        <Limb Name="gOdolwaBugMiddleRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_MIDDLE_RIGHT_LEG_LOWER" Offset="0x22208" />
+        <Limb Name="gOdolwaBugBackLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_ROOT" Offset="0x22214" />
+        <Limb Name="gOdolwaBugBackLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_UPPER" Offset="0x22220" />
+        <Limb Name="gOdolwaBugBackLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_LEFT_LEG_LOWER" Offset="0x2222C" />
+        <Limb Name="gOdolwaBugBackRightLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_ROOT" Offset="0x22238" />
+        <Limb Name="gOdolwaBugBackRightLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_UPPER" Offset="0x22244" />
+        <Limb Name="gOdolwaBugBackRightLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_BACK_RIGHT_LEG_LOWER" Offset="0x22250" />
+        <Limb Name="gOdolwaBugFrontLeftLegRootLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_ROOT" Offset="0x2225C" />
+        <Limb Name="gOdolwaBugFrontLeftLegUpperLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_UPPER" Offset="0x22268" />
+        <Limb Name="gOdolwaBugFrontLeftLegLowerLimb" Type="Standard" EnumName="ODOLWA_BUG_LIMB_FRONT_LEFT_LEG_LOWER" Offset="0x22274" />
+        <Skeleton Name="gOdolwaBugSkel" Type="Flex" LimbType="Standard" LimbNone="ODOLWA_BUG_LIMB_NONE" LimbMax="ODOLWA_BUG_LIMB_MAX" EnumName="OdolwaBugLimb" Offset="0x222D0" />
         <Animation Name="object_boss01_Anim_022550" Offset="0x22550" />
     </File>
 </Root>

--- a/assets/xml/objects/object_bsmask.xml
+++ b/assets/xml/objects/object_bsmask.xml
@@ -18,7 +18,7 @@
         <Texture Name="gRemainsTwinmoldSnoutTLUT" OutName="remains_twinmold_snout_tlut" Format="rgba16" Width="4" Height="4" Offset="0x58F0" />
 
         <!-- Boss Remains Textures -->
-        <Texture Name="gRemainsOdolwaHairTex" OutName="remains_odolwa_hair" Format="rgba16" Width="16" Height="16" Offset="0x5910" />
+        <Texture Name="gRemainsOdolwaPlumeTex" OutName="remains_odolwa_plume" Format="rgba16" Width="16" Height="16" Offset="0x5910" />
         <Texture Name="gRemainsOdolwaFaceTex" OutName="remains_odolwa_face" Format="ci4" Width="64" Height="64" Offset="0x5B10" />
         <Texture Name="gRemainsOdolwaEarTex" OutName="remains_odolwa_ear" Format="ci4" Width="64" Height="64" Offset="0x6310" />
         <Texture Name="gRemainsGyorgTwinmoldEyeTex" OutName="remains_gyorg_twinmold_eye" Format="rgba16" Width="32" Height="32" Offset="0x6B10" />

--- a/assets/xml/objects/object_ob.xml
+++ b/assets/xml/objects/object_ob.xml
@@ -3,7 +3,7 @@
     <File Name="object_ob" Segment="6">
     
         <!-- Moonchild Mask DisplayLists -->
-        <DList Name="gMoonChildOdalwasMaskDL" Offset="0x690" />
+        <DList Name="gMoonChildOdolwasMaskDL" Offset="0x690" />
         <DList Name="gMoonChildGyorgsMaskDL" Offset="0x1D80" />
         <DList Name="gMoonChildGohtsMaskDL" Offset="0x3AD0" />
         <DList Name="gMoonChildTwinmoldsMaskDL" Offset="0x5020" />
@@ -18,16 +18,16 @@
         <Texture Name="gMoonChildMajorasMaskSpike4Tex" OutName="moonchild_majoras_mask_spike_4" Format="rgba16" Width="16" Height="16" Offset="0x7DE0" />
         <Texture Name="gMoonChildMajorasMaskBackTex" OutName="moonchild_majoras_mask_back" Format="rgba16" Width="32" Height="32" Offset="0x7FE0" />
         <Texture Name="gMoonChildMajorasMaskEyesTex" OutName="moonchild_majoras_mask_eyes" Format="rgba16" Width="32" Height="32" Offset="0x87E0" />
-        <Texture Name="gMoonChildOdalwasMaskFaceTLUT" OutName="moonchild_odalwas_mask_face_tlut" Format="rgba16" Width="4" Height="4" Offset="0x8FE0" />
-        <Texture Name="gMoonChildOdalwasMaskEarTLUT" OutName="moonchild_odalwas_mask_ear_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9000" />
+        <Texture Name="gMoonChildOdolwasMaskFaceTLUT" OutName="moonchild_odolwas_mask_face_tlut" Format="rgba16" Width="4" Height="4" Offset="0x8FE0" />
+        <Texture Name="gMoonChildOdolwasMaskEarTLUT" OutName="moonchild_odolwas_mask_ear_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9000" />
         <Texture Name="gMoonChildGyorgsMaskSkinTLUT" OutName="moonchild_gyorgs_mask_skin_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9020" />
         <Texture Name="gMoonChildGyorgsMaskMouthTLUT" OutName="moonchild_gyorgs_mask_mouth_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9040" />
         <Texture Name="gMoonChildGyorgsMaskToothHornTLUT" OutName="moonchild_gyorgs_mask_tooth_horn_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9060" />
         <Texture Name="gMoonChildTwinmoldsMaskSkinTLUT" OutName="moonchild_twinmolds_mask_skin_tlut" Format="rgba16" Width="4" Height="4" Offset="0x9080" />
         <Texture Name="gMoonChildTwinmoldsMaskSnoutTLUT" OutName="moonchild_twinmolds_snout_tlut" Format="rgba16" Width="4" Height="4" Offset="0x90A0" />
-        <Texture Name="gMoonChildOdalwasMaskHairTex" OutName="moonchild_odalwas_mask_hair" Format="rgba16" Width="16" Height="16" Offset="0x90C0" />
-        <Texture Name="gMoonChildOdalwasMaskFaceTex" OutName="moonchild_odalwas_mask_face" Format="ci4" Width="64" Height="64" Offset="0x92C0" />
-        <Texture Name="gMoonChildOdalwasMaskEarTex" OutName="moonchild_odalwas_mask_ear" Format="ci4" Width="64" Height="64" Offset="0x9AC0" />
+        <Texture Name="gMoonChildOdolwasMaskPlumeTex" OutName="moonchild_odolwas_mask_plume" Format="rgba16" Width="16" Height="16" Offset="0x90C0" />
+        <Texture Name="gMoonChildOdolwasMaskFaceTex" OutName="moonchild_odolwas_mask_face" Format="ci4" Width="64" Height="64" Offset="0x92C0" />
+        <Texture Name="gMoonChildOdolwasMaskEarTex" OutName="moonchild_odolwas_mask_ear" Format="ci4" Width="64" Height="64" Offset="0x9AC0" />
         <Texture Name="gMoonChildGyorgsTwinmoldsMaskEyeTex" OutName="moonchild_gyorgs_twinmolds_mask_eye" Format="rgba16" Width="32" Height="32" Offset="0xA2C0" />
         <Texture Name="gMoonChildGyorgsMaskSkinTex" OutName="moonchild_gyorgs_mask_skin" Format="ci4" Width="64" Height="64" Offset="0xAAC0" />
         <Texture Name="gMoonChildGyorgsMaskMouthTex" OutName="moonchild_gyorgs_mask_mouth" Format="ci4" Width="64" Height="64" Offset="0xB2C0" />

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -60,7 +60,7 @@ static ColliderCylinderInit sCylinderInit = {
 };
 
 static Gfx* D_8096ABCC[] = {
-    gMoonChildMajorasMaskDL, gMoonChildOdalwasMaskDL,   gMoonChildGohtsMaskDL,
+    gMoonChildMajorasMaskDL, gMoonChildOdolwasMaskDL,   gMoonChildGohtsMaskDL,
     gMoonChildGyorgsMaskDL,  gMoonChildTwinmoldsMaskDL,
 };
 


### PR DESCRIPTION
Had to engage in more speculation than normal on this one in order to guess at the original names, but I think I'm right about the final set of animations just being `jmp_stop` plus a number. There's an array in Boss01's data (`D_809D7CF4` if you're interested) that's just all of those animations in order (minus `jmp_stop02`, which is used for the intro), and the gaps in the animation names perfectly line up if you just keep sequentially counting up.

Since Odolwa has a lot of dancing/hopping animations that are fairly similar, I'll post GIFs of them along with my names; feel free to invent better names based on your own observations:

`gOdolwaReadyAnim`:
![image](https://cdn.discordapp.com/attachments/873211000122384415/1032239317831143505/anim.gif)

`gOdolwaSpinSwordAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196839303-cff31257-0ab7-45a6-8e5e-6a062b7e4caa.gif)

`gOdolwaVerticalHopAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196839434-95a39abf-1f92-43ee-94cb-c558f1014496.gif)

`gOdolwaHipShakeAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196839609-ce474ac3-1de3-4cc5-a071-f3b5bf71bafb.gif)

`gOdolwaUpAndDownDanceAnim`:
![image](https://cdn.discordapp.com/attachments/873211000122384415/1032257194814607390/anim.gif)

`gOdolwaArmSwingDanceAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196839891-8c1ca923-b8fd-40ee-9476-89d80e7ce6b6.gif)

`gOdolwaSideToSideHopAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196840031-0683d896-ee51-446d-8484-657be784f2ba.gif)

`gOdolwaSideToSideDanceAnim`:
![anim](https://cdn.discordapp.com/attachments/873211000122384415/1032435323285798982/anim.gif)

`gOdolwaSpinDanceAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196840264-be3c97cc-e159-4d40-bb8c-d1339048110c.gif)

`gOdolwaJumpDanceAnim`:
![anim](https://user-images.githubusercontent.com/12245827/196840480-65ae52cc-d91e-41aa-9cde-758be64859ce.gif)

