### PR TITLE
Add original asset names to all `object_a*` files

### DIFF
--- a/assets/xml/objects/object_ah.xml
+++ b/assets/xml/objects/object_ah.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_ah" Segment="6">
-        <Animation Name="object_ah_Anim_000968" Offset="0x968" />
-        <Animation Name="object_ah_Anim_000DDC" Offset="0xDDC" />
-        <Animation Name="object_ah_Anim_001860" Offset="0x1860" />
-        <Animation Name="object_ah_Anim_002280" Offset="0x2280" />
+        <Animation Name="object_ah_Anim_000968" Offset="0x968" /> <!-- Original name is "ah_deteike" (probably based on her Japanese dialogue, where she tells Kafei to "get out") -->
+        <Animation Name="object_ah_Anim_000DDC" Offset="0xDDC" /> <!-- Original name is "ah_suwari" ("sitting") -->
+        <Animation Name="object_ah_Anim_001860" Offset="0x1860" /> <!-- Original name is "ah_wait" -->
+        <Animation Name="object_ah_Anim_002280" Offset="0x2280" /> <!-- Original name is "ah_wait2deteike" -->
         <DList Name="object_ah_DL_004A60" Offset="0x4A60" />
         <DList Name="object_ah_DL_004B70" Offset="0x4B70" />
         <DList Name="object_ah_DL_004C80" Offset="0x4C80" />

--- a/assets/xml/objects/object_al.xml
+++ b/assets/xml/objects/object_al.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_al" Segment="6">
-        <Animation Name="object_al_Anim_000C54" Offset="0xC54" />
+        <Animation Name="object_al_Anim_000C54" Offset="0xC54" /> <!-- Original name is "al_suwaruA" ("suwaru" = "to sit") -->
         <DList Name="gMadameAromaRightFootDL" Offset="0x45F0" />
         <DList Name="gMadameAromaLeftFootDL" Offset="0x4738" />
         <DList Name="gMadameAromaLegsDL" Offset="0x4880" />
@@ -66,10 +66,10 @@
         <Limb Name="gMadameAromaLeftFootLimb" Type="Standard" EnumName="MADAME_AROMA_LIMB_LEFT_FOOT" Offset="0xA058" />
         <Limb Name="gMadameAromaRightFootLimb" Type="Standard" EnumName="MADAME_AROMA_LIMB_RIGHT_FOOT" Offset="0xA064" />
         <Skeleton Name="gMadameAromaSkel" Type="Flex" LimbType="Standard" LimbNone="MADAME_AROMA_LIMB_NONE" LimbMax="MADAME_AROMA_LIMB_MAX" EnumName="MadameAromaLimb" Offset="0xA0D8" />
-        <Animation Name="object_al_Anim_00A764" Offset="0xA764" />
-        <Animation Name="object_al_Anim_00ACA0" Offset="0xACA0" />
-        <Animation Name="object_al_Anim_00BCA4" Offset="0xBCA4" />
-        <Animation Name="object_al_Anim_00CA28" Offset="0xCA28" />
-        <Animation Name="object_al_Anim_00DBE0" Offset="0xDBE0" />
+        <Animation Name="object_al_Anim_00A764" Offset="0xA764" /> <!-- Original name is "al_suwaruAtalk" -->
+        <Animation Name="object_al_Anim_00ACA0" Offset="0xACA0" /> <!-- Original name is "al_suwaruB2talk" -->
+        <Animation Name="object_al_Anim_00BCA4" Offset="0xBCA4" /> <!-- Original name is "al_suwaruBarayada" ("arayada" = "Oh no; Oh dear​") -->
+        <Animation Name="object_al_Anim_00CA28" Offset="0xCA28" /> <!-- Original name is "al_suwaruBtalk" -->
+        <Animation Name="object_al_Anim_00DBE0" Offset="0xDBE0" /> <!-- Original name is "al_suwaruBwait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_am.xml
+++ b/assets/xml/objects/object_am.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_am" Segment="6">
         <Collision Name="object_am_Colheader_000118" Offset="0x118" />
