### PR TITLE
Add original asset names for all `object_b*` and `object_c*` files (and some related stuff)

### DIFF
--- a/assets/xml/objects/object_bai.xml
+++ b/assets/xml/objects/object_bai.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_bai" Segment="6">
-        <Animation Name="object_bai_Anim_0008B4" Offset="0x8B4" />
-        <Animation Name="object_bai_Anim_0011C0" Offset="0x11C0" />
+        <Animation Name="object_bai_Anim_0008B4" Offset="0x8B4" /> <!-- Original name is "bai_talk01" -->
+        <Animation Name="object_bai_Anim_0011C0" Offset="0x11C0" /> <!-- Original name is "bai_wait01" -->
         <DList Name="object_bai_DL_0049C0" Offset="0x49C0" />
         <DList Name="object_bai_DL_004BA8" Offset="0x4BA8" />
         <DList Name="object_bai_DL_004EC0" Offset="0x4EC0" />
@@ -48,6 +48,6 @@
         <Limb Name="object_bai_Standardlimb_0078A4" Type="Standard" EnumName="OBJECT_BAI_LIMB_12" Offset="0x78A4" />
         <Limb Name="object_bai_Standardlimb_0078B0" Type="Standard" EnumName="OBJECT_BAI_LIMB_13" Offset="0x78B0" />
         <Skeleton Name="object_bai_Skel_007908" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BAI_LIMB_NONE" LimbMax="OBJECT_BAI_LIMB_MAX" EnumName="ObjectBaiLimb" Offset="0x7908" />
-        <Animation Name="object_bai_Anim_008198" Offset="0x8198" />
+        <Animation Name="object_bai_Anim_008198" Offset="0x8198" /> <!-- Original name is "bai_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_bal.xml
+++ b/assets/xml/objects/object_bal.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_bal" Segment="6">
-        <Animation Name="object_bal_Anim_0005FC" Offset="0x5FC" />
-        <Animation Name="object_bal_Anim_000840" Offset="0x840" />
-        <Animation Name="object_bal_Anim_000C78" Offset="0xC78" />
-        <Animation Name="object_bal_Anim_001804" Offset="0x1804" />
+        <Animation Name="object_bal_Anim_0005FC" Offset="0x5FC" /> <!-- Original name is "bal_fly" -->
+        <Animation Name="object_bal_Anim_000840" Offset="0x840" /> <!-- Original name is "bal_fly2" -->
+        <Animation Name="object_bal_Anim_000C78" Offset="0xC78" /> <!-- Original name is "bal_kaiten" ("rotation; revolution; turn; spin​") -->
+        <Animation Name="object_bal_Anim_001804" Offset="0x1804" /> <!-- Original name is "bal_kami" ("paper​") -->
         <DList Name="object_bal_DL_004000" Offset="0x4000" />
         <DList Name="object_bal_DL_004108" Offset="0x4108" />
         <DList Name="object_bal_DL_0041E8" Offset="0x41E8" />
@@ -69,13 +69,13 @@
         <Limb Name="object_bal_Standardlimb_00A638" Type="Standard" EnumName="OBJECT_BAL_LIMB_1F" Offset="0xA638" />
         <Limb Name="object_bal_Standardlimb_00A644" Type="Standard" EnumName="OBJECT_BAL_LIMB_20" Offset="0xA644" />
         <Skeleton Name="object_bal_Skel_00A6D0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BAL_LIMB_NONE" LimbMax="OBJECT_BAL_LIMB_MAX" EnumName="ObjectBalLimb" Offset="0xA6D0" />
-        <Animation Name="object_bal_Anim_00A7DC" Offset="0xA7DC" />
-        <Animation Name="object_bal_Anim_00B1E8" Offset="0xB1E8" />
-        <Animation Name="object_bal_Anim_00B604" Offset="0xB604" />
-        <Animation Name="object_bal_Anim_00C498" Offset="0xC498" />
-        <Animation Name="object_bal_Anim_00C8D8" Offset="0xC8D8" />
-        <Animation Name="object_bal_Anim_00CB78" Offset="0xCB78" />
-        <Animation Name="object_bal_Anim_00D530" Offset="0xD530" />
-        <DList Name="object_bal_DL_00D5A0" Offset="0xD5A0" />
+        <Animation Name="object_bal_Anim_00A7DC" Offset="0xA7DC" /> <!-- Original name is "bal_put" -->
+        <Animation Name="object_bal_Anim_00B1E8" Offset="0xB1E8" /> <!-- Original name is "bal_talk" -->
+        <Animation Name="object_bal_Anim_00B604" Offset="0xB604" /> <!-- Original name is "bal_talk2" -->
+        <Animation Name="object_bal_Anim_00C498" Offset="0xC498" /> <!-- Original name is "bal_talk3" -->
+        <Animation Name="object_bal_Anim_00C8D8" Offset="0xC8D8" /> <!-- Original name is "bal_talk4" -->
+        <Animation Name="object_bal_Anim_00CB78" Offset="0xCB78" /> <!-- Original name is "bal_tereru" ("to be shy; to be bashful") -->
+        <Animation Name="object_bal_Anim_00D530" Offset="0xD530" /> <!-- Original name is "bal_wait" -->
+        <DList Name="object_bal_DL_00D5A0" Offset="0xD5A0" /> <!-- Original name is "bal_cube32_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_bba.xml
+++ b/assets/xml/objects/object_bba.xml
@@ -18,10 +18,10 @@
         <DList Name="gBbaFeetDL" Offset="0x4180" />
 
         <!-- Animations -->
-        <Animation Name="gBbaSwayAnim" Offset="0x4910" />
-        <Animation Name="gBbaKnockedOverAnim" Offset="0x5154" />
-        <Animation Name="gBbaLyingDownAnim" Offset="0x58B8" />
-        <Animation Name="gBbaIdleHoldingBagAnim" Offset="0x5DC4" />
+        <Animation Name="gBbaSwayAnim" Offset="0x4910" /> <!-- Original name is "sb_ending" -->
+        <Animation Name="gBbaKnockedOverAnim" Offset="0x5154" /> <!-- Original name is "sb_taore" ("to fall (over, down); to collapse; to take a fall") -->
+        <Animation Name="gBbaLyingDownAnim" Offset="0x58B8" /> <!-- Original name is "sb_taorewait" -->
+        <Animation Name="gBbaIdleHoldingBagAnim" Offset="0x5DC4" /> <!-- Original name is "sb_wait01" -->
 
         <!-- Skeleton -->
         <Limb Name="gBbaUpperLegsLimb" Type="Standard" EnumName="BBA_LIMB_UPPER_LEGS" Offset="0x5DE0" />
@@ -44,8 +44,8 @@
         <Skeleton Name="gBbaSkel" Type="Flex" LimbType="Standard" LimbNone="BBA_LIMB_NONE" LimbMax="BBA_LIMB_MAX" EnumName="BbaLimb" Offset="0x5EF0" />
 
          <!-- Animations -->
-        <Animation Name="gBbaIdleAnim" Offset="0x6550" />
-        <Animation Name="gBbaWalkingHoldingBagAnim" Offset="0x6B10" />
+        <Animation Name="gBbaIdleAnim" Offset="0x6550" /> <!-- Original name is "sb_wait02" -->
+        <Animation Name="gBbaWalkingHoldingBagAnim" Offset="0x6B10" /> <!-- Original name is "sb_walk01" -->
 
         <!-- TLUT -->
         <Texture Name="gBbaTLUT" OutName="bba_tlut" Format="rgba16" Width="16" Height="16" Offset="0x6B20" />

--- a/assets/xml/objects/object_bee.xml
+++ b/assets/xml/objects/object_bee.xml
@@ -2,7 +2,7 @@
     <!-- Object for Bee -->
     <File Name="object_bee" Segment="6">
         <!-- Bee Animations -->
-        <Animation Name="gBeeFlyingAnim" Offset="0x5C" />
+        <Animation Name="gBeeFlyingAnim" Offset="0x5C" /> <!-- Original name is "bee_fyl" [sic] -->
 
         <!-- Bee Limb DisplayLists -->
         <DList Name="gBeeBodyDL" Offset="0x550" />

--- a/assets/xml/objects/object_bg.xml
+++ b/assets/xml/objects/object_bg.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_bg" Segment="6">
-        <Animation Name="object_bg_Anim_000968" Offset="0x968" />
-        <Animation Name="object_bg_Anim_000A00" Offset="0xA00" />
-        <Animation Name="object_bg_Anim_001384" Offset="0x1384" />
+        <Animation Name="object_bg_Anim_000968" Offset="0x968" /> <!-- Original name is "bg_asking" -->
+        <Animation Name="object_bg_Anim_000A00" Offset="0xA00" /> <!-- Original name is "bg_getup" -->
+        <Animation Name="object_bg_Anim_001384" Offset="0x1384" /> <!-- Original name is "bg_kunekune" ("wiggling; waving; swaying; twisting and turning​") -->
         <DList Name="object_bg_DL_003F50" Offset="0x3F50" />
         <DList Name="object_bg_DL_004558" Offset="0x4558" />
         <DList Name="object_bg_DL_004768" Offset="0x4768" />
@@ -52,11 +52,11 @@
         <Limb Name="object_bg_Standardlimb_008F54" Type="Standard" EnumName="OBJECT_BG_1_LIMB_16" Offset="0x8F54" />
         <Limb Name="object_bg_Standardlimb_008F60" Type="Standard" EnumName="OBJECT_BG_1_LIMB_17" Offset="0x8F60" />
         <Skeleton Name="object_bg_Skel_008FC8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BG_1_LIMB_NONE" LimbMax="OBJECT_BG_1_LIMB_MAX" EnumName="ObjectBg1Limb" Offset="0x8FC8" />
