### PR TITLE
Update `m2ctx.py`

### DIFF
--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -25,10 +25,8 @@ CPP_FLAGS = [
     "-D_Static_assert(x, y)=",
     "-D__attribute__(x)="
     "-D_MIPS_SZLONG=32",
-    "-D__attribute__(x)=",
     "-ffreestanding",
     "-DM2CTX",
-    "-DNON_MATCHING",
 
     "-std=gnu89",
 ]

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -24,7 +24,6 @@ CPP_FLAGS = [
     "-DNON_MATCHING",
     "-D_Static_assert(x, y)=",
     "-D__attribute__(x)="
-    "-DNDEBUG",
     "-D_MIPS_SZLONG=32",
     "-D__attribute__(x)=",
     "-ffreestanding",

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -25,11 +25,8 @@ CPP_FLAGS = [
     "-D_Static_assert(x, y)=",
     "-D__attribute__(x)="
     "-DNDEBUG",
-    "-D_FINALROM",
     "-D_MIPS_SZLONG=32",
-    "-DSCRIPT(x)="
     "-D__attribute__(x)=",
-    "-D__asm__(x)=",
     "-ffreestanding",
     "-DM2CTX",
     "-DNON_MATCHING",

--- a/tools/m2ctx.py
+++ b/tools/m2ctx.py
@@ -14,8 +14,10 @@ src_dir = root_dir / "src"
 # Project-specific
 CPP_FLAGS = [
     "-Iinclude",
-    "-Iassets",
     "-Isrc",
+    "-Iassets",
+    "-Ibuild",
+    "-I.",
 
     "-D__sgi",
     "-D_LANGUAGE_C",


### PR DESCRIPTION
I cleaned up the script and modified it so macros are preserved. Useful for cases when you want to manually create a decomp.me scratch because gfx macros are preserved in context