-        <Animation Name="gArmosHopAnim" Offset="0x238" />
-        <Animation Name="gArmosPushedBackAnim" Offset="0x33C" />
+        <Animation Name="gArmosHopAnim" Offset="0x238" /> <!-- Original name is "am_jump" -->
+        <Animation Name="gArmosPushedBackAnim" Offset="0x33C" /> <!-- Original name is "am_mamori" ("protection; defense") -->
         <DList Name="object_am_DL_0005D0" Offset="0x5D0" />
         <DList Name="object_am_DL_0007A8" Offset="0x7A8" />
         <DList Name="object_am_DL_0016C8" Offset="0x16C8" />
@@ -35,7 +35,7 @@
         <Limb Name="object_am_Standardlimb_0058FC" Type="Standard" EnumName="OBJECT_AM_LIMB_BASE" Offset="0x58FC" />
         <Limb Name="object_am_Standardlimb_005908" Type="Standard" EnumName="OBJECT_AM_LIMB_0D" Offset="0x5908" />
         <Skeleton Name="object_am_Skel_005948" Type="Normal" LimbType="Standard" LimbNone="OBJECT_AM_LIMB_NONE" LimbMax="OBJECT_AM_LIMB_MAX" EnumName="ObjectAmLimb" Offset="0x5948" />
-        <Animation Name="gArmosTakeDamageAnim" Offset="0x5B3C" />
+        <Animation Name="gArmosTakeDamageAnim" Offset="0x5B3C" /> <!-- Original name is "am_yarare" ("to suffer damage") -->
         <Collision Name="object_am_Colheader_005CF8" Offset="0x5CF8" />
     </File>
 </Root>

--- a/assets/xml/objects/object_an1.xml
+++ b/assets/xml/objects/object_an1.xml
@@ -1,16 +1,16 @@
 ﻿<Root>
     <File Name="object_an1" Segment="6">
-        <Animation Name="object_an1_Anim_001090" Offset="0x1090" />
-        <Animation Name="object_an1_Anim_00144C" Offset="0x144C" />
-        <Animation Name="object_an1_Anim_001E74" Offset="0x1E74" />
-        <Animation Name="object_an1_Anim_0026B4" Offset="0x26B4" />
-        <Animation Name="object_an1_Anim_00341C" Offset="0x341C" />
-        <Animation Name="object_an1_Anim_003EA8" Offset="0x3EA8" />
-        <Animation Name="object_an1_Anim_00544C" Offset="0x544C" />
-        <Animation Name="object_an1_Anim_0065C8" Offset="0x65C8" />
-        <Animation Name="object_an1_Anim_0071E8" Offset="0x71E8" />
-        <Animation Name="object_an1_Anim_007E08" Offset="0x7E08" />
-        <Animation Name="object_an1_Anim_008B6C" Offset="0x8B6C" />
+        <Animation Name="object_an1_Anim_001090" Offset="0x1090" /> <!-- Original name is "an_ajimi" ("tasting; sampling​") -->
+        <Animation Name="object_an1_Anim_00144C" Offset="0x144C" /> <!-- Original name is "an_ajimiend" -->
+        <Animation Name="object_an1_Anim_001E74" Offset="0x1E74" /> <!-- Original name is "an_aogu" ("to look up") -->
+        <Animation Name="object_an1_Anim_0026B4" Offset="0x26B4" /> <!-- Original name is "an_bikkuri" ("to be surprised") -->
+        <Animation Name="object_an1_Anim_00341C" Offset="0x341C" /> <!-- Original name is "an_obonwait" ("obon" = "tray") -->
+        <Animation Name="object_an1_Anim_003EA8" Offset="0x3EA8" /> <!-- Original name is "an_obonwalk" -->
+        <Animation Name="object_an1_Anim_00544C" Offset="0x544C" /> <!-- Original name is "an_ojigit" ("bow; bowing") -->
+        <Animation Name="object_an1_Anim_0065C8" Offset="0x65C8" /> <!-- Original name is "an_ryouri" ("cooking") -->
+        <Animation Name="object_an1_Anim_0071E8" Offset="0x71E8" /> <!-- Original name is "an_suwaru" ("to sit") -->
+        <Animation Name="object_an1_Anim_007E08" Offset="0x7E08" /> <!-- Original name is "an_suzetsubou" ("su" = short for "suwaru", "zetsubou" = "despair; hopelessness​") -->
+        <Animation Name="object_an1_Anim_008B6C" Offset="0x8B6C" /> <!-- Original name is "an_wait" -->
         <DList Name="object_an1_DL_00BC20" Offset="0xBC20" />
         <DList Name="object_an1_DL_00BD20" Offset="0xBD20" />
         <DList Name="object_an1_DL_00BE60" Offset="0xBE60" />