-        <Animation Name="object_bg_Anim_009890" Offset="0x9890" />
-        <Animation Name="object_bg_Anim_009F20" Offset="0x9F20" />
-        <Animation Name="object_bg_Anim_00A280" Offset="0xA280" />
-        <Animation Name="object_bg_Anim_00AD98" Offset="0xAD98" />
-        <Animation Name="object_bg_Anim_00B19C" Offset="0xB19C" />
+        <Animation Name="object_bg_Anim_009890" Offset="0x9890" /> <!-- Original name is "bg_newwait" -->
+        <Animation Name="object_bg_Anim_009F20" Offset="0x9F20" /> <!-- Original name is "bg_sleeping" -->
+        <Animation Name="object_bg_Anim_00A280" Offset="0xA280" /> <!-- Original name is "bg_tokune" (probably the English word "to" and "kunekune") -->
+        <Animation Name="object_bg_Anim_00AD98" Offset="0xAD98" /> <!-- Original name is "bg_up" -->
+        <Animation Name="object_bg_Anim_00B19C" Offset="0xB19C" /> <!-- Original name is "bg_wait" -->
         <DList Name="object_bg_DL_00D5E0" Offset="0xD5E0" />
         <DList Name="object_bg_DL_00D780" Offset="0xD780" />
         <DList Name="object_bg_DL_00DB38" Offset="0xDB38" />

--- a/assets/xml/objects/object_bh.xml
+++ b/assets/xml/objects/object_bh.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_bh" Segment="6">
-        <Animation Name="gBhFlyingAnim" Offset="0x74" />
+        <Animation Name="gBhFlyingAnim" Offset="0x74" /> <!-- Original name is "bh_fly" -->
         <DList Name="gBhBodyDL" Offset="0x2B0" />
         <DList Name="gBhRightWingToEdgeDL" Offset="0x3A0" />
         <DList Name="gBhRightWingToBodyDL" Offset="0x450" />

--- a/assets/xml/objects/object_big_fwall.xml
+++ b/assets/xml/objects/object_big_fwall.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_big_fwall" Segment="6">
         <Texture Name="object_big_fwall_Tex_000000" OutName="tex_000000" Format="i8" Width="32" Height="64" Offset="0x0" />
-        <DList Name="object_big_fwall_DL_0009A0" Offset="0x9A0" />
+        <DList Name="object_big_fwall_DL_0009A0" Offset="0x9A0" /> <!-- Original name is "big_firewall_modelT" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_bigicicle.xml
+++ b/assets/xml/objects/object_bigicicle.xml
@@ -2,11 +2,11 @@
     <File Name="object_bigicicle" Segment="6">
         <Texture Name="object_bigicicle_Tex_000000" OutName="tex_000000" Format="i4" Width="64" Height="64" Offset="0x0" />
         <Texture Name="object_bigicicle_Tex_000800" OutName="tex_000800" Format="i4" Width="16" Height="16" Offset="0x800" />
-        <DList Name="object_bigicicle_DL_0009B0" Offset="0x9B0" />
-        <DList Name="object_bigicicle_DL_000B20" Offset="0xB20" />
-        <DList Name="object_bigicicle_DL_000D60" Offset="0xD60" />
-        <DList Name="object_bigicicle_DL_000F40" Offset="0xF40" />
-        <DList Name="object_bigicicle_DL_0014F0" Offset="0x14F0" />
+        <DList Name="object_bigicicle_DL_0009B0" Offset="0x9B0" /> <!-- Original name is "trr_hahen_modelT" -->
+        <DList Name="object_bigicicle_DL_000B20" Offset="0xB20" /> <!-- Original name is "trr_hibi01_modelT" ("crack; fissure") -->
+        <DList Name="object_bigicicle_DL_000D60" Offset="0xD60" /> <!-- Original name is "trr_hibi02_modelT" -->
+        <DList Name="object_bigicicle_DL_000F40" Offset="0xF40" /> <!-- Original name is "trr_hibi03_modelT" -->
+        <DList Name="object_bigicicle_DL_0014F0" Offset="0x14F0" /> <!-- Original name is "trr_inside_modelT" -->
         <TextureAnimation Name="object_bigicicle_Matanimheader_001678" Offset="0x1678" />
         <DList Name="object_bigicicle_DL_001D10" Offset="0x1D10" />
         <DList Name="object_bigicicle_DL_002530" Offset="0x2530" />

--- a/assets/xml/objects/object_bigokuta.xml
+++ b/assets/xml/objects/object_bigokuta.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_bigokuta" Segment="6">
-        <Animation Name="gBigOctoRiseOutOfWaterAnim" Offset="0x444" />
-        <Animation Name="gBigOctoDeathAnim" Offset="0xA74" />
-        <Animation Name="gBigOctoHitAnim" Offset="0xD1C" />
-        <Animation Name="gBigOctoIdleAnim" Offset="0x14B8" />
-        <Animation Name="gBigOctoWalkAnim" Offset="0x1CA4" />
+        <Animation Name="gBigOctoRiseOutOfWaterAnim" Offset="0x444" /> <!-- Original name is "ocd_damagejump" -->
+        <Animation Name="gBigOctoDeathAnim" Offset="0xA74" /> <!-- Original name is "ocd_dead" -->
+        <Animation Name="gBigOctoHitAnim" Offset="0xD1C" /> <!-- Original name is "ocd_stop" -->
+        <Animation Name="gBigOctoIdleAnim" Offset="0x14B8" /> <!-- Original name is "ocd_wait" -->
+        <Animation Name="gBigOctoWalkAnim" Offset="0x1CA4" /> <!-- Original name is "ocd_walk" -->
         <DList Name="gBigOctoBodyDL" Offset="0x4090" />
         <DList Name="gBigOctoCenterSnoutDL" Offset="0x4158" />
         <DList Name="gBigOctoLeftSnoutDL" Offset="0x42A8" />

--- a/assets/xml/objects/object_bigpo.xml
+++ b/assets/xml/objects/object_bigpo.xml
@@ -1,14 +1,14 @@
 ﻿<Root>
     <!-- Assets for Big Poes -->
     <File Name="object_bigpo" Segment="6">
-        <Animation Name="gBigpoSwingLampAttackAnim" Offset="0x158" />
-        <Animation Name="gBigpoShockAnim" Offset="0x454" />
-        <Animation Name="gBigpoBackpeddleAnim" Offset="0x608" />
-        <Animation Name="gBigpoFloatAnim" Offset="0x924" />
-        <Animation Name="gBigpoAwakenSpawnAnim" Offset="0xF9C" />
-        <Animation Name="gBigpoAwakenStretchAnim" Offset="0x1360" />
+        <Animation Name="gBigpoSwingLampAttackAnim" Offset="0x158" /> <!-- Original name is "pog_atack" -->
+        <Animation Name="gBigpoShockAnim" Offset="0x454" /> <!-- Original name is "pog_damage" -->
+        <Animation Name="gBigpoBackpeddleAnim" Offset="0x608" /> <!-- Original name is "pog_escape" -->
+        <Animation Name="gBigpoFloatAnim" Offset="0x924" /> <!-- Original name is "pog_fly" -->
+        <Animation Name="gBigpoAwakenSpawnAnim" Offset="0xF9C" /> <!-- Original name is "pog_start" -->
+        <Animation Name="gBigpoAwakenStretchAnim" Offset="0x1360" /> <!-- Original name is "pog_wait" -->
         <Texture Name="gBigpoSoulFace" OutName="bigpo_soul_face" Format="i8" Width="32" Height="64" Offset="0x1370" />
-        <DList Name="gBigpoDrawSoulDL" Offset="0x1BB0" />
+        <DList Name="gBigpoDrawSoulDL" Offset="0x1BB0" /> <!-- Original name is "bigpo_soul_modelT" -->
         <Texture Name="gBigpoNecklaceSkullHalfTex" OutName="bigpo_skull_necklace" Format="rgba16" Width="16" Height="16" Offset="0x1C70" />
         <Texture Name="gBigpoLanternGlassTex" OutName="bigpo_lantern_glass" Format="rgba16" Width="16" Height="16" Offset="0x1E70" />
         <Texture Name="gBigpoTornRobeTex" OutName="bigpo_torn_robe" Format="rgba16" Width="32" Height="32" Offset="0x2070" />
@@ -19,8 +19,8 @@
         <Texture Name="gBigpoGlowingEyeTex" OutName="bigpo_glowing_eye" Format="rgba16" Width="16" Height="16" Offset="0x2DF0" />
         <!-- <Blob Name="object_bigpo_Blob_003200" Size="0x350" Offset="0x3200" /> -->
         <!-- <Blob Name="object_bigpo_Blob_003790" Size="0x370" Offset="0x3790" /> -->
-        <DList Name="gBigpoDrawLanternFallingDL" Offset="0x41A0" />
-        <DList Name="gBigpoDrawLanternMainDL" Offset="0x42C8" />
+        <DList Name="gBigpoDrawLanternFallingDL" Offset="0x41A0" /> <!-- Original name is "pog_kantera_hahen_model" ("kantera" = "lantern", "hahen" = "fragment") -->
+        <DList Name="gBigpoDrawLanternMainDL" Offset="0x42C8" /> <!-- Original name is "poh_big_cantera" -->
         <DList Name="gBigpoDrawLanternPurpleTopDL" Offset="0x43F8" />
         <DList Name="gBigpoDrawHandDL" Offset="0x4488" />
         <DList Name="gBigpoDrawSmallArmDL" Offset="0x4538" />

--- a/assets/xml/objects/object_bigslime.xml
+++ b/assets/xml/objects/object_bigslime.xml
@@ -1,30 +1,30 @@
 ﻿<Root>
     <!-- Assets for the Gekko, Minislime, and Bigslime -->
     <File Name="object_bigslime" Segment="6">
-        <Animation Name="gGekkoFullFistPumpAnim" Offset="0x994" />
-        <Animation Name="gGekkoSurpriseJumpAnim" Offset="0x10F4" />
-        <Animation Name="gGekkoCallAnim" Offset="0x1B08" />
-        <Animation Name="gGekkoCrawlAnim" Offset="0x1E14" />
-        <Animation Name="gGekkoFallInAirAnim" Offset="0x1F20" />
-        <Animation Name="gGekkoFloorIdleAnim" Offset="0x225C" />
-        <Animation Name="gGekkoDamagedAnim" Offset="0x276C" />
-        <Animation Name="gGekkoJumpUpAnim" Offset="0x2E0C" />
-        <Animation Name="gGekkoRecoverAnim" Offset="0x30E4" />
-        <Animation Name="gGekkoJabPunchAnim" Offset="0x347C" />
-        <Animation Name="gGekkoJumpForwardAnim" Offset="0x39C4" />
-        <Animation Name="gGekkoKickAnim" Offset="0x3F28" />
-        <Animation Name="gGekkoFallOnGroundAnim" Offset="0x4298" />
-        <Animation Name="gGekkoStandingIdleAnim" Offset="0x4680" />
-        <Animation Name="gGekkoJumpOnSnapperAnim" Offset="0x4894" />
-        <Animation Name="gGekkoQuickFistPumpAnim" Offset="0x4D50" />
-        <Animation Name="gGekkoSqueezeAnim" Offset="0x50B8" />
-        <Animation Name="gGekkoLandOnSnapperAnim" Offset="0x52EC" />
-        <Animation Name="gGekkoWiggleAnim" Offset="0x5694" />
-        <Animation Name="gGekkoKnockbackAnim" Offset="0x5D54" />
-        <Animation Name="gGekkoLookAroundAnim" Offset="0x66B4" />
-        <Animation Name="gGekkoNervousIdleAnim" Offset="0x69FC" />
-        <Animation Name="gGekkoHookPunchAnim" Offset="0x70C4" />
-        <Animation Name="gGekkoSwimForwardAnim" Offset="0x7790" />
+        <Animation Name="gGekkoFullFistPumpAnim" Offset="0x994" /> <!-- Original name is "bsl_aisatsuDEMO" ("greeting") -->
+        <Animation Name="gGekkoSurpriseJumpAnim" Offset="0x10F4" /> <!-- Original name is "bsl_bikkuri" ("to be surprised; to be frightened") -->
+        <Animation Name="gGekkoCallAnim" Offset="0x1B08" /> <!-- Original name is "bsl_callDEMO" -->
+        <Animation Name="gGekkoCrawlAnim" Offset="0x1E14" /> <!-- Original name is "bsl_clim" -->
+        <Animation Name="gGekkoFallInAirAnim" Offset="0x1F20" /> <!-- Original name is "bsl_climdamage" -->
+        <Animation Name="gGekkoFloorIdleAnim" Offset="0x225C" /> <!-- Original name is "bsl_climwait" -->
+        <Animation Name="gGekkoDamagedAnim" Offset="0x276C" /> <!-- Original name is "bsl_damage" -->
+        <Animation Name="gGekkoJumpUpAnim" Offset="0x2E0C" /> <!-- Original name is "bsl_flyjump" -->
+        <Animation Name="gGekkoRecoverAnim" Offset="0x30E4" /> <!-- Original name is "bsl_hukki" ("return; comeback") -->
+        <Animation Name="gGekkoJabPunchAnim" Offset="0x347C" /> <!-- Original name is "bsl_jabA" -->
+        <Animation Name="gGekkoJumpForwardAnim" Offset="0x39C4" /> <!-- Original name is "bsl_jump" -->
+        <Animation Name="gGekkoKickAnim" Offset="0x3F28" /> <!-- Original name is "bsl_kickA" -->
+        <Animation Name="gGekkoFallOnGroundAnim" Offset="0x4298" /> <!-- Original name is "bsl_rakka" ("fall; drop; descent") -->
+        <Animation Name="gGekkoStandingIdleAnim" Offset="0x4680" /> <!-- Original name is "bsl_ride" -->
+        <Animation Name="gGekkoJumpOnSnapperAnim" Offset="0x4894" /> <!-- Orignal name is "bsl_ridefuse" -->
+        <Animation Name="gGekkoQuickFistPumpAnim" Offset="0x4D50" /> <!-- Original name is "bsl_ridegogo" -->
+        <Animation Name="gGekkoSqueezeAnim" Offset="0x50B8" /> <!-- Original name is "bsl_ridejump" -->
+        <Animation Name="gGekkoLandOnSnapperAnim" Offset="0x52EC" /> <!-- Original name is "bsl_rideokiru" ("okiru" = "to get up; to rise") -->
+        <Animation Name="gGekkoWiggleAnim" Offset="0x5694" /> <!-- Original name is "bsl_riderakka" -->
+        <Animation Name="gGekkoKnockbackAnim" Offset="0x5D54" /> <!-- Original name is "bsl_standdamage" -->
+        <Animation Name="gGekkoLookAroundAnim" Offset="0x66B4" /> <!-- Original name is "bsl_standview" -->
+        <Animation Name="gGekkoNervousIdleAnim" Offset="0x69FC" /> <!-- Original name is "bsl_standwalk" -->
+        <Animation Name="gGekkoHookPunchAnim" Offset="0x70C4" /> <!-- Original name is "bsl_strertA" (maybe a severe mispelling of "straight", as in "straight punch"?) -->
+        <Animation Name="gGekkoSwimForwardAnim" Offset="0x7790" /> <!-- Original name is "bsl_swim" -->
 
         <DList Name="gGekkoRightEyeDL" Offset="0x9D90" />
         <DList Name="gGekkoLeftEyeDL" Offset="0x9FF0" />
@@ -90,12 +90,12 @@
         <Limb Name="gGekkoRightEyeLimb" Type="Standard" EnumName="GEKKO_LIMB_RIGHT_EYE" Offset="0xDF30" />
         <Skeleton Name="gGekkoSkel" Type="Flex" LimbType="Standard" LimbNone="GEKKO_LIMB_NONE" LimbMax="GEKKO_LIMB_MAX" EnumName="GekkoLimb" Offset="0xDF98" />
 
-        <Animation Name="gGekkoWindupPunchAnim" Offset="0xF048" />
-        <Animation Name="gGekkoSwimUpAnim" Offset="0xF3F0" />
-        <Animation Name="gGekkoBoxingStanceAnim" Offset="0xF990" />
+        <Animation Name="gGekkoWindupPunchAnim" Offset="0xF048" /> <!-- Original name is "bsl_upperA" -->
+        <Animation Name="gGekkoSwimUpAnim" Offset="0xF3F0" /> <!-- Original name is "bsl_upswim" -->
+        <Animation Name="gGekkoBoxingStanceAnim" Offset="0xF990" /> <!-- Original name is "bsl_waitA" -->
         
-        <DList Name="gBigslimeBubbleDL" Offset="0xF9D0" />
-        <DList Name="gBigslimeShockwaveDL" Offset="0xFB40" />
+        <DList Name="gBigslimeBubbleDL" Offset="0xF9D0" /> <!-- Original name is "bsl_bable_model" -->
+        <DList Name="gBigslimeShockwaveDL" Offset="0xFB40" /> <!-- Original name is "bsl_coolwave_modelT" -->
         <Texture Name="gBigslimeShockwave1Tex" OutName="bigslime_shockwave_1" Format="i4" Width="32" Height="64" Offset="0xFC28" />
         <Blob Name="object_bigslime_zeroes_Blob_010028" Size="0x400" Offset="0x10028" />
         <Texture Name="gBigslimeShockwave2Tex" OutName="bigslime_shockwave_2" Format="i4" Width="16" Height="16" Offset="0x10428" />
@@ -109,15 +109,15 @@
         <DList Name="gBigslimeFrozenMaterialDL" Offset="0x10B80" />
 
         <TextureAnimation Name="gBigslimeFrozenTexAnim" Offset="0x10C48" />
-        <DList Name="gMinislimeFrozenDL" Offset="0x10DB0" />
+        <DList Name="gMinislimeFrozenDL" Offset="0x10DB0" /> <!-- Original name is "bsl_icepart_model" (the original asset exists in MM3D, along with an updated asset named "muddjelly_icepart") -->
         <TextureAnimation Name="gMinislimeFrozenTexAnim" Offset="0x10EC8" />
 
         <DList Name="gBigslimeIceShardDL" Offset="0x10F20" />
-        <DList Name="gBigslimeIceShardVtxDL" Offset="0x10FE0" />
+        <DList Name="gBigslimeIceShardVtxDL" Offset="0x10FE0" /> <!-- Original name is probably "bsl_icepeace_model" (called "muddjelly_icepeace" in MM3D) -->
         <TextureAnimation Name="gBigslimeIceShardTexAnim" Offset="0x11008" />
         
-        <DList Name="gBigslimeShadowDL" Offset="0x11050" />
-        <DList Name="gMinislimeNormalDL" Offset="0x113B0" />
+        <DList Name="gBigslimeShadowDL" Offset="0x11050" /> <!-- Original name is "bsl_kage_model" ("shadow; silhouette") -->
+        <DList Name="gMinislimeNormalDL" Offset="0x113B0" /> <!-- Original name is probably "bsl_smallgel_model" (called "muddjelly_smallgel" in MM3D) -->
 
         <Texture Name="gBigslimeBubbleTex" OutName="bigslime_bubble" Format="i4" Width="16" Height="16" Offset="0x11580" />
         <Texture Name="gBigslimeShadowTex" OutName="bigslime_shadow" Format="i8" Width="32" Height="32" Offset="0x11600" />

--- a/assets/xml/objects/object_bji.xml
+++ b/assets/xml/objects/object_bji.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_bji" Segment="6">
-        <Animation Name="object_bji_Anim_00066C" Offset="0x66C" />
-        <Animation Name="object_bji_Anim_000AB0" Offset="0xAB0" />
-        <Animation Name="object_bji_Anim_000FDC" Offset="0xFDC" />
+        <Animation Name="object_bji_Anim_00066C" Offset="0x66C" /> <!-- Original name is "Bji_fushigigaru" ("to be curious; to wonder; to marvel​") -->
+        <Animation Name="object_bji_Anim_000AB0" Offset="0xAB0" /> <!-- Original name is "Bji_talk" -->
+        <Animation Name="object_bji_Anim_000FDC" Offset="0xFDC" /> <!-- Original name is "Bji_wait01" -->
         
         <DList Name="gShikashiHeadDL" Offset="0x23A0" />
         <DList Name="gShikashiRightHandDL" Offset="0x28D8" />
@@ -59,6 +59,6 @@
         <Limb Name="gShikashiHeadLimb" Type="Standard" EnumName="SHIKASHI_LIMB_HEAD" Offset="0x5744" />
         <Skeleton Name="gShikashiSkel" Type="Flex" LimbType="Standard" LimbNone="SHIKASHI_LIMB_NONE" LimbMax="SHIKASHI_LIMB_MAX" EnumName="ShikashiLimb" Offset="0x578C" />
 