@@ -52,7 +52,7 @@
         <Texture Name="object_an1_Tex_0103A0" OutName="tex_0103A0" Format="ci8" Width="32" Height="32" Offset="0x103A0" />
         <!-- <Blob Name="object_an1_Blob_0107A0" Size="0xA40" Offset="0x107A0" /> -->
         <DList Name="object_an1_DL_0111E0" Offset="0x111E0" />
-        <DList Name="object_an1_DL_0111E8" Offset="0x111E8" />
+        <DList Name="object_an1_DL_0111E8" Offset="0x111E8" /> <!-- Original name is "an_obon_model" -->
         <Texture Name="object_an1_Tex_011928" OutName="tex_011928" Format="i8" Width="32" Height="32" Offset="0x11928" />
         <Texture Name="object_an1_Tex_011D28" OutName="tex_011D28" Format="rgba16" Width="16" Height="16" Offset="0x11D28" />
         <Texture Name="object_an1_Tex_011F28" OutName="tex_011F28" Format="rgba16" Width="16" Height="16" Offset="0x11F28" />
@@ -60,7 +60,7 @@
         <Texture Name="object_an1_Tex_012228" OutName="tex_012228" Format="i4" Width="16" Height="16" Offset="0x12228" />
         <Texture Name="object_an1_Tex_0122A8" OutName="tex_0122A8" Format="i8" Width="16" Height="16" Offset="0x122A8" />
         <!-- <Blob Name="object_an1_Blob_0123A8" Size="0x10" Offset="0x123A8" /> -->
-        <DList Name="object_an1_DL_012478" Offset="0x12478" />
+        <DList Name="object_an1_DL_012478" Offset="0x12478" /> <!-- Original name is "an_hashi_model" ("chopsticks​") -->
         <Limb Name="object_an1_Standardlimb_0124D8" Type="Standard" EnumName="OBJECT_AN1_LIMB_01" Offset="0x124D8" />
         <Limb Name="object_an1_Standardlimb_0124E4" Type="Standard" EnumName="OBJECT_AN1_LIMB_02" Offset="0x124E4" />
         <Limb Name="object_an1_Standardlimb_0124F0" Type="Standard" EnumName="OBJECT_AN1_LIMB_03" Offset="0x124F0" />
@@ -82,7 +82,7 @@
         <Limb Name="object_an1_Standardlimb_0125B0" Type="Standard" EnumName="OBJECT_AN1_LIMB_13" Offset="0x125B0" />
         <Limb Name="object_an1_Standardlimb_0125BC" Type="Standard" EnumName="OBJECT_AN1_LIMB_14" Offset="0x125BC" />
         <Skeleton Name="object_an1_Skel_012618" Type="Flex" LimbType="Standard" LimbNone="OBJECT_AN1_LIMB_NONE" LimbMax="OBJECT_AN1_LIMB_MAX" EnumName="ObjectAn1Limb" Offset="0x12618" />