-        <Animation Name="object_bji_Anim_005B58" Offset="0x5B58" />
+        <Animation Name="object_bji_Anim_005B58" Offset="0x5B58" /> <!-- Original name is "Bji_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_bjt.xml
+++ b/assets/xml/objects/object_bjt.xml
@@ -1,13 +1,12 @@
 ﻿<Root>
+    <!-- ??? (Hand in Toilet) assets -->
     <File Name="object_bjt" Segment="6">
-        <!-- ??? (Hand in Toilet) assets -->
-
         <!-- ??? animations -->
-        <Animation Name="gToiletHandWaggingFingerAnim" Offset="0xFC" /><!-- Original name: bjt_chigau ("different/wrong") -->
-        <Animation Name="gToiletHandFistAnim" Offset="0x218" /><!-- Original name: bjt_guu ("fist") -->
-        <Animation Name="gToiletHandThumbsUpAnim" Offset="0x3A8" /><!-- Original name: bjt_ok (thumbs up, correct) -->
-        <Animation Name="gToiletHandOpenHandAnim" Offset="0x564" /><!-- Original name: bjt_par ("paper"? Open hand, palm up) -->
-        <Animation Name="gToiletHandWaitingAnim" Offset="0x7B8" /><!-- Original name: bjt_wait (flopping around grasping at air) -->
+        <Animation Name="gToiletHandWaggingFingerAnim" Offset="0xFC" /><!-- Original name is "bjt_chigau" ("different/wrong") -->
+        <Animation Name="gToiletHandFistAnim" Offset="0x218" /><!-- Original name is "bjt_guu" ("fist") -->
+        <Animation Name="gToiletHandThumbsUpAnim" Offset="0x3A8" /><!-- Original name is "bjt_ok" (thumbs up, correct) -->
+        <Animation Name="gToiletHandOpenHandAnim" Offset="0x564" /><!-- Original name is "bjt_par" ("paper"? Open hand, palm up) -->
+        <Animation Name="gToiletHandWaitingAnim" Offset="0x7B8" /><!-- Original name is "bjt_wait" (flopping around grasping at air) -->
 
         <!-- ??? model -->
         <DList Name="gToiletHandIndexFingerDL" Offset="0x1570" />

--- a/assets/xml/objects/object_boj.xml
+++ b/assets/xml/objects/object_boj.xml
@@ -1,20 +1,20 @@
 ﻿<Root>
     <File Name="object_boj" Segment="6">
-        <Animation Name="object_boj_Anim_00041C" Offset="0x41C" />
-        <Animation Name="object_boj_Anim_0004D0" Offset="0x4D0" />
-        <Animation Name="object_boj_Anim_00071C" Offset="0x71C" />
-        <Animation Name="object_boj_Anim_0008C0" Offset="0x8C0" /> <!-- object_ginko_floorsmacking_anim -->
-        <Animation Name="object_boj_Anim_000AC4" Offset="0xAC4" /> <!-- object_ginko_advertising_anim -->
-        <Animation Name="object_boj_Anim_001494" Offset="0x1494" />
-        <Animation Name="object_boj_Anim_001908" Offset="0x1908" />
-        <Animation Name="object_boj_Anim_002734" Offset="0x2734" />
-        <Animation Name="object_boj_Anim_0033B0" Offset="0x33B0" />
-        <Animation Name="object_boj_Anim_004078" Offset="0x4078" />
-        <Animation Name="object_boj_Anim_0043F0" Offset="0x43F0" /> <!-- object_ginko_sitting_anim -->
-        <Animation Name="object_boj_Anim_004A7C" Offset="0x4A7C" /> <!-- object_ginko_amazed_anim -->
-        <Animation Name="object_boj_Anim_004F40" Offset="0x4F40" /> <!-- object_ginko_stamp_reach_anim -->
-        <Animation Name="object_boj_Anim_005CE4" Offset="0x5CE4" />
-        <Animation Name="object_boj_Anim_005D9C" Offset="0x5D9C" />
+        <Animation Name="object_boj_Anim_00041C" Offset="0x41C" /> <!-- Original name is "Boj2_17" -->
+        <Animation Name="object_boj_Anim_0004D0" Offset="0x4D0" /> <!-- Original name is "Boj2_19" -->
+        <Animation Name="object_boj_Anim_00071C" Offset="0x71C" /> <!-- Original name is "Boj2_5" -->
+        <Animation Name="object_boj_Anim_0008C0" Offset="0x8C0" /> <!-- Original name is "Boj2_9" -->
+        <Animation Name="object_boj_Anim_000AC4" Offset="0xAC4" /> <!-- Original name is "Boj2_9_2" -->
+        <Animation Name="object_boj_Anim_001494" Offset="0x1494" /> <!-- Original name is "Boj_13" -->
+        <Animation Name="object_boj_Anim_001908" Offset="0x1908" /> <!-- Original name is "Boj_14" -->
+        <Animation Name="object_boj_Anim_002734" Offset="0x2734" /> <!-- Original name is "Boj_card_aka_talk" ("aka" = "red") -->
+        <Animation Name="object_boj_Anim_0033B0" Offset="0x33B0" /> <!-- Original name is "Boj_card_aka_wait" -->
+        <Animation Name="object_boj_Anim_004078" Offset="0x4078" /> <!-- Original name is "Boj_card_ao_wait" ("ao" = "blue") -->
+        <Animation Name="object_boj_Anim_0043F0" Offset="0x43F0" /> <!-- Original name is "Boj_ginkowait" ("ginko" = "bank") -->
+        <Animation Name="object_boj_Anim_004A7C" Offset="0x4A7C" /> <!-- Original name is "Boj_ginkoyobi" ("yobi" = "call; invitation") -->
+        <Animation Name="object_boj_Anim_004F40" Offset="0x4F40" /> <!-- Original name is "Boj_hanko" ("seal; stamp") -->
+        <Animation Name="object_boj_Anim_005CE4" Offset="0x5CE4" /> <!-- Original name is "Boj_juggling" -->
+        <Animation Name="object_boj_Anim_005D9C" Offset="0x5D9C" /> <!-- Original name is "Boj_matsu" ("to wait​") -->
         <Texture Name="object_boj_TLUT_005DB0" OutName="tlut_005DB0" Format="rgba16" Width="16" Height="16" Offset="0x5DB0" />
         <Texture Name="object_boj_Tex_005FB0" OutName="tex_005FB0" Format="ci8" Width="8" Height="16" Offset="0x5FB0" />
         <Texture Name="object_boj_Tex_006030" OutName="tex_006030" Format="ci8" Width="8" Height="8" Offset="0x6030" />
@@ -58,7 +58,7 @@
         <DList Name="object_boj_DL_00BA28" Offset="0xBA28" />
         <DList Name="object_boj_DL_00BA30" Offset="0xBA30" />
         <Texture Name="object_boj_Tex_00BB88" OutName="tex_00BB88" Format="i8" Width="16" Height="16" Offset="0xBB88" />
-        <DList Name="object_boj_DL_00BCC8" Offset="0xBCC8" />
+        <DList Name="object_boj_DL_00BCC8" Offset="0xBCC8" /> <!-- Original name is "jug_ball_model" -->
         <Texture Name="object_boj_Tex_00BD50" OutName="tex_00BD50" Format="i8" Width="32" Height="32" Offset="0xBD50" />
         <Limb Name="object_boj_Standardlimb_00C150" Type="Standard" EnumName="OBJECT_BOJ_LIMB_01" Offset="0xC150" />
         <Limb Name="object_boj_Standardlimb_00C15C" Type="Standard" EnumName="OBJECT_BOJ_LIMB_02" Offset="0xC15C" />
@@ -76,18 +76,18 @@
         <Limb Name="object_boj_Standardlimb_00C1EC" Type="Standard" EnumName="OBJECT_BOJ_LIMB_0E" Offset="0xC1EC" />
         <Limb Name="object_boj_Standardlimb_00C1F8" Type="Standard" EnumName="OBJECT_BOJ_LIMB_0F" Offset="0xC1F8" />
         <Skeleton Name="object_boj_Skel_00C240" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BOJ_LIMB_NONE" LimbMax="OBJECT_BOJ_LIMB_MAX" EnumName="ObjectBojLimb" Offset="0xC240" /> <!-- object_ginko_skeleton -->
-        <Animation Name="object_boj_Anim_00DED8" Offset="0xDED8" />
-        <Animation Name="object_boj_Anim_00F920" Offset="0xF920" />
-        <Animation Name="object_boj_Anim_00FC1C" Offset="0xFC1C" />
-        <Animation Name="object_boj_Anim_00FEE4" Offset="0xFEE4" />
-        <Animation Name="object_boj_Anim_010330" Offset="0x10330" />
-        <Animation Name="object_boj_Anim_010BDC" Offset="0x10BDC" />
-        <Animation Name="object_boj_Anim_01139C" Offset="0x1139C" />
-        <Animation Name="object_boj_Anim_011C38" Offset="0x11C38" />
-        <Animation Name="object_boj_Anim_011F84" Offset="0x11F84" />
-        <Animation Name="object_boj_Anim_0128F4" Offset="0x128F4" />
-        <Animation Name="object_boj_Anim_012E84" Offset="0x12E84" />
-        <DList Name="gBombShopBagDL" Offset="0x13380" />
+        <Animation Name="object_boj_Anim_00DED8" Offset="0xDED8" /> <!-- Original name is "boj_door1" -->
+        <Animation Name="object_boj_Anim_00F920" Offset="0xF920" /> <!-- Original name is "boj_door2" -->
+        <Animation Name="object_boj_Anim_00FC1C" Offset="0xFC1C" /> <!-- Original name is "boj_walk1" -->
+        <Animation Name="object_boj_Anim_00FEE4" Offset="0xFEE4" /> <!-- Original name is "boj_walk2" -->
+        <Animation Name="object_boj_Anim_010330" Offset="0x10330" /> <!-- Original name is "boj_walk3" -->
+        <Animation Name="object_boj_Anim_010BDC" Offset="0x10BDC" /> <!-- Original name is "scm_harau" ("to drive away") -->
+        <Animation Name="object_boj_Anim_01139C" Offset="0x1139C" /> <!-- Original name is "scm_niwait" -->
+        <Animation Name="object_boj_Anim_011C38" Offset="0x11C38" /> <!-- Original name is "scm_odoroku" ("surprise") -->
+        <Animation Name="object_boj_Anim_011F84" Offset="0x11F84" /> <!-- Original name is "scm_teburarun" ("tebura" = "empty-handed​") -->
+        <Animation Name="object_boj_Anim_0128F4" Offset="0x128F4" /> <!-- Original name is "scm_teburawait" -->
+        <Animation Name="object_boj_Anim_012E84" Offset="0x12E84" /> <!-- Original name is "scm_yarare" ("to suffer damage") -->
+        <DList Name="gBombShopBagDL" Offset="0x13380" /> <!-- Original name is "seb_model" -->
         <Texture Name="gBombShopBagTLUT" OutName="bomb_shop_bag_tlut" Format="rgba16" Width="16" Height="16" Offset="0x134C0" />
         <Texture Name="gBombShopBagTex" OutName="bomb_shop_bag" Format="ci8" Width="16" Height="16" Offset="0x136C0" />
     </File>

--- a/assets/xml/objects/object_bombf.xml
+++ b/assets/xml/objects/object_bombf.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_bombf" Segment="6">
-        <DList Name="object_bombf_DL_000340" Offset="0x340" />
-        <DList Name="object_bombf_DL_000408" Offset="0x408" />
-        <DList Name="object_bombf_DL_000530" Offset="0x530" />
+        <DList Name="object_bombf_DL_000340" Offset="0x340" /> <!-- Original name is "bm_leaf_model" -->
+        <DList Name="object_bombf_DL_000408" Offset="0x408" /> <!-- Original name is "bm_flower_model" -->
+        <DList Name="object_bombf_DL_000530" Offset="0x530" /> <!-- Original name is "bm_leaf2_model" -->
         <Texture Name="object_bombf_Tex_0005D8" OutName="tex_0005D8" Format="rgba16" Width="32" Height="32" Offset="0x5D8" />
         <Texture Name="object_bombf_Tex_000DD8" OutName="tex_000DD8" Format="rgba16" Width="16" Height="32" Offset="0xDD8" />
         <Texture Name="object_bombf_Tex_0011D8" OutName="tex_0011D8" Format="ia16" Width="32" Height="32" Offset="0x11D8" />

--- a/assets/xml/objects/object_bombiwa.xml
+++ b/assets/xml/objects/object_bombiwa.xml
@@ -2,26 +2,26 @@
     <File Name="object_bombiwa" Segment="6">
         <Texture Name="object_bombiwa_TLUT_000000" OutName="tlut_000000" Format="rgba16" Width="4" Height="4" Offset="0x0" />
         <Texture Name="object_bombiwa_Tex_000020" OutName="tex_000020" Format="ci4" Width="64" Height="64" Offset="0x20" />
-        <DList Name="object_bombiwa_DL_0009E0" Offset="0x9E0" />
+        <DList Name="object_bombiwa_DL_0009E0" Offset="0x9E0" /> <!-- Original name is "obj_18b_stone_model" -->
         <DList Name="object_bombiwa_DL_000AF0" Offset="0xAF0" />
         <Texture Name="object_bombiwa_Tex_000C00" OutName="tex_000C00" Format="i4" Width="64" Height="64" Offset="0xC00" />
-        <DList Name="object_bombiwa_DL_001700" Offset="0x1700" />
+        <DList Name="object_bombiwa_DL_001700" Offset="0x1700" /> <!-- Original name is "obj_bombstone_model" -->
         <DList Name="object_bombiwa_DL_001800" Offset="0x1800" />
         <DList Name="object_bombiwa_DL_001820" Offset="0x1820" />
-        <DList Name="object_bombiwa_DL_001990" Offset="0x1990" />
+        <DList Name="object_bombiwa_DL_001990" Offset="0x1990" /> <!-- Original name is "g5_model" -->
         <Texture Name="object_bombiwa_Tex_001A70" OutName="tex_001A70" Format="rgba16" Width="32" Height="32" Offset="0x1A70" />
         <Texture Name="object_bombiwa_Tex_002270" OutName="tex_002270" Format="i4" Width="64" Height="64" Offset="0x2270" />
-        <DList Name="object_bombiwa_DL_002F60" Offset="0x2F60" />
+        <DList Name="object_bombiwa_DL_002F60" Offset="0x2F60" /> <!-- Original name is "g2_model" -->
         <DList Name="object_bombiwa_DL_003110" Offset="0x3110" />
         <Texture Name="object_bombiwa_Tex_0031C0" OutName="tex_0031C0" Format="ia8" Width="16" Height="16" Offset="0x31C0" />
         <Texture Name="object_bombiwa_Tex_0032C0" OutName="tex_0032C0" Format="rgba16" Width="32" Height="32" Offset="0x32C0" />
         <Texture Name="object_bombiwa_Tex_003AC0" OutName="tex_003AC0" Format="i4" Width="64" Height="64" Offset="0x3AC0" />
-        <DList Name="object_bombiwa_DL_004560" Offset="0x4560" />
+        <DList Name="object_bombiwa_DL_004560" Offset="0x4560" /> <!-- Original name is "g4_model" -->
         <DList Name="object_bombiwa_DL_004688" Offset="0x4688" />
         <Texture Name="object_bombiwa_Tex_004730" OutName="tex_004730" Format="ia8" Width="16" Height="16" Offset="0x4730" />
         <Texture Name="object_bombiwa_Tex_004830" OutName="tex_004830" Format="rgba16" Width="32" Height="32" Offset="0x4830" />
         <Texture Name="object_bombiwa_Tex_005030" OutName="tex_005030" Format="i4" Width="64" Height="64" Offset="0x5030" />
-        <DList Name="object_bombiwa_DL_005990" Offset="0x5990" />
+        <DList Name="object_bombiwa_DL_005990" Offset="0x5990" /> <!-- Original name is "hahen_model" -->
         <Texture Name="object_bombiwa_Tex_005A70" OutName="tex_005A70" Format="rgba16" Width="32" Height="32" Offset="0x5A70" />
         <Texture Name="object_bombiwa_Tex_006270" OutName="tex_006270" Format="i4" Width="64" Height="64" Offset="0x6270" />
     </File>

--- a/assets/xml/objects/object_boss05.xml
+++ b/assets/xml/objects/object_boss05.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_boss05" Segment="6">
-        <Animation Name="object_boss05_Anim_0006A4" Offset="0x6A4" />
-        <Animation Name="object_boss05_Anim_000A5C" Offset="0xA5C" />
+        <Animation Name="object_boss05_Anim_0006A4" Offset="0x6A4" /> <!-- Original name is "wdb_atackH" -->
+        <Animation Name="object_boss05_Anim_000A5C" Offset="0xA5C" /> <!-- Original name is "wdb_atackwalkH" -->
         <Animation Name="object_boss05_Anim_000ABC" Offset="0xABC" />
         <DList Name="object_boss05_DL_0011C0" Offset="0x11C0" />
         <DList Name="object_boss05_DL_001288" Offset="0x1288" />
@@ -25,9 +25,9 @@
         <Limb Name="object_boss05_Standardlimb_0024A4" Type="Standard" EnumName="OBJECT_BOSS05_1_LIMB_08" Offset="0x24A4" />
         <Limb Name="object_boss05_Standardlimb_0024B0" Type="Standard" EnumName="OBJECT_BOSS05_1_LIMB_09" Offset="0x24B0" />
         <Skeleton Name="object_boss05_Skel_0024E0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BOSS05_1_LIMB_NONE" LimbMax="OBJECT_BOSS05_1_LIMB_MAX" EnumName="ObjectBoss051Limb" Offset="0x24E0" />
-        <Animation Name="object_boss05_Anim_002F0C" Offset="0x2F0C" />
-        <Animation Name="object_boss05_Anim_003448" Offset="0x3448" />
-        <Animation Name="object_boss05_Anim_003500" Offset="0x3500" />
+        <Animation Name="object_boss05_Anim_002F0C" Offset="0x2F0C" /> <!-- Original name is "wdb_damageH" -->
+        <Animation Name="object_boss05_Anim_003448" Offset="0x3448" /> <!-- Original name is "wdb_hakkenH" ("detection") -->
+        <Animation Name="object_boss05_Anim_003500" Offset="0x3500" /> <!-- Original name is "wdb_head" -->
         <DList Name="object_boss05_DL_004620" Offset="0x4620" />
         <DList Name="object_boss05_DL_0046C8" Offset="0x46C8" />
         <DList Name="object_boss05_DL_004788" Offset="0x4788" />
@@ -73,9 +73,9 @@
         <Limb Name="object_boss05_Standardlimb_006314" Type="Standard" EnumName="OBJECT_BOSS05_2_LIMB_12" Offset="0x6314" />
         <Limb Name="object_boss05_Standardlimb_006320" Type="Standard" EnumName="OBJECT_BOSS05_2_LIMB_13" Offset="0x6320" />
         <Skeleton Name="object_boss05_Skel_006378" Type="Flex" LimbType="Standard" LimbNone="OBJECT_BOSS05_2_LIMB_NONE" LimbMax="OBJECT_BOSS05_2_LIMB_MAX" EnumName="ObjectBoss052Limb" Offset="0x6378" />
-        <Animation Name="object_boss05_Anim_006484" Offset="0x6484" />
-        <Animation Name="object_boss05_Anim_006E50" Offset="0x6E50" />
-        <Animation Name="object_boss05_Anim_007488" Offset="0x7488" />
-        <Animation Name="object_boss05_Anim_007908" Offset="0x7908" />
+        <Animation Name="object_boss05_Anim_006484" Offset="0x6484" /> <!-- Original name is "wdb_pakupaku" ("repeatedly opening and closing (one's mouth)") -->
+        <Animation Name="object_boss05_Anim_006E50" Offset="0x6E50" /> <!-- Original name is "wdb_startH" -->
+        <Animation Name="object_boss05_Anim_007488" Offset="0x7488" /> <!-- Original name is "wdb_waitH" -->
+        <Animation Name="object_boss05_Anim_007908" Offset="0x7908" /> <!-- Original name is "wdb_walkH" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_botihasira.xml
+++ b/assets/xml/objects/object_botihasira.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_botihasira" Segment="6">
-        <DList Name="object_botihasira_DL_0004A0" Offset="0x4A0" />
+        <DList Name="object_botihasira_DL_0004A0" Offset="0x4A0" /> <!-- Original name is "z2_botihasira_model" ("boti" = "graveyard", "hasira" = "post") -->
         <DList Name="object_botihasira_DL_000628" Offset="0x628" />
         <DList Name="object_botihasira_DL_000638" Offset="0x638" />
         <Texture Name="object_botihasira_Tex_000648" OutName="tex_000648" Format="rgba16" Width="32" Height="64" Offset="0x648" />