-        <Animation Name="object_an1_Anim_013048" Offset="0x13048" />
-        <Animation Name="object_an1_Anim_013E1C" Offset="0x13E1C" />
+        <Animation Name="object_an1_Anim_013048" Offset="0x13048" /> <!-- Original name is "an_walk" -->
+        <Animation Name="object_an1_Anim_013E1C" Offset="0x13E1C" /> <!-- Original name is "anj_tetunagu_loop" ("joined hands") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_an2.xml
+++ b/assets/xml/objects/object_an2.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_an2" Segment="6">
         <DList Name="object_an2_DL_000370" Offset="0x370" />
-        <DList Name="object_an2_DL_000378" Offset="0x378" />
+        <DList Name="object_an2_DL_000378" Offset="0x378" /> <!-- Original name is "an_kasa_model" ("umbrella; parasol") -->
         <Texture Name="object_an2_Tex_000578" OutName="tex_000578" Format="i8" Width="16" Height="16" Offset="0x578" />
         <Texture Name="object_an2_Tex_000678" OutName="tex_000678" Format="i8" Width="32" Height="32" Offset="0x678" />
-        <Animation Name="object_an2_Anim_001B80" Offset="0x1B80" />
-        <Animation Name="object_an2_Anim_0028DC" Offset="0x28DC" />
-        <Animation Name="object_an2_Anim_0038A0" Offset="0x38A0" />
-        <Animation Name="object_an2_Anim_0042CC" Offset="0x42CC" />
+        <Animation Name="object_an2_Anim_001B80" Offset="0x1B80" /> <!-- Original name is "an_kasasuwarinaku" ("suwari" = "sitting", "naku" = "to cry; to weep; to sob") -->
+        <Animation Name="object_an2_Anim_0028DC" Offset="0x28DC" /> <!-- Original name is "an_kasawait" -->
+        <Animation Name="object_an2_Anim_0038A0" Offset="0x38A0" /> <!-- Original name is "an_kasawait2suwaru" ("suwaru" = "to sit") -->
+        <Animation Name="object_an2_Anim_0042CC" Offset="0x42CC" /> <!-- Original name is "an_kasawalk" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_an3.xml
+++ b/assets/xml/objects/object_an3.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_an3" Segment="6">
         <DList Name="object_an3_DL_000300" Offset="0x300" />
-        <DList Name="object_an3_DL_000308" Offset="0x308" />
+        <DList Name="object_an3_DL_000308" Offset="0x308" /> <!-- Original name is "an_hoki_model" ("broom") -->
         <Texture Name="object_an3_Tex_0004C8" OutName="tex_0004C8" Format="i8" Width="16" Height="16" Offset="0x4C8" />
         <Texture Name="object_an3_Tex_0005C8" OutName="tex_0005C8" Format="rgba16" Width="8" Height="32" Offset="0x5C8" />
         <Texture Name="object_an3_Tex_0007C8" OutName="tex_0007C8" Format="rgba16" Width="8" Height="8" Offset="0x7C8" />
-        <Animation Name="object_an3_Anim_0012C0" Offset="0x12C0" />
-        <Animation Name="object_an3_Anim_00201C" Offset="0x201C" />
-        <Animation Name="object_an3_Anim_002A4C" Offset="0x2A4C" />
+        <Animation Name="object_an3_Anim_0012C0" Offset="0x12C0" /> <!-- Original name is "an_hokihaku" ("haku" = "to sweep; to brush; to clean​") -->
+        <Animation Name="object_an3_Anim_00201C" Offset="0x201C" /> <!-- Original name is "an_hokiwait" -->
+        <Animation Name="object_an3_Anim_002A4C" Offset="0x2A4C" /> <!-- Original name is "an_hokiwalk" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_an4.xml
+++ b/assets/xml/objects/object_an4.xml
@@ -1,15 +1,15 @@
 ﻿<Root>
     <File Name="object_an4" Segment="6">