--- a/assets/xml/objects/object_box.xml
+++ b/assets/xml/objects/object_box.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_box" Segment="6">
-        <Animation Name="gBoxBigChestOpenChildAnim" Offset="0x128" />
-        <Animation Name="gBoxBigChestOpenAdultAnim" Offset="0x24C" />
+        <Animation Name="gBoxBigChestOpenChildAnim" Offset="0x128" /> <!-- Original name is "cdemo_box_boxA" -->
+        <Animation Name="gBoxBigChestOpenAdultAnim" Offset="0x24C" /> <!-- Original name is "demo_box_boxA" -->
         <Blob Name="object_box_zeroes_unk_0000025C" Size="0xF4" Offset="0x25C" />
-        <Animation Name="gBoxChestOpenAnim" Offset="0x43C" />
+        <Animation Name="gBoxChestOpenAnim" Offset="0x43C" /> <!-- Original name is "demo_box_boxB" -->
         <Blob Name="object_box_zeroes_unk_0000044C" Size="0x64" Offset="0x44C" />
         <DList Name="gBoxChestBaseDL" Offset="0x6F0" />
         <DList Name="gBoxChestBaseGildedDL" Offset="0xA50" />
@@ -22,8 +22,8 @@
         <Limb Name="object_box_Standardlimb_006678" Type="Standard" EnumName="OBJECT_BOX_CHEST_LIMB_03" Offset="0x6678" />
         <Limb Name="object_box_Standardlimb_006684" Type="Standard" EnumName="OBJECT_BOX_CHEST_LIMB_04" Offset="0x6684" />
         <Skeleton Name="gBoxChestSkel" Type="Normal" LimbType="Standard" LimbNone="OBJECT_BOX_CHEST_LIMB_NONE" LimbMax="OBJECT_BOX_CHEST_LIMB_MAX" EnumName="ObjectBoxChestLimb" Offset="0x66A0" />
-        <CurveAnimation Name="gBoxLightAdultCurveAnim" SkelOffset="0x7D78" Offset="0x6A20"/>
-        <CurveAnimation Name="gBoxLightChildCurveAnim" SkelOffset="0x7D78" Offset="0x6E30"/>
+        <CurveAnimation Name="gBoxLightAdultCurveAnim" SkelOffset="0x7D78" Offset="0x6A20"/> <!-- Original name is "demo_tre_lgt_c_fcurve_data" -->
+        <CurveAnimation Name="gBoxLightChildCurveAnim" SkelOffset="0x7D78" Offset="0x6E30"/> <!-- Original name is "demo_tre_lgt_fcurve_data" -->
         <Texture Name="gBoxLightTex" OutName="box_light_tex" Format="i8" Width="64" Height="32" Offset="0x6E40" />
         <DList Name="object_box_DL_007890" Offset="0x7890" />
         <DList Name="object_box_DL_007978" Offset="0x7978" />
@@ -45,8 +45,8 @@
         <Limb Name="object_box_Curvelimb_007D28" Type="Curve" EnumName="OBJECT_BOX_LIGHT_LIMB_13" Offset="0x7D28" />
         <Limb Name="object_box_Curvelimb_007D34" Type="Curve" EnumName="OBJECT_BOX_LIGHT_LIMB_14" Offset="0x7D34" />
         <Skeleton Name="gBoxLightCurveSkel" Type="Curve" LimbType="Curve" LimbNone="OBJECT_BOX_LIGHT_LIMB_NONE" LimbMax="OBJECT_BOX_LIGHT_LIMB_MAX" EnumName="ObjectBoxLightLimb" Offset="0x7D78" />
-        <Animation Name="gBoxBigChestOpenGoronAnim" Offset="0x7E54" />
-        <Animation Name="gBoxBigChestOpenDekuAnim" Offset="0x7F30" />
+        <Animation Name="gBoxBigChestOpenGoronAnim" Offset="0x7E54" /> <!-- Original name is "pg_Tbox" -->
+        <Animation Name="gBoxBigChestOpenDekuAnim" Offset="0x7F30" /> <!-- Original name is "pn_Tbox" -->
         <Blob Name="object_box_zeroes_unk_00007F40" Size="0xA0" Offset="0x7F40" />
         <Collision Name="gBoxChestCol" Offset="0x80E8" />
     </File>

--- a/assets/xml/objects/object_bsb.xml
+++ b/assets/xml/objects/object_bsb.xml
@@ -1,27 +1,27 @@
 ﻿<Root>
     <File Name="object_bsb" Segment="6">
-        <Animation Name="object_bsb_Anim_000400" Offset="0x400" />
-        <Animation Name="object_bsb_Anim_000C50" Offset="0xC50" />
-        <Animation Name="object_bsb_Anim_000FF0" Offset="0xFF0" />
-        <Animation Name="object_bsb_Anim_001390" Offset="0x1390" />
-        <Animation Name="object_bsb_Anim_001CD8" Offset="0x1CD8" />
-        <Animation Name="object_bsb_Anim_001F90" Offset="0x1F90" />
-        <Animation Name="object_bsb_Anim_002590" Offset="0x2590" />
-        <Animation Name="object_bsb_Anim_002AF4" Offset="0x2AF4" />
-        <Animation Name="object_bsb_Anim_003238" Offset="0x3238" />
-        <Animation Name="object_bsb_Anim_003E1C" Offset="0x3E1C" />
-        <Animation Name="object_bsb_Anim_004208" Offset="0x4208" />
-        <Animation Name="object_bsb_Anim_0043A4" Offset="0x43A4" />
-        <Animation Name="object_bsb_Anim_004510" Offset="0x4510" />
-        <Animation Name="object_bsb_Anim_004894" Offset="0x4894" />
-        <Animation Name="object_bsb_Anim_004E2C" Offset="0x4E2C" />
-        <Animation Name="object_bsb_Anim_005440" Offset="0x5440" />
-        <Animation Name="object_bsb_Anim_00606C" Offset="0x606C" />
-        <Animation Name="object_bsb_Anim_0065D8" Offset="0x65D8" />
-        <Animation Name="object_bsb_Anim_006C48" Offset="0x6C48" />
-        <Animation Name="object_bsb_Anim_007120" Offset="0x7120" />
-        <Animation Name="object_bsb_Anim_007B18" Offset="0x7B18" />
-        <Animation Name="object_bsb_Anim_0086BC" Offset="0x86BC" />
+        <Animation Name="object_bsb_Anim_000400" Offset="0x400" /> <!-- Original name is "bsb_aita" ("Ouch!") -->
+        <Animation Name="object_bsb_Anim_000C50" Offset="0xC50" /> <!-- Original name is "bsb_atack" -->
+        <Animation Name="object_bsb_Anim_000FF0" Offset="0xFF0" /> <!-- Original name is "bsb_battlewalk" -->
+        <Animation Name="object_bsb_Anim_001390" Offset="0x1390" /> <!-- Original name is "bsb_damage" -->
+        <Animation Name="object_bsb_Anim_001CD8" Offset="0x1CD8" /> <!-- Original name is "bsb_demo_wait" -->
+        <Animation Name="object_bsb_Anim_001F90" Offset="0x1F90" /> <!-- Original name is "bsb_don" (onomatopoeic for "bang; bam; boom; thud") -->
+        <Animation Name="object_bsb_Anim_002590" Offset="0x2590" /> <!-- Original name is "bsb_dosuni" -->
+        <Animation Name="object_bsb_Anim_002AF4" Offset="0x2AF4" /> <!-- Original name is "bsb_down" -->
+        <Animation Name="object_bsb_Anim_003238" Offset="0x3238" /> <!-- Original name is "bsb_furi_wait" -->
+        <Animation Name="object_bsb_Anim_003E1C" Offset="0x3E1C" /> <!-- Original name is "bsb_furimuki" ("to turn around") -->
+        <Animation Name="object_bsb_Anim_004208" Offset="0x4208" /> <!-- Original name is "bsb_jidanda" ("to stamp one's feet (in frustration, impatience, etc.)") -->
+        <Animation Name="object_bsb_Anim_0043A4" Offset="0x43A4" /> <!-- Original name is "bsb_jump" -->
+        <Animation Name="object_bsb_Anim_004510" Offset="0x4510" /> <!-- Original name is "bsb_jumpTOdon" -->
+        <Animation Name="object_bsb_Anim_004894" Offset="0x4894" /> <!-- Original name is "bsb_kei_wait" -->
+        <Animation Name="object_bsb_Anim_004E2C" Offset="0x4E2C" /> <!-- Original name is "bsb_keirei" ("salute") -->
+        <Animation Name="object_bsb_Anim_005440" Offset="0x5440" /> <!-- Original name is "bsb_kiwo_wait" -->
+        <Animation Name="object_bsb_Anim_00606C" Offset="0x606C" /> <!-- Original name is "bsb_kiwotuke" ("standing at attention​") -->
+        <Animation Name="object_bsb_Anim_0065D8" Offset="0x65D8" /> <!-- Original name is "bsb_kyorokyoro" (onomatopoeic for "looking around restlessly") -->
+        <Animation Name="object_bsb_Anim_006C48" Offset="0x6C48" /> <!-- Original name is "bsb_laugh" -->
+        <Animation Name="object_bsb_Anim_007120" Offset="0x7120" /> <!-- Original name is "bsb_matarei" -->
+        <Animation Name="object_bsb_Anim_007B18" Offset="0x7B18" /> <!-- Original name is "bsb_rajio" -->
+        <Animation Name="object_bsb_Anim_0086BC" Offset="0x86BC" /> <!-- Original name is "bsb_start" -->
         <DList Name="object_bsb_DL_00A010" Offset="0xA010" />
         <DList Name="object_bsb_DL_00A0D8" Offset="0xA0D8" />
         <DList Name="object_bsb_DL_00A188" Offset="0xA188" />