-        <Animation Name="object_an4_Anim_00041C" Offset="0x41C" />
-        <Animation Name="object_an4_Anim_0013C8" Offset="0x13C8" />
-        <Animation Name="object_an4_Anim_002550" Offset="0x2550" />
-        <Animation Name="object_an4_Anim_00353C" Offset="0x353C" />
-        <Animation Name="object_an4_Anim_004498" Offset="0x4498" />
-        <Animation Name="object_an4_Anim_004A78" Offset="0x4A78" />
-        <Animation Name="object_an4_Anim_00506C" Offset="0x506C" />
-        <Animation Name="object_an4_Anim_0060B4" Offset="0x60B4" />
-        <Animation Name="object_an4_Anim_006CC0" Offset="0x6CC0" />
-        <Animation Name="object_an4_Anim_007E3C" Offset="0x7E3C" />
-        <Animation Name="object_an4_Anim_0088C0" Offset="0x88C0" />
+        <Animation Name="object_an4_Anim_00041C" Offset="0x41C" /> <!-- Original name is "anj_awase" ("to face; to be opposite (someone)") -->
+        <Animation Name="object_an4_Anim_0013C8" Offset="0x13C8" /> <!-- Original name is "anj_dakiau" ("to embrace each other​") -->
+        <Animation Name="object_an4_Anim_002550" Offset="0x2550" /> <!-- Original name is "anj_dakiau_loop" -->
+        <Animation Name="object_an4_Anim_00353C" Offset="0x353C" /> <!-- Original name is "anj_hanare" ("to be separated; to be apart") -->
+        <Animation Name="object_an4_Anim_004498" Offset="0x4498" /> <!-- Original name is "anj_hanare_loop" -->
+        <Animation Name="object_an4_Anim_004A78" Offset="0x4A78" /> <!-- Original name is "anj_kaoage" ("raising face") -->
+        <Animation Name="object_an4_Anim_00506C" Offset="0x506C" /> <!-- Original name is "anj_kaoage_loop" -->
+        <Animation Name="object_an4_Anim_0060B4" Offset="0x60B4" /> <!-- Original name is "anj_miseau" ("to show each other​") -->
+        <Animation Name="object_an4_Anim_006CC0" Offset="0x6CC0" /> <!-- Original name is "anj_mitume_loop" ("to stare (at); to gaze (at)") -->
+        <Animation Name="object_an4_Anim_007E3C" Offset="0x7E3C" /> <!-- Original name is "anj_omen" ("mask") -->
+        <Animation Name="object_an4_Anim_0088C0" Offset="0x88C0" /> <!-- Original name is "anj_omen_loop" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_and.xml
+++ b/assets/xml/objects/object_and.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_and" Segment="6">
-        <Animation Name="object_and_Anim_0000C8" Offset="0xC8" />
+        <Animation Name="object_and_Anim_0000C8" Offset="0xC8" /> <!-- Original name is "and_test" -->
         <DList Name="object_and_DL_004670" Offset="0x4670" />
         <DList Name="object_and_DL_004708" Offset="0x4708" />
         <DList Name="object_and_DL_0047F0" Offset="0x47F0" />
@@ -68,12 +68,12 @@
         <Limb Name="object_and_Standardlimb_00B304" Type="Standard" EnumName="OBJECT_AND_LIMB_18" Offset="0xB304" />
         <Limb Name="object_and_Standardlimb_00B310" Type="Standard" EnumName="OBJECT_AND_LIMB_19" Offset="0xB310" />
         <Skeleton Name="object_and_Skel_00B380" Type="Flex" LimbType="Standard" LimbNone="OBJECT_AND_LIMB_NONE" LimbMax="OBJECT_AND_LIMB_MAX" EnumName="ObjectAndLimb" Offset="0xB380" />