@@ -73,8 +73,8 @@
         <Limb Name="object_bsb_Standardlimb_00C378" Type="Standard" EnumName="OBJECT_BSB_LIMB_13" Offset="0xC378" />
         <Limb Name="object_bsb_Standardlimb_00C384" Type="Standard" EnumName="OBJECT_BSB_LIMB_14" Offset="0xC384" />
         <Skeleton Name="object_bsb_Skel_00C3E0" Type="Normal" LimbType="Standard" LimbNone="OBJECT_BSB_LIMB_NONE" LimbMax="OBJECT_BSB_LIMB_MAX" EnumName="ObjectBsbLimb" Offset="0xC3E0" />
-        <Animation Name="object_bsb_Anim_00C790" Offset="0xC790" />
-        <Animation Name="object_bsb_Anim_00CD88" Offset="0xCD88" />
-        <Animation Name="object_bsb_Anim_00D3CC" Offset="0xD3CC" />
+        <Animation Name="object_bsb_Anim_00C790" Offset="0xC790" /> <!-- Original name is "bsb_tatsu" ("to stand; to rise; to stand up​") -->
+        <Animation Name="object_bsb_Anim_00CD88" Offset="0xCD88" /> <!-- Original name is "bsb_walk" -->
+        <Animation Name="object_bsb_Anim_00D3CC" Offset="0xD3CC" /> <!-- Original name is "bsb_yareyare" ("oh!; ah!; oh dear!; good grief!; dear me!") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_bsmask.xml
+++ b/assets/xml/objects/object_bsmask.xml
@@ -3,10 +3,10 @@
     <File Name="object_bsmask" Segment="6">
 
         <!-- Boss Remains Display Lists -->
-        <DList Name="gRemainsOdolwaDL" Offset="0x690" />
-        <DList Name="gRemainsGyorgDL" Offset="0x1D80" />
-        <DList Name="gRemainsGohtDL" Offset="0x3AD0" />
-        <DList Name="gRemainsTwinmoldDL" Offset="0x5020" />
+        <DList Name="gRemainsOdolwaDL" Offset="0x690" /> <!-- Original name is "face01_get_model" -->
+        <DList Name="gRemainsGyorgDL" Offset="0x1D80" /> <!-- Original name is "face02_get_model" -->
+        <DList Name="gRemainsGohtDL" Offset="0x3AD0" /> <!-- Original name is "face03_get_model" -->
+        <DList Name="gRemainsTwinmoldDL" Offset="0x5020" /> <!-- Original name is "face04_get_model" -->
 
         <!-- Boss Remains TLUTs -->
         <Texture Name="gRemainsOdolwaFaceTLUT" OutName="remains_odolwa_face_tlut" Format="rgba16" Width="4" Height="4" Offset="0x5830" />

--- a/assets/xml/objects/object_cha.xml
+++ b/assets/xml/objects/object_cha.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_cha" Segment="6">
-        <DList Name="object_cha_DL_000710" Offset="0x710" />
-        <DList Name="object_cha_DL_000958" Offset="0x958" />
+        <DList Name="object_cha_DL_000710" Offset="0x710" /> <!-- Original name is "cha_ki_model" -->
+        <DList Name="object_cha_DL_000958" Offset="0x958" /> <!-- Original name is "cha_kane_model" -->
         <Texture Name="object_cha_TLUT_000B08" OutName="tlut_000B08" Format="rgba16" Width="16" Height="16" Offset="0xB08" />
         <Texture Name="object_cha_Tex_000D08" OutName="tex_000D08" Format="ci8" Width="32" Height="32" Offset="0xD08" />
         <Texture Name="object_cha_Tex_001108" OutName="tex_001108" Format="ci8" Width="32" Height="32" Offset="0x1108" />

--- a/assets/xml/objects/object_comb.xml
+++ b/assets/xml/objects/object_comb.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_comb" Segment="6">
         <Texture Name="object_comb_Tex_000000" OutName="tex_000000" Format="rgba16" Width="32" Height="32" Offset="0x0" />
-        <DList Name="object_comb_DL_000CB0" Offset="0xCB0" />
+        <DList Name="object_comb_DL_000CB0" Offset="0xCB0" /> <!-- Original name is "hatisu_model" ("hive; beehive") -->
         <Texture Name="object_comb_Tex_000E10" OutName="tex_000E10" Format="rgba16" Width="16" Height="16" Offset="0xE10" />
-        <DList Name="object_comb_DL_001040" Offset="0x1040" />
+        <DList Name="object_comb_DL_001040" Offset="0x1040" /> <!-- Original name is "hatisu_hahen_model" ("hahen" = "fragment; broken piece") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_crow.xml
+++ b/assets/xml/objects/object_crow.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_crow" Segment="6">
-        <Animation Name="gGuayFlyAnim" Offset="0xF0" />
+        <Animation Name="gGuayFlyAnim" Offset="0xF0" /> <!-- Original name is "df_flygue" -->
         <DList Name="gGuayBodyDL" Offset="0x490" />
         <DList Name="gGuayRightWingTipDL" Offset="0x5E0" />
         <DList Name="gGuayRightWingBodyDL" Offset="0x6B0" />

--- a/assets/xml/objects/object_cs.xml
+++ b/assets/xml/objects/object_cs.xml
@@ -2,25 +2,25 @@
     <File Name="object_cs" Segment="6">
         <DList Name="object_cs_DL_000040" Offset="0x40" />
         <Texture Name="object_cs_Tex_0000C0" OutName="tex_0000C0" Format="ia8" Width="64" Height="64" Offset="0xC0" />
-        <Animation Name="object_cs_Anim_001708" Offset="0x1708" />
-        <Animation Name="object_cs_Anim_001A1C" Offset="0x1A1C" />
-        <Animation Name="object_cs_Anim_002044" Offset="0x2044" />
-        <Animation Name="object_cs_Anim_0026B0" Offset="0x26B0" />
-        <Animation Name="object_cs_Anim_002930" Offset="0x2930" />
-        <Animation Name="object_cs_Anim_0031C4" Offset="0x31C4" />
-        <Animation Name="object_cs_Anim_00349C" Offset="0x349C" />
-        <Animation Name="object_cs_Anim_0036B0" Offset="0x36B0" />
-        <Animation Name="object_cs_Anim_003EE4" Offset="0x3EE4" />
-        <Animation Name="object_cs_Anim_00433C" Offset="0x433C" />
-        <Animation Name="object_cs_Anim_00478C" Offset="0x478C" />
-        <Animation Name="object_cs_Anim_004960" Offset="0x4960" />
-        <Animation Name="object_cs_Anim_004C1C" Offset="0x4C1C" />
-        <Animation Name="object_cs_Anim_005128" Offset="0x5128" />
-        <Animation Name="object_cs_Anim_0053F4" Offset="0x53F4" />
-        <Animation Name="object_cs_Anim_0057C8" Offset="0x57C8" />
-        <Animation Name="object_cs_Anim_005DC4" Offset="0x5DC4" />
-        <Animation Name="object_cs_Anim_0060E8" Offset="0x60E8" />
-        <Animation Name="gBomberIdleAnim" Offset="0x64B8" />
+        <Animation Name="object_cs_Anim_001708" Offset="0x1708" /> <!-- Original name is "csn_atsume" ("to collect; to assemble; to gather​") -->
+        <Animation Name="object_cs_Anim_001A1C" Offset="0x1A1C" /> <!-- Original name is "csn_fly" -->
+        <Animation Name="object_cs_Anim_002044" Offset="0x2044" /> <!-- Original name is "csn_fukiya" ("blowgun; blowpipe; dart​") -->
+        <Animation Name="object_cs_Anim_0026B0" Offset="0x26B0" /> <!-- Original name is "csn_keirei" ("salute") -->
+        <Animation Name="object_cs_Anim_002930" Offset="0x2930" /> <!-- Original name is "csn_kinobori" ("tree climbing​") -->
+        <Animation Name="object_cs_Anim_0031C4" Offset="0x31C4" /> <!-- Original name is "csn_kyoro" (onomatopoeic for "looking around restlessly") -->
+        <Animation Name="object_cs_Anim_00349C" Offset="0x349C" /> <!-- Original name is "csn_odoroku" ("surprise") -->
+        <Animation Name="object_cs_Anim_0036B0" Offset="0x36B0" /> <!-- Original name is "csn_run03" -->
+        <Animation Name="object_cs_Anim_003EE4" Offset="0x3EE4" /> <!-- Original name is "csn_senakamise" ("senaka" = "back (of the body)​", "mise" = "to show; to display​") -->
+        <Animation Name="object_cs_Anim_00433C" Offset="0x433C" /> <!-- Original name is "csn_senakatalk" -->
+        <Animation Name="object_cs_Anim_00478C" Offset="0x478C" /> <!-- Original name is "csn_senakawait" -->
+        <Animation Name="object_cs_Anim_004960" Offset="0x4960" /> <!-- Original name is "csn_shagamu" ("to squat; to crouch​") -->
+        <Animation Name="object_cs_Anim_004C1C" Offset="0x4C1C" /> <!-- Original name is "csn_suwari" ("sitting") -->
+        <Animation Name="object_cs_Anim_005128" Offset="0x5128" /> <!-- Original name is "csn_suwaripiyo" ("piyo" = "weakly moving") -->
+        <Animation Name="object_cs_Anim_0053F4" Offset="0x53F4" /> <!-- Original name is "csn_talk01" -->
+        <Animation Name="object_cs_Anim_0057C8" Offset="0x57C8" /> <!-- Original name is "csn_talk02" -->
+        <Animation Name="object_cs_Anim_005DC4" Offset="0x5DC4" /> <!-- Original name is "csn_talk03" -->
+        <Animation Name="object_cs_Anim_0060E8" Offset="0x60E8" /> <!-- Original name is "csn_tome" -->
+        <Animation Name="gBomberIdleAnim" Offset="0x64B8" /> <!-- Original name is "csn_wait01" -->
         <DList Name="object_cs_DL_009130" Offset="0x9130" />
         <DList Name="object_cs_DL_009478" Offset="0x9478" />
         <DList Name="object_cs_DL_009578" Offset="0x9578" />