-        <Animation Name="object_and_Anim_00DA58" Offset="0xDA58" />
-        <Animation Name="object_and_Anim_00EE00" Offset="0xEE00" />
-        <Animation Name="object_and_Anim_00F6C4" Offset="0xF6C4" />
-        <Animation Name="object_and_Anim_00FE64" Offset="0xFE64" />
-        <Animation Name="object_and_Anim_01067C" Offset="0x1067C" />
-        <Animation Name="object_and_Anim_011AFC" Offset="0x11AFC" />
-        <Animation Name="object_and_Anim_0122D0" Offset="0x122D0" />
+        <Animation Name="object_and_Anim_00DA58" Offset="0xDA58" /> <!-- Original name is "wa_aruku" ("walk") -->
+        <Animation Name="object_and_Anim_00EE00" Offset="0xEE00" /> <!-- Original name is "wa_hidari" ("left; left hand side") -->
+        <Animation Name="object_and_Anim_00F6C4" Offset="0xF6C4" /> <!-- Original name is "wa_hidari_loop" -->
+        <Animation Name="object_and_Anim_00FE64" Offset="0xFE64" /> <!-- Original name is "wa_kaoage" ("raising face") -->
+        <Animation Name="object_and_Anim_01067C" Offset="0x1067C" /> <!-- Original name is "wa_kaoage_loop" -->
+        <Animation Name="object_and_Anim_011AFC" Offset="0x11AFC" /> <!-- Original name is "wa_kaoaruki" (probably a combination of "kaoage" and "aruki") -->
+        <Animation Name="object_and_Anim_0122D0" Offset="0x122D0" /> <!-- Original name is "wa_utumuki_loop" ("looking down") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_ani.xml
+++ b/assets/xml/objects/object_ani.xml
@@ -1,11 +1,11 @@
 ﻿<Root>
     <File Name="object_ani" Segment="6">
-        <Animation Name="gAniTreeHangLosingBalanceAnim" Offset="0x7FC" />
-        <Animation Name="gAniFallOverHoldingFootAnim" Offset="0xC14" />
-        <Animation Name="gAniHoldingFootWrithingInPainAnim" Offset="0x11CC" />
-        <Animation Name="gAniUnusedSidesteppingAnim" Offset="0x1584" />
-        <Animation Name="gAniTreeHangingAnim" Offset="0x1D48" />
-        <Animation Name="gAniTreeHangingReachAnim" Offset="0x27A0" />
+        <Animation Name="gAniTreeHangLosingBalanceAnim" Offset="0x7FC" /> <!-- Original name is "Ani_guratsuku" ("to be unsteady; to reel; to shake​") -->
+        <Animation Name="gAniFallOverHoldingFootAnim" Offset="0xC14" /> <!-- Original name is "Ani_itameru" ("to hurt; to injure; to cause pain") -->
+        <Animation Name="gAniHoldingFootWrithingInPainAnim" Offset="0x11CC" /> <!-- Original name is "Ani_itameru2" -->
+        <Animation Name="gAniUnusedSidesteppingAnim" Offset="0x1584" /> <!-- Original name is "Ani_kaniark" ("kami" = "crab", "ark" = probably short for "aruki", which is "to walk") -->
+        <Animation Name="gAniTreeHangingAnim" Offset="0x1D48" /> <!-- Original name is "Ani_ki01" ("tree") -->
+        <Animation Name="gAniTreeHangingReachAnim" Offset="0x27A0" /> <!-- Original name is "Ani_ki02" -->
         <Limb Name="gAniPelvisLimb" Type="Standard" EnumName="ANI_LIMB_PELVIS" Offset="0x27B0" />
         <Limb Name="gAniLeftThighLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_THIGH" Offset="0x27BC" />
         <Limb Name="gAniLeftCalfLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_CALF" Offset="0x27C8" />
@@ -53,15 +53,15 @@
         <DList Name="gAniHeadDL" Offset="0x7B58" />
 
         <!-- Only the first half of the animation is used by EnAni when knocked out of tree -->
-        <Animation Name="gAniLandingThenStandingUpAnim" Offset="0x9220" />
+        <Animation Name="gAniLandingThenStandingUpAnim" Offset="0x9220" /> <!-- Original name is "Ani_oriru" ("to go down; to come down​") -->
         <!-- used by EnOssan -->
-        <Animation Name="gAniHoldUpHandAnim" Offset="0x9734" />
-        <Animation Name="gAniStandingNormalAnim" Offset="0x9D34" />
-        <Animation Name="gAniHandBehindHeadApologyAnim" Offset="0xA460" />
+        <Animation Name="gAniHoldUpHandAnim" Offset="0x9734" /> <!-- Original name is "Ani_talk" -->
+        <Animation Name="gAniStandingNormalAnim" Offset="0x9D34" /> <!-- Original name is "Ani_wait" -->
+        <Animation Name="gAniHandBehindHeadApologyAnim" Offset="0xA460" /> <!-- Original name is "Ani_zorawait" -->
         <!-- left over from OOT firetemple deathmountain cutscene, unused in MM -->
-        <Animation Name="gAniKnockBackAnim" Offset="0xA978" />
-        <Animation Name="gAniKnockBackGettingUpAnim" Offset="0xB2B0" />
+        <Animation Name="gAniKnockBackAnim" Offset="0xA978" /> <!-- Original name is "ani_bikkuri" ("to be amazed; to be frightened") -->
+        <Animation Name="gAniKnockBackGettingUpAnim" Offset="0xB2B0" /> <!-- Original name is "ani_nanyarona" -->
         <!-- left over from OOT sitting on roof, unused in MM -->
-        <Animation Name="gAniSittingBackAnim" Offset="0xB8AC" />
+        <Animation Name="gAniSittingBackAnim" Offset="0xB8AC" /> <!-- Original name is "ani_suwari_wait" ("sitting") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_astr_obj.xml
+++ b/assets/xml/objects/object_astr_obj.xml
@@ -5,9 +5,9 @@
         <Texture Name="object_astr_obj_Tex_000820" OutName="tex_000820" Format="ci4" Width="64" Height="64" Offset="0x820" />
         <Texture Name="object_astr_obj_Tex_001020" OutName="tex_001020" Format="ia8" Width="64" Height="64" Offset="0x1020" />
         <DList Name="object_astr_obj_DL_002170" Offset="0x2170" />
-        <DList Name="object_astr_obj_DL_002178" Offset="0x2178" />
+        <DList Name="object_astr_obj_DL_002178" Offset="0x2178" /> <!-- Original name is "z2_tennmondai_hahen_model" ("tennmondai" = "astronomical observatory​", "hahen" = "fragment") -->
         <DList Name="object_astr_obj_DL_0022E0" Offset="0x22E0" />
-        <DList Name="object_astr_obj_DL_002380" Offset="0x2380" />
+        <DList Name="object_astr_obj_DL_002380" Offset="0x2380" /> <!-- Original name is "z2_tennmondai_kabe_model" ("tennmondai" = "astronomical observatory​", "kabe" = "wall") -->
         <Collision Name="object_astr_obj_Colheader_002498" Offset="0x2498" />
     </File>
 </Root>


### PR DESCRIPTION
For a long time, most people have just asked me what the original asset names from MM3D are, rather than finding the names themselves. This is, overall, fine, but it has a "bus factor" of 1; if I'm not around, you can't get the names from me. So I've decided to just put the original asset names in for *every* object so that people don't have to rely on me.

This PR does every single object whose name starts with `object_a*`. Thanks, as always, to @emilybrooks for patiently answering my Japanese questions.