@@ -90,8 +90,8 @@
         <Limb Name="object_cs_Standardlimb_00F7C4" Type="Standard" EnumName="OBJECT_CS_LIMB_13" Offset="0xF7C4" />
         <Limb Name="object_cs_Standardlimb_00F7D0" Type="Standard" EnumName="OBJECT_CS_LIMB_14" Offset="0xF7D0" />
         <Skeleton Name="object_cs_Skel_00F82C" Type="Flex" LimbType="Standard" LimbNone="OBJECT_CS_LIMB_NONE" LimbMax="OBJECT_CS_LIMB_MAX" EnumName="ObjectCsLimb" Offset="0xF82C" />
-        <Animation Name="object_cs_Anim_00FAF4" Offset="0xFAF4" />
-        <Animation Name="object_cs_Anim_01007C" Offset="0x1007C" />
-        <Animation Name="object_cs_Anim_010B68" Offset="0x10B68" />
+        <Animation Name="object_cs_Anim_00FAF4" Offset="0xFAF4" /> <!-- Original name is "csn_wait02" -->
+        <Animation Name="object_cs_Anim_01007C" Offset="0x1007C" /> <!-- Original name is "csn_walk" -->
+        <Animation Name="object_cs_Anim_010B68" Offset="0x10B68" /> <!-- Original name is "csn_yarare" ("to suffer damage") -->
     </File>
 </Root>

--- a/assets/xml/objects/object_ctower_rot.xml
+++ b/assets/xml/objects/object_ctower_rot.xml
@@ -67,34 +67,34 @@
         <!-- DLists and Collision -->
 
         <!-- CeilingCog -->
-        <DList Name="gClockTowerEmpty1DL" Offset="0x10820" />
-        <DList Name="gClockTowerCeilingCogDL" Offset="0x10828" />
+        <DList Name="gClockTowerEmpty1DL" Offset="0x10820" /> <!-- Original name is "w2_gia_modelT" (probably a mispelling of "gear") -->
+        <DList Name="gClockTowerCeilingCogDL" Offset="0x10828" /> <!-- Original name is "w2_gia_model" -->
         
         <!-- Corridor -->
         <DList Name="gClockTowerCorridorFoliageDL" Offset="0x129D0" />
-        <DList Name="gClockTowerCorridorDL" Offset="0x12DA0" />
+        <DList Name="gClockTowerCorridorDL" Offset="0x12DA0" /> <!-- Original name is "w2_hineri_model" ("twist; spin") -->
         <Collision Name="gClockTowerCorridorCol" Offset="0x142E8" />
         
         <!-- Organ -->
-        <DList Name="gClockTowerOrganPipesDL" Offset="0x15F30" />
-        <DList Name="gClockTowerOrganDL" Offset="0x160A0" />
+        <DList Name="gClockTowerOrganPipesDL" Offset="0x15F30" /> <!-- Original name is "w2_piano_modelT" -->
+        <DList Name="gClockTowerOrganDL" Offset="0x160A0" /> <!-- Original name is "w2_piano_model" -->
         <Collision Name="gClockTowerOrganCol" Offset="0x16E70" />
         
         <!-- CenterCog -->
-        <DList Name="gClockTowerEmpty2DL" Offset="0x17010" />
-        <DList Name="gClockTowerCenterCogDL" Offset="0x17018" />
+        <DList Name="gClockTowerEmpty2DL" Offset="0x17010" /> <!-- Original name is "w2_shaft_modelT" -->
+        <DList Name="gClockTowerCenterCogDL" Offset="0x17018" /> <!-- Original name is "w2_shaft_model" -->
         
         <!-- StoneDoorMain -->
-        <DList Name="gClockTowerStoneDoorMainDL" Offset="0x17220" />
+        <DList Name="gClockTowerStoneDoorMainDL" Offset="0x17220" /> <!-- Original name is "w2_shatter_higashi_model" ("higashi" = "east") -->
         <Collision Name="gClockTowerStoneDoorMainCol" Offset="0x17410" />
         
         <!-- StoneDoor -->
-        <DList Name="gClockTowerStoneDoorDL" Offset="0x174E0" />
+        <DList Name="gClockTowerStoneDoorDL" Offset="0x174E0" /> <!-- Original name is "w2_shatter_nishi_model" ("nishi" = "west") -->
         <Collision Name="gClockTowerStoneDoorCol" Offset="0x17650" />
         
         <!-- WaterWheel -->
-        <DList Name="gClockTowerEmpty3DL" Offset="0x18110" />
-        <DList Name="gClockTowerWaterWheelDL" Offset="0x18118" />
+        <DList Name="gClockTowerEmpty3DL" Offset="0x18110" /> <!-- Original name is "w2_suisha_modelT" ("water wheel") -->
+        <DList Name="gClockTowerWaterWheelDL" Offset="0x18118" /> <!-- Original name is "w2_suisha_model" -->
         <Collision Name="gClockTowerWaterWheelCol" Offset="0x18588" />
     </File>
 </Root>

--- a/assets/xml/objects/object_os_anime.xml
+++ b/assets/xml/objects/object_os_anime.xml
@@ -12,11 +12,11 @@
         <Animation Name="object_os_anime_Anim_00107C" Offset="0x107C" />
         <Animation Name="object_os_anime_Anim_001270" Offset="0x1270" />
         <Animation Name="object_os_anime_Anim_0012FC" Offset="0x12FC" />
-        <Animation Name="object_os_anime_Anim_001458" Offset="0x1458" />
-        <Animation Name="object_os_anime_Anim_0017D8" Offset="0x17D8" />
-        <Animation Name="object_os_anime_Anim_001C9C" Offset="0x1C9C" />
-        <Animation Name="object_os_anime_Anim_001D44" Offset="0x1D44" />
-        <Animation Name="object_os_anime_Anim_001EE0" Offset="0x1EE0" />
+        <Animation Name="object_os_anime_Anim_001458" Offset="0x1458" /> <!-- Original name is "Cne2_15" -->
+        <Animation Name="object_os_anime_Anim_0017D8" Offset="0x17D8" /> <!-- Original name is "Cne_aruku" ("walk") -->
+        <Animation Name="object_os_anime_Anim_001C9C" Offset="0x1C9C" /> <!-- Original name is "Cne_hiso_wait" ("hiso" = onomatopoeic for "whisper") -->
+        <Animation Name="object_os_anime_Anim_001D44" Offset="0x1D44" /> <!-- Original name is "Cne_matsu" -->
+        <Animation Name="object_os_anime_Anim_001EE0" Offset="0x1EE0" /> <!-- Original name is "Cne_n_wait" ("to wait​") -->
         <Animation Name="object_os_anime_Anim_001F78" Offset="0x1F78" />
         <Animation Name="object_os_anime_Anim_0020F8" Offset="0x20F8" />
         <Animation Name="object_os_anime_Anim_0021B8" Offset="0x21B8" />

--- a/assets/xml/overlays/ovl_En_Sth.xml
+++ b/assets/xml/overlays/ovl_En_Sth.xml
@@ -2,13 +2,13 @@
     <File Name="ovl_En_Sth" BaseAddress="0x80B66D30" RangeStart="0x1890" RangeEnd="0x646C">
         <DList Name="ovl_En_Sth_DL_0034A0" Offset="0x34A0"/>
         <DList Name="ovl_En_Sth_DL_0037C0" Offset="0x37C0"/>
-        <Animation Name="ovl_En_Sth_Anim_003F50" Offset="0x3F50" />
-        <Animation Name="ovl_En_Sth_Anim_0045B4" Offset="0x45B4" />
-        <Animation Name="ovl_En_Sth_Anim_004CC0" Offset="0x4CC0" />
-        <Animation Name="ovl_En_Sth_Anim_00533C" Offset="0x533C" />
-        <Animation Name="ovl_En_Sth_Anim_0059B8" Offset="0x59B8" />
-        <Animation Name="ovl_En_Sth_Anim_005E40" Offset="0x5E40" />
-        <Animation Name="ovl_En_Sth_Anim_006354" Offset="0x6354" />
-        <Animation Name="ovl_En_Sth_Anim_00645C" Offset="0x645C" />
+        <Animation Name="ovl_En_Sth_Anim_003F50" Offset="0x3F50" /> <!-- Original name is "sth_ko_matsu" ("matsu" = "to wait​") -->
+        <Animation Name="ovl_En_Sth_Anim_0045B4" Offset="0x45B4" /> <!-- Original name is "sth_kibunwaru" ("bad mood") -->
+        <Animation Name="ovl_En_Sth_Anim_004CC0" Offset="0x4CC0" /> <!-- Original name is "sth_talk2000" -->
+        <Animation Name="ovl_En_Sth_Anim_00533C" Offset="0x533C" /> <!-- Original name is "sth_wait2000" -->
+        <Animation Name="ovl_En_Sth_Anim_0059B8" Offset="0x59B8" /> <!-- Original name is "sth_miageru" ("look up") -->
+        <Animation Name="ovl_En_Sth_Anim_005E40" Offset="0x5E40" /> <!-- Original name is "sth_kyorokyoro" (onomatopoeic for "looking around restlessly") -->
+        <Animation Name="ovl_En_Sth_Anim_006354" Offset="0x6354" /> <!-- Original name is "sth_onegai" ("request; favor (to ask); wish") -->
+        <Animation Name="ovl_En_Sth_Anim_00645C" Offset="0x645C" /> <!-- Original name is "sth_tasukete" ("help!​") -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Sth2.xml
+++ b/assets/xml/overlays/ovl_En_Sth2.xml
@@ -9,6 +9,6 @@
         <Texture Name="gEnSth2HairTex" OutName="en_sth2_hair" Format="rgba16" Width="8" Height="16" Offset="0x12E0"/>
         <DList Name="gEnSth2HeadDL" Offset="0x2070"/>
         <DList Name="gEnSth2HairDL" Offset="0x2390"/>
-        <Animation Name="gEnSth2WavingHandAnim" Offset="0x2B20"/>
+        <Animation Name="gEnSth2WavingHandAnim" Offset="0x2B20"/> <!-- Original name is "sth_ko_matsu" ("matsu" = "to wait​") -->
     </File>
 </Root>


### PR DESCRIPTION
Specifically, I did parts of `object_os_anime`, as well as all of `ovl_En_Sth` and `ovl_En_Sth2`, since their animations were moved to `zelda2_cne` and `zelda2_boj` in MM3D.