### PR TITLE
Add original asset names for all `object_e*` and `object_f*` files

### DIFF
--- a/assets/xml/objects/object_efc_star_field.xml
+++ b/assets/xml/objects/object_efc_star_field.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_efc_star_field" Segment="6">
-        <DList Name="object_efc_star_field_DL_000080" Offset="0x80" />
+        <DList Name="object_efc_star_field_DL_000080" Offset="0x80" /> <!-- Original name is "efc_star_field_modelT" -->
         <Texture Name="object_efc_star_field_Tex_000108" OutName="tex_000108" Format="i8" Width="16" Height="64" Offset="0x108" />
-        <DList Name="object_efc_star_field_DL_000DE0" Offset="0xDE0" />
+        <DList Name="object_efc_star_field_DL_000DE0" Offset="0xDE0" /> <!-- Original name is "demo_rock_model" -->
         <Texture Name="object_efc_star_field_Tex_000FD0" OutName="tex_000FD0" Format="i4" Width="64" Height="64" Offset="0xFD0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_efc_tw.xml
+++ b/assets/xml/objects/object_efc_tw.xml
@@ -4,7 +4,7 @@
         <Array Name="object_efc_tw_Vtx_000060" Count="21" Offset="0x60" >
             <Vtx/>
         </Array>
-        <DList Name="object_efc_tw_DL_0001B0" Offset="0x1B0" />
+        <DList Name="object_efc_tw_DL_0001B0" Offset="0x1B0" /> <!-- Original name is "top_fc_mdl" -->
         <Texture Name="object_efc_tw_Tex_0002C8" OutName="tex_0002C8" Format="i8" Width="64" Height="64" Offset="0x2C8" />
         <Limb Name="object_efc_tw_Curvelimb_0012C8" Type="Curve" EnumName="OBJECT_EFC_TW_LIMB_01" Offset="0x12C8" />
         <Limb Name="object_efc_tw_Curvelimb_0012D4" Type="Curve" EnumName="OBJECT_EFC_TW_LIMB_02" Offset="0x12D4" />

--- a/assets/xml/objects/object_eg.xml
+++ b/assets/xml/objects/object_eg.xml
@@ -2,20 +2,20 @@
     <!-- Assets for the Eyegore enemy and associated props -->
     <File Name="object_eg" Segment="6">
         <!-- Display lists and textures for Eyegore's effects -->
-        <DList Name="gEyegoreEffectImpactDL" Offset="0x40" />
+        <DList Name="gEyegoreEffectImpactDL" Offset="0x40" /> <!-- Original name is "grid1_model" -->
         <Texture Name="gEyegoreEffectImpactTex" OutName="eyegore_effect_impact" Format="ia8" Width="64" Height="64" Offset="0xC0" />
         <TextureAnimation Name="gEyegoreEmpty1TexAnim" Offset="0x10C0" />
-        <DList Name="gEyegoreEffectLargeBodyPieceDL" Offset="0x1170" />
+        <DList Name="gEyegoreEffectLargeBodyPieceDL" Offset="0x1170" /> <!-- Original name is "baku_shape1_model" -->
         <Texture Name="gEyegoreEffectLargeBodyPieceTex" OutName="eyegore_effect_large_piece" Format="rgba16" Width="8" Height="16" Offset="0x1210" />
-        <DList Name="gEyegoreEffectSmallBodyPieceDL" Offset="0x13B0" />
+        <DList Name="gEyegoreEffectSmallBodyPieceDL" Offset="0x13B0" /> <!-- Original name is "baku_shape2_model" -->
         <Texture Name="gEyegoreEffectSmallBodyPieceTex" OutName="eyegore_effect_small_piece" Format="rgba16" Width="8" Height="16" Offset="0x1450" />
         <DList Name="gEyegoreEmpty1DL" Offset="0x1690" />
 
         <!-- Assets for Eyegore's destructible pillars (unused) -->
         <DList Name="gEyegoreBlockDL" Offset="0x1698" />
-        <Collision Name="gEyegoreBlockCol" Offset="0x1820" />
+        <Collision Name="gEyegoreBlockCol" Offset="0x1820" /> <!-- Original name is "eg_block1_bgdatainfo" -->
         <DList Name="gEyegoreEmpty2DL" Offset="0x1910" />
-        <DList Name="gEyegoreEffectSolidDebrisDL" Offset="0x1918" />
+        <DList Name="gEyegoreEffectSolidDebrisDL" Offset="0x1918" /> <!-- Original name is "eg_block2_model" -->
         <Texture Name="gEyegoreEffectSolidDebrisTex" OutName="eyegore_effect_solid_debris" Format="rgba16" Width="16" Height="16" Offset="0x19B0" />
         <TextureAnimation Name="gEyegoreEmpty2TexAnim" Offset="0x1BB0" />
         <DList Name="gEyegoreEmpty3DL" Offset="0x1BF0" />
@@ -24,7 +24,7 @@
         <TextureAnimation Name="gEyegoreEmpty3TexAnim" Offset="0x1E80" />
 
         <!-- Slam attack animation -->
-        <Animation Name="gEyegoreSlamAnim" Offset="0x2460" />
+        <Animation Name="gEyegoreSlamAnim" Offset="0x2460" /> <!-- Original name is "eg_atack01" -->
 
         <!-- Unused vertex mesh. Purpose unknown. -->
         <Array Name="gEyegoreUnusedVtx" Count="464" Offset="0x2470"> <!-- type is uncertain -->
@@ -32,7 +32,7 @@
         </Array>
 
         <!-- Display list for Eyegore's laser attack -->
-        <DList Name="gEyegoreLaserDL" Offset="0x41F0" />
+        <DList Name="gEyegoreLaserDL" Offset="0x41F0" /> <!-- Original name is "eg_sen_SCR1_F_model" -->
         
         <!-- Several unused textures. Purpose unknown. -->
         <Texture Name="gEyegoreUnusedUnknown1Tex" OutName="eyegore_unused_unknown_1" Format="rgba16" Width="8" Height="8" Offset="0x4280" /> <!-- unused -->
@@ -105,32 +105,32 @@
         <Skeleton Name="gEyegoreSkel" Type="Flex" LimbType="Standard" LimbNone="EYEGORE_LIMB_NONE" LimbMax="EYEGORE_LIMB_MAX" EnumName="EyegoreLimb" Offset="0x9664" />
 
         <!-- Various fight animations -->
-        <Animation Name="gEyegoreSlamWaitAnim" Offset="0x9D2C" />
-        <Animation Name="gEyegoreSlamEndAnim" Offset="0xA204" />
-        <Animation Name="gEyegoreLaserAnim" Offset="0xA484" />
-        <Animation Name="gEyegoreUnusedLaserEndAnim" Offset="0xA73C" />
-        <Animation Name="gEyegoreDamagedAnim" Offset="0xADF8" />
-        <Animation Name="gEyegoreDeathAnim" Offset="0xBC60" />
-        <Animation Name="gEyegoreRetreatAnim" Offset="0xBEB8" />
-        <Animation Name="gEyegoreLeftPunchAnim" Offset="0xC434" />
-        <Animation Name="gEyegoreRightPunchAnim" Offset="0xC9B4" />
-        <Animation Name="gEyegoreStunnedAnim" Offset="0xCC4C" />
-        <Animation Name="gEyegoreStunEndAnim" Offset="0xCE54" />
-        <Animation Name="gEyegoreSitAnim" Offset="0xD3D8" />
+        <Animation Name="gEyegoreSlamWaitAnim" Offset="0x9D2C" /> <!-- Original name is "eg_atack02" -->
+        <Animation Name="gEyegoreSlamEndAnim" Offset="0xA204" /> <!-- Original name is "eg_atack03" -->
+        <Animation Name="gEyegoreLaserAnim" Offset="0xA484" /> <!-- Original name is "eg_beam" -->
+        <Animation Name="gEyegoreUnusedLaserEndAnim" Offset="0xA73C" /> <!-- Original name is "eg_beamTOwalk" -->
+        <Animation Name="gEyegoreDamagedAnim" Offset="0xADF8" /> <!-- Original name is "eg_damage" -->
+        <Animation Name="gEyegoreDeathAnim" Offset="0xBC60" /> <!-- Original name is "eg_dead" -->
+        <Animation Name="gEyegoreRetreatAnim" Offset="0xBEB8" /> <!-- Original name is "eg_escape" -->
+        <Animation Name="gEyegoreLeftPunchAnim" Offset="0xC434" /> <!-- Original name is "eg_hatakiL" -->
+        <Animation Name="gEyegoreRightPunchAnim" Offset="0xC9B4" /> <!-- Original name is "eg_hatakiR" -->
+        <Animation Name="gEyegoreStunnedAnim" Offset="0xCC4C" /> <!-- Original name is "eg_mahi" -->
+        <Animation Name="gEyegoreStunEndAnim" Offset="0xCE54" /> <!-- Original name is "eg_mahiTOwalk" -->
+        <Animation Name="gEyegoreSitAnim" Offset="0xD3D8" /> <!-- Original name is "eg_nemuru" -->
 
-        <!-- Unused stone display list and texture. Could be prototype of final stone assets. -->
+        <!-- Unused stone display list and texture. It's a copy of the stone in object_efc_star_field. -->
         <DList Name="gEyegoreUnusedStoneDL" Offset="0xDCC0" />
         <Texture Name="gEyegoreUnusedStoneTex" OutName="eyegore_unused_stone" Format="i4" Width="64" Height="64" Offset="0xDEA8" />
 
         <!-- Various walking and idle animations. Contains several unused ones. -->
-        <Animation Name="gEyegoreUnusedChaseAnim" Offset="0xEA10" />
-        <Animation Name="gEyegoreStandAnim" Offset="0xEE4C" />
-        <Animation Name="gEyegoreUnusedWalkAnim" Offset="0xF524" />
-        <Animation Name="gEyegoreUnusedIdleAnim" Offset="0xFB0C" />
-        <Animation Name="gEyegoreWalkAnim" Offset="0x100C0" />
+        <Animation Name="gEyegoreUnusedChaseAnim" Offset="0xEA10" /> <!-- Original name is "eg_run" -->
+        <Animation Name="gEyegoreStandAnim" Offset="0xEE4C" /> <!-- Original name is "eg_start" -->
+        <Animation Name="gEyegoreUnusedWalkAnim" Offset="0xF524" /> <!-- Original name is "eg_turn" -->
+        <Animation Name="gEyegoreUnusedIdleAnim" Offset="0xFB0C" /> <!-- Original name is "eg_wait" -->
+        <Animation Name="gEyegoreWalkAnim" Offset="0x100C0" /> <!-- Original name is "eg_walk" -->
 
         <!-- Display list and texture for the stones created by Eyegore's attacks -->
-        <DList Name="gEyegoreStoneDL" Offset="0x10240" />
+        <DList Name="gEyegoreStoneDL" Offset="0x10240" /> <!-- Original name is "iwaA_cube1_model" -->
         <Texture Name="gEyegoreStoneTex" OutName="eyegore_stone" Format="rgba16" Width="36" Height="36" Offset="0x10310" />
 
         <!-- Duplicate of gEyegoreEffectImpactTex -->

--- a/assets/xml/objects/object_ending_obj.xml
+++ b/assets/xml/objects/object_ending_obj.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_ending_obj" Segment="6">
-        <DList Name="object_ending_obj_DL_0003D0" Offset="0x3D0" />
+        <DList Name="object_ending_obj_DL_0003D0" Offset="0x3D0" /> <!-- Original name is "lost_woods_light_u_modelT" -->
         <DList Name="object_ending_obj_DL_0005E0" Offset="0x5E0" />
         <Texture Name="object_ending_obj_Tex_0005E8" OutName="tex_0005E8" Format="i8" Width="32" Height="64" Offset="0x5E8" />
         <Texture Name="object_ending_obj_Tex_000DE8" OutName="tex_000DE8" Format="i8" Width="8" Height="64" Offset="0xDE8" />
         <Texture Name="object_ending_obj_Tex_000FE8" OutName="tex_000FE8" Format="ia8" Width="64" Height="64" Offset="0xFE8" />
         <TextureAnimation Name="object_ending_obj_Matanimheader_001FF8" Offset="0x1FF8" />
-        <DList Name="object_ending_obj_DL_0031A0" Offset="0x31A0" />
-        <DList Name="object_ending_obj_DL_003440" Offset="0x3440" />
+        <DList Name="object_ending_obj_DL_0031A0" Offset="0x31A0" /> <!-- Original name is "z2_lost_woods_end_modelT" -->
+        <DList Name="object_ending_obj_DL_003440" Offset="0x3440" /> <!-- Original name is "z2_lost_woods_end_model" -->
         <Texture Name="object_ending_obj_Tex_003958" OutName="tex_003958" Format="ia4" Width="128" Height="64" Offset="0x3958" />
         <Texture Name="object_ending_obj_Tex_004958" OutName="tex_004958" Format="rgba16" Width="32" Height="32" Offset="0x4958" />
         <Texture Name="object_ending_obj_Tex_005158" OutName="tex_005158" Format="ia16" Width="16" Height="64" Offset="0x5158" />

--- a/assets/xml/objects/object_f40_obj.xml
+++ b/assets/xml/objects/object_f40_obj.xml
@@ -11,7 +11,7 @@
         <DList Name="object_f40_obj_DL_004030" Offset="0x4030" />
         <DList Name="object_f40_obj_DL_004038" Offset="0x4038" />
         <Collision Name="object_f40_obj_Colheader_004240" Offset="0x4240" />
-        <DList Name="object_f40_obj_DL_0043D0" Offset="0x43D0" />
-        <Collision Name="object_f40_obj_Colheader_004640" Offset="0x4640" />
+        <DList Name="object_f40_obj_DL_0043D0" Offset="0x43D0" /> <!-- Original name is "z2_f40obj01_model" -->
+        <Collision Name="object_f40_obj_Colheader_004640" Offset="0x4640" /> <!-- Original name is "z2_f40obj01_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_f40_switch.xml
+++ b/assets/xml/objects/object_f40_switch.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_f40_switch" Segment="6">
-        <Collision Name="object_f40_switch_Colheader_000118" Offset="0x118" />
-        <DList Name="object_f40_switch_DL_000390" Offset="0x390" />
-        <DList Name="object_f40_switch_DL_000438" Offset="0x438" />
+        <Collision Name="object_f40_switch_Colheader_000118" Offset="0x118" /> <!-- Original name is "f40_switch_1_bgdatainfo" -->
+        <DList Name="object_f40_switch_DL_000390" Offset="0x390" /> <!-- Original name is "z2_switch_lb_modelT" -->
+        <DList Name="object_f40_switch_DL_000438" Offset="0x438" /> <!-- Original name is "z2_switch_lb_model" -->
         <Texture Name="object_f40_switch_Tex_0004E8" OutName="tex_0004E8" Format="rgba16" Width="16" Height="64" Offset="0x4E8" />
         <Texture Name="object_f40_switch_Tex_000CE8" OutName="tex_000CE8" Format="ia8" Width="16" Height="16" Offset="0xCE8" />
     </File>

--- a/assets/xml/objects/object_f52_obj.xml
+++ b/assets/xml/objects/object_f52_obj.xml
@@ -1,16 +1,16 @@
 ﻿<Root>
     <File Name="object_f52_obj" Segment="6">
-        <DList Name="object_f52_obj_DL_000570" Offset="0x570" /> <!-- Bell post -->
-        <DList Name="object_f52_obj_DL_000698" Offset="0x698" /> <!-- Bell -->
+        <DList Name="object_f52_obj_DL_000570" Offset="0x570" /> <!-- Original name is "bw_01_model". Bell post -->
+        <DList Name="object_f52_obj_DL_000698" Offset="0x698" /> <!-- Original name is "bk_model". Bell -->
         <DList Name="object_f52_obj_DL_0007A8" Offset="0x7A8" /> <!-- Bell Base -->
-        <DList Name="object_f52_obj_DL_000840" Offset="0x840" /> <!-- Bell Shadow -->
-        <DList Name="object_f52_obj_DL_0008D0" Offset="0x8D0" /> <!-- Bell Hook -->
+        <DList Name="object_f52_obj_DL_000840" Offset="0x840" /> <!-- Original name is "bqT_model". Bell Shadow -->
+        <DList Name="object_f52_obj_DL_0008D0" Offset="0x8D0" /> <!-- Original name is "bhT_model". Bell Hook -->
         <DList Name="object_f52_obj_DL_000960" Offset="0x960" /> <!-- Bell Designs -->
         <Texture Name="object_f52_obj_Tex_000A10" OutName="tex_000A10" Format="rgba16" Width="32" Height="16" Offset="0xA10" />
         <Texture Name="object_f52_obj_Tex_000E10" OutName="tex_000E10" Format="ia16" Width="16" Height="16" Offset="0xE10" />
         <Texture Name="object_f52_obj_Tex_001010" OutName="tex_001010" Format="rgba16" Width="32" Height="16" Offset="0x1010" />
         <Texture Name="object_f52_obj_Tex_001410" OutName="tex_001410" Format="rgba16" Width="16" Height="32" Offset="0x1410" />
         <Texture Name="object_f52_obj_Tex_001810" OutName="tex_001810" Format="rgba16" Width="8" Height="16" Offset="0x1810" />
-        <Collision Name="object_f52_obj_Colheader_001BA8" Offset="0x1BA8" />
+        <Collision Name="object_f52_obj_Colheader_001BA8" Offset="0x1BA8" /> <!-- Original name is "z2_bell_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_f53_obj.xml
+++ b/assets/xml/objects/object_f53_obj.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_f53_obj" Segment="6">
-        <DList Name="object_f53_obj_DL_000090" Offset="0x90" />
+        <DList Name="object_f53_obj_DL_000090" Offset="0x90" /> <!-- Original name is "z2_entotu_modelT" -->
         <DList Name="object_f53_obj_DL_000148" Offset="0x148" />
         <DList Name="object_f53_obj_DL_000158" Offset="0x158" />
         <Texture Name="object_f53_obj_Tex_000168" OutName="tex_000168" Format="rgba16" Width="32" Height="64" Offset="0x168" />
         <DList Name="gBankShutterDL" Offset="0x11E0" />
         <Texture Name="object_f53_obj_Tex_001278" OutName="tex_001278" Format="rgba16" Width="32" Height="32" Offset="0x1278" />
         <!-- <Blob Name="object_f53_obj_Blob_001A78" Size="0x78" Offset="0x1A78" /> -->
-        <DList Name="object_f53_obj_DL_001AF0" Offset="0x1AF0" />
+        <DList Name="object_f53_obj_DL_001AF0" Offset="0x1AF0" /> <!-- Original name is "z2_smork_modelT" -->
         <DList Name="object_f53_obj_DL_001BF0" Offset="0x1BF0" />
         <DList Name="object_f53_obj_DL_001C00" Offset="0x1C00" />
         <Texture Name="object_f53_obj_Tex_001C10" OutName="tex_001C10" Format="ia8" Width="32" Height="32" Offset="0x1C10" />

--- a/assets/xml/objects/object_fall.xml
+++ b/assets/xml/objects/object_fall.xml
@@ -7,14 +7,14 @@
     -->
     <File Name="object_fall" Segment="6">
         <!-- Debris -->
-        <DList Name="gMoonEmptyDL1" Offset="0x190" /> <!-- Was likely going to be used with gMoonDebrisModel1DL before they made all debris use the same material -->
+        <DList Name="gMoonEmpty1DL" Offset="0x190" /> <!-- Was likely going to be used with gMoonDebrisModel1DL before they made all debris use the same material -->
         <DList Name="gMoonDebrisMaterialDL" Offset="0x198" />
-        <DList Name="gMoonDebrisModel1DL" Offset="0x220" />
+        <DList Name="gMoonDebrisModel1DL" Offset="0x220" /> <!-- Original name is "at_dust_01_model" -->
         <Texture Name="gMoonDebrisTex" OutName="moon_debris" Format="i8" Width="16" Height="16" Offset="0x260" />
-        <DList Name="gMoonEmptyDL2" Offset="0x420" /> <!-- Was likely going to be used with gMoonDebrisModel2DL before they made all debris use the same material -->
-        <DList Name="gMoonDebrisModel2DL" Offset="0x428" />
-        <DList Name="gMoonEmptyDL3" Offset="0x490" /> <!-- Was likely going to be used with gMoonDebrisModel3DL before they made all debris use the same material -->
-        <DList Name="gMoonDebrisModel3DL" Offset="0x498" />\
+        <DList Name="gMoonEmpty2DL" Offset="0x420" /> <!-- Was likely going to be used with gMoonDebrisModel2DL before they made all debris use the same material -->
+        <DList Name="gMoonDebrisModel2DL" Offset="0x428" /> <!-- Original name is "at_dust_02_model" -->
+        <DList Name="gMoonEmpty3DL" Offset="0x490" /> <!-- Was likely going to be used with gMoonDebrisModel3DL before they made all debris use the same material -->
+        <DList Name="gMoonDebrisModel3DL" Offset="0x498" /> <!-- Original name is "at_dust_03_model" -->
 
         <!-- Fireball Vertices -->
         <Array Name="gMoonFireballVtx" Count="209" Offset="0x4C0">
@@ -22,7 +22,7 @@
         </Array>
         
         <!-- Fireball DisplayList -->
-        <DList Name="gMoonFireballDL" Offset="0x11D0" />
+        <DList Name="gMoonFireballDL" Offset="0x11D0" /> <!-- Original name is "moon_fall_model" -->
 
         <!-- Fireball Textures -->
         <Texture Name="gMoonFireballFlecksTex" OutName="moon_fireball_flecks" Format="i8" Width="64" Height="64" Offset="0x1688" />
@@ -30,7 +30,7 @@
         <Texture Name="gMoonFireballMaskTex" OutName="moon_fireball_mask" Format="i4" Width="64" Height="64" Offset="0x2E88" />
 
         <!-- Fire Ring DisplayList -->
-        <DList Name="gMoonFireRingDL" Offset="0x3C30" />
+        <DList Name="gMoonFireRingDL" Offset="0x3C30" /> <!-- Original name is "moon_fall2_model" -->
 
         <!-- Fire Ring Textures -->
         <Texture Name="gMoonFireRingFlamesTex" OutName="moon_fire_ring_flames" Format="i8" Width="32" Height="64" Offset="0x3E28" />
@@ -43,7 +43,7 @@
         <TextureAnimation Name="gMoonUnusedFireballTexAnim" Offset="0x4E58" /> <!-- Almost certainly scrapped for just doing the TwoTexScrolls manually in EnFall_Fireball_Draw -->
 
         <!-- Moon DisplayList -->
-        <DList Name="gMoonDL" Offset="0x77F0" />
+        <DList Name="gMoonDL" Offset="0x77F0" /> <!-- Original name is "moon" -->
 
         <!-- Moon Textures -->
         <Texture Name="gMoonFarSideTLUT" OutName="moon_far_side_tlut" Format="rgba16" Width="4" Height="4" Offset="0x82F8" />

--- a/assets/xml/objects/object_fall2.xml
+++ b/assets/xml/objects/object_fall2.xml
@@ -12,7 +12,7 @@
         <Texture Name="gOpenMouthMoonFaceTex" OutName="open_mouth_moon_face" Format="ci4" Width="64" Height="64" Offset="0x44E8" />
         <Texture Name="gOpenMouthMoonTeethTex" OutName="open_mouth_moon_teeth" Format="rgba16" Width="64" Height="32" Offset="0x4CE8" />
         <!-- <Blob Name="object_fall2_Blob_005CE8" Size="0x20C" Offset="0x5CE8" /> -->
-        <Blob Name="object_fall2_Blob_005EF4" Size="0x1C" Offset="0x5EF4" /> <!-- Original name might be "moon_start_anm"; either this or the one below is named that. -->
+        <Blob Name="object_fall2_Blob_005EF4" Size="0x1C" Offset="0x5EF4" /> <!-- Original name might be "moon_start_anm"; needs c_keyframe docs to know if it's this one or the one below. -->
         <Array Name="object_fall2_Vtx_005F10" Count="239" Offset="0x5F10">
             <Vtx />
         </Array>
@@ -29,6 +29,6 @@
         <Texture Name="object_fall2_Tex_007838" OutName="tex_007838" Format="i4" Width="64" Height="64" Offset="0x7838" />
         <Texture Name="object_fall2_Tex_008038" OutName="tex_008038" Format="i4" Width="64" Height="64" Offset="0x8038" />
         <TextureAnimation Name="object_fall2_Matanimheader_008840" Offset="0x8840" />
-        <Blob Name="object_fall2_Blob_008898" Size="0x8" Offset="0x8898" /> <!-- Original name might be "moon_start_anm"; either this or the one above is named that. -->
+        <Blob Name="object_fall2_Blob_008898" Size="0x8" Offset="0x8898" /> <!-- Original name might be "moon_start_anm"; needs c_keyframe docs to know if it's this one or the one above. -->
     </File>
 </Root>

--- a/assets/xml/objects/object_fall2.xml
+++ b/assets/xml/objects/object_fall2.xml
@@ -4,7 +4,7 @@
         moon's mouth, both used in the cutscene before warping to the moon.
     -->
     <File Name="object_fall2" Segment="6">
-        <DList Name="gOpenMouthMoonDL" Offset="0x2970" />
+        <DList Name="gOpenMouthMoonDL" Offset="0x2970" /> <!-- Original name is "moon_open" -->
         <Texture Name="gOpenMouthMoonFarSideTLUT" OutName="open_mouth_moon_far_side_tlut" Format="rgba16" Width="4" Height="4" Offset="0x34A8" />
         <Texture Name="gOpenMouthMoonFaceTLUT" OutName="open_mouth_moon_face_tlut" Format="rgba16" Width="4" Height="4" Offset="0x34C8" />
         <Texture Name="gOpenMouthMoonEyesTex" OutName="open_mouth_moon_eyes" Format="rgba16" Width="32" Height="32" Offset="0x34E8" />
@@ -12,7 +12,7 @@
         <Texture Name="gOpenMouthMoonFaceTex" OutName="open_mouth_moon_face" Format="ci4" Width="64" Height="64" Offset="0x44E8" />
         <Texture Name="gOpenMouthMoonTeethTex" OutName="open_mouth_moon_teeth" Format="rgba16" Width="64" Height="32" Offset="0x4CE8" />
         <!-- <Blob Name="object_fall2_Blob_005CE8" Size="0x20C" Offset="0x5CE8" /> -->
-        <Blob Name="object_fall2_Blob_005EF4" Size="0x1C" Offset="0x5EF4" />
+        <Blob Name="object_fall2_Blob_005EF4" Size="0x1C" Offset="0x5EF4" /> <!-- Original name might be "moon_start_anm"; either this or the one below is named that. -->
         <Array Name="object_fall2_Vtx_005F10" Count="239" Offset="0x5F10">
             <Vtx />
         </Array>
@@ -29,6 +29,6 @@
         <Texture Name="object_fall2_Tex_007838" OutName="tex_007838" Format="i4" Width="64" Height="64" Offset="0x7838" />
         <Texture Name="object_fall2_Tex_008038" OutName="tex_008038" Format="i4" Width="64" Height="64" Offset="0x8038" />
         <TextureAnimation Name="object_fall2_Matanimheader_008840" Offset="0x8840" />
-        <Blob Name="object_fall2_Blob_008898" Size="0x8" Offset="0x8898" />
+        <Blob Name="object_fall2_Blob_008898" Size="0x8" Offset="0x8898" /> <!-- Original name might be "moon_start_anm"; either this or the one above is named that. -->
     </File>
 </Root>

--- a/assets/xml/objects/object_famos.xml
+++ b/assets/xml/objects/object_famos.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <!-- Death Armos: flying statues in Inverted Stone Tower Temple -->
     <File Name="object_famos" Segment="6">
-        <Animation Name="gFamosShakeAnim" Offset="0xF8" />
+        <Animation Name="gFamosShakeAnim" Offset="0xF8" /> <!-- Original name is "fam_aizu" -->
         <DList Name="gFamosHelmetDL" Offset="0x12B0" />
         <DList Name="gFamosMainBodyDL" Offset="0x1528" />
         <DList Name="gFamosShieldDL" Offset="0x1C88" />
@@ -24,7 +24,7 @@
         <Limb Name="gFamosHeadLimb" Type="Standard" EnumName="FAMOS_LIMB_HEAD" Offset="0x3D18" />
         <Skeleton Name="gFamosSkeleton" Type="Normal" LimbType="Standard" LimbNone="FAMOS_LIMB_NONE" LimbMax="FAMOS_LIMB_MAX" EnumName="FamosLimb" Offset="0x3D38" />
 
-        <Animation Name="gFamosIdleAnim" Offset="0x3DC8" />
+        <Animation Name="gFamosIdleAnim" Offset="0x3DC8" /> <!-- Original name is "fam_dosun" -->
         <TextureAnimation Name="gFamosNormalGlowingEmblemTexAnim" Offset="0x3E30" />
         <TextureAnimation Name="gFamosFlippedGlowingEmblemTexAnim" Offset="0x3E38" />
     </File>

--- a/assets/xml/objects/object_fb.xml
+++ b/assets/xml/objects/object_fb.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_fb" Segment="6">
-        <Animation Name="object_fb_Anim_0006D8" Offset="0x6D8" />
-        <Animation Name="object_fb_Anim_0007D4" Offset="0x7D4" />
-        <Animation Name="object_fb_Anim_000ACC" Offset="0xACC" />
-        <Animation Name="object_fb_Anim_001174" Offset="0x1174" />
-        <Animation Name="object_fb_Anim_0013AC" Offset="0x13AC" />
+        <Animation Name="object_fb_Anim_0006D8" Offset="0x6D8" /> <!-- Original name is "fb_eat" -->
+        <Animation Name="object_fb_Anim_0007D4" Offset="0x7D4" /> <!-- Original name is "fb_fastswim" -->
+        <Animation Name="object_fb_Anim_000ACC" Offset="0xACC" /> <!-- Original name is "fb_neweat" -->
+        <Animation Name="object_fb_Anim_001174" Offset="0x1174" /> <!-- Original name is "fb_spitout" -->
+        <Animation Name="object_fb_Anim_0013AC" Offset="0x13AC" /> <!-- Original name is "fb_swim" -->
         <DList Name="object_fb_DL_002000" Offset="0x2000" />
         <DList Name="object_fb_DL_002088" Offset="0x2088" />
         <DList Name="object_fb_DL_002110" Offset="0x2110" />

--- a/assets/xml/objects/object_firefly.xml
+++ b/assets/xml/objects/object_firefly.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_firefly" Segment="6">
-        <Animation Name="object_firefly_Anim_00017C" Offset="0x17C" />
+        <Animation Name="object_firefly_Anim_00017C" Offset="0x17C" /> <!-- Original name is "firefly_foot_fly" -->
         <Texture Name="object_firefly_Tex_000190" OutName="tex_000190" Format="rgba16" Width="8" Height="8" Offset="0x190" />
         <Texture Name="object_firefly_Tex_000210" OutName="tex_000210" Format="rgba16" Width="8" Height="8" Offset="0x210" />
         <Texture Name="object_firefly_Tex_000290" OutName="tex_000290" Format="rgba16" Width="8" Height="8" Offset="0x290" />

--- a/assets/xml/objects/object_fish.xml
+++ b/assets/xml/objects/object_fish.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_fish" Segment="6">
-        <Animation Name="gFishingFishAnim" Offset="0x7C" />
+        <Animation Name="gFishingFishAnim" Offset="0x7C" /> <!-- Original name is "basu" -->
         <DList Name="object_fish_DL_000940" Offset="0x940" />
         <DList Name="object_fish_DL_0009E8" Offset="0x9E8" />
         <DList Name="object_fish_DL_000B00" Offset="0xB00" />
@@ -54,10 +54,10 @@
         <Texture Name="object_fish_Tex_003778" OutName="tex_003778" Format="rgba16" Width="16" Height="16" Offset="0x3778" />
         <DList Name="gFishingRainSplashMaterialDL" Offset="0x39A8" />
         <DList Name="gFishingRainSplashModelDL" Offset="0x3A18" />
-        <Animation Name="gFishingOwnerAnim" Offset="0x453C" />
+        <Animation Name="gFishingOwnerAnim" Offset="0x453C" /> <!-- Original name is "fs_matsu" -->
         <DList Name="object_fish_DL_006F60" Offset="0x6F60" />
         <DList Name="gFishingOwnerHairDL" Offset="0x7350" />
-        <DList Name="gFishingOwnerHatDL" Offset="0x74C8" />
+        <DList Name="gFishingOwnerHatDL" Offset="0x74C8" /> <!-- Original name is "fs_cap_model" -->
         <DList Name="object_fish_DL_0076B8" Offset="0x76B8" />
         <DList Name="object_fish_DL_007CF8" Offset="0x7CF8" />
         <DList Name="object_fish_DL_007E48" Offset="0x7E48" />
@@ -78,7 +78,7 @@
         <DList Name="gFishingRippleModelDL" Offset="0x8678" />
         <Texture Name="object_fish_Tex_008690" OutName="tex_008690" Format="i4" Width="32" Height="32" Offset="0x8690" />
         <DList Name="gFishingWaterDustMaterialDL" Offset="0x88C0" />
-        <DList Name="gFishingWaterDustModelDL" Offset="0x8970" />
+        <DList Name="gFishingWaterDustModelDL" Offset="0x8970" /> <!-- Original name is "fs_smoke_modelT" -->
         <Texture Name="object_fish_TLUT_008990" OutName="tlut_008990" Format="rgba16" Width="16" Height="16" Offset="0x8990" />
         <Texture Name="object_fish_Tex_008B90" OutName="tex_008B90" Format="ci8" Width="8" Height="8" Offset="0x8B90" />
         <Texture Name="object_fish_Tex_008BD0" OutName="tex_008BD0" Format="ci8" Width="16" Height="16" Offset="0x8BD0" />
@@ -99,10 +99,10 @@
         <DList Name="gFishingSinkingLureSegmentModelDL" Offset="0xB9C0" />
         <Texture Name="object_fish_Tex_00B9E0" OutName="tex_00B9E0" Format="rgba16" Width="64" Height="16" Offset="0xB9E0" />
         <DList Name="gFishingGroupFishMaterialDL" Offset="0xC220" />
-        <DList Name="gFishingGroupFishModelDL" Offset="0xC298" />
+        <DList Name="gFishingGroupFishModelDL" Offset="0xC298" /> <!-- Original name is "minnow_model" -->
         <DList Name="object_fish_DL_00C650" Offset="0xC650" />
         <Texture Name="object_fish_Tex_00C780" OutName="tex_00C780" Format="rgba16" Width="32" Height="32" Offset="0xC780" />
-        <Animation Name="gFishingLoachAnim" Offset="0xCFE0" />
+        <Animation Name="gFishingLoachAnim" Offset="0xCFE0" /> <!-- Original name is "nz_namazu" -->
         <DList Name="object_fish_DL_00DED0" Offset="0xDED0" />
         <DList Name="object_fish_DL_00DFA8" Offset="0xDFA8" />
         <DList Name="object_fish_DL_00E048" Offset="0xE048" />
@@ -137,26 +137,26 @@
         <Texture Name="gFishingRodSegmentBlackTex" OutName="tex_011170" Format="rgba16" Width="16" Height="8" Offset="0x11170" />
         <Texture Name="gFishingRodSegmentWhiteTex" OutName="tex_011270" Format="rgba16" Width="16" Height="8" Offset="0x11270" />
         <DList Name="gFishingRodSetupDL" Offset="0x113D0" />
-        <DList Name="gFishingRodSegmentDL" Offset="0x11410" />
+        <DList Name="gFishingRodSegmentDL" Offset="0x11410" /> <!-- Original name is "rod_model" -->
         <Texture Name="object_fish_Tex_011440" OutName="tex_011440" Format="rgba16" Width="32" Height="32" Offset="0x11440" />
         <Texture Name="object_fish_Tex_011C40" OutName="tex_011C40" Format="rgba16" Width="32" Height="16" Offset="0x11C40" />
-        <DList Name="gFishingLureHookDL" Offset="0x12160" />
-        <DList Name="gFishingLureFloatDL" Offset="0x121F0" />
+        <DList Name="gFishingLureHookDL" Offset="0x12160" /> <!-- Original name is "rua_hari_model" -->
+        <DList Name="gFishingLureFloatDL" Offset="0x121F0" /> <!-- Original name is "rua_body_model" -->
         <Texture Name="object_fish_Tex_0122E0" OutName="tex_0122E0" Format="rgba16" Width="32" Height="32" Offset="0x122E0" />
         <Texture Name="object_fish_Tex_012AE0" OutName="tex_012AE0" Format="rgba16" Width="32" Height="32" Offset="0x12AE0" />
         <DList Name="gFishingLilyPadMaterialDL" Offset="0x13330" />
-        <DList Name="gFishingLilyPadModelDL" Offset="0x133B0" />
+        <DList Name="gFishingLilyPadModelDL" Offset="0x133B0" /> <!-- Original name is "turi_hasu_model" -->
         <DList Name="gFishingRockMaterialDL" Offset="0x13590" />
         <DList Name="gFishingRockModelDL" Offset="0x13610" />
         <Texture Name="object_fish_Tex_013660" OutName="tex_013660" Format="rgba16" Width="32" Height="32" Offset="0x13660" />
         <DList Name="gFishingWoodPostMaterialDL" Offset="0x13F50" />
         <DList Name="gFishingWoodPostModelDL" Offset="0x13FD0" />
         <DList Name="gFishingReedMaterialDL" Offset="0x14030" />
-        <DList Name="gFishingReedModelDL" Offset="0x140B0" />
+        <DList Name="gFishingReedModelDL" Offset="0x140B0" /> <!-- Original name is "turi_kusa_model" -->
         <Texture Name="object_fish_Tex_0140D0" OutName="tex_0140D0" Format="rgba16" Width="16" Height="16" Offset="0x140D0" />
         <Texture Name="object_fish_Tex_0142D0" OutName="tex_0142D0" Format="rgba16" Width="32" Height="32" Offset="0x142D0" />
         <Texture Name="object_fish_Tex_014AD0" OutName="tex_014AD0" Format="i8" Width="32" Height="32" Offset="0x14AD0" />
         <DList Name="gFishingAquariumBottomDL" Offset="0x153D0" />
-        <DList Name="gFishingAquariumContainerDL" Offset="0x15470" />
+        <DList Name="gFishingAquariumContainerDL" Offset="0x15470" /> <!-- Original name is "turi_suisou_modelT" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_flowerpot.xml
+++ b/assets/xml/objects/object_flowerpot.xml
@@ -3,9 +3,9 @@
         <Texture Name="object_flowerpot_Tex_000000" OutName="tex_000000" Format="rgba16" Width="16" Height="32" Offset="0x0" />
         <Texture Name="object_flowerpot_Tex_000400" OutName="tex_000400" Format="rgba16" Width="16" Height="32" Offset="0x400" />
         <Texture Name="object_flowerpot_Tex_000800" OutName="tex_000800" Format="rgba16" Width="32" Height="32" Offset="0x800" />
-        <DList Name="object_flowerpot_DL_0012E0" Offset="0x12E0" />
-        <DList Name="object_flowerpot_DL_001408" Offset="0x1408" />
-        <DList Name="object_flowerpot_DL_0014F0" Offset="0x14F0" />
-        <DList Name="object_flowerpot_DL_0015B0" Offset="0x15B0" />
+        <DList Name="object_flowerpot_DL_0012E0" Offset="0x12E0" /> <!-- Original name is "hati01_model" -->
+        <DList Name="object_flowerpot_DL_001408" Offset="0x1408" /> <!-- Original name is "kusa_nearT_model" -->
+        <DList Name="object_flowerpot_DL_0014F0" Offset="0x14F0" /> <!-- Original name is "haT_model" -->
+        <DList Name="object_flowerpot_DL_0015B0" Offset="0x15B0" /> <!-- Original name is "hati02_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_fr.xml
+++ b/assets/xml/objects/object_fr.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_fr" Segment="6">
-        <Animation Name="object_fr_Anim_0007BC" Offset="0x7BC" />
-        <Animation Name="object_fr_Anim_0011C0" Offset="0x11C0" />
-        <Animation Name="object_fr_Anim_001534" Offset="0x1534" />
+        <Animation Name="object_fr_Anim_0007BC" Offset="0x7BC" /> <!-- Original name is "Jump" -->
+        <Animation Name="object_fr_Anim_0011C0" Offset="0x11C0" /> <!-- Original name is "swing" -->
+        <Animation Name="object_fr_Anim_001534" Offset="0x1534" /> <!-- Original name is "wait" -->
         <Texture Name="object_fr_Tex_001550" OutName="tex_001550" Format="rgba16" Width="32" Height="32" Offset="0x1550" />
         <!-- <Blob Name="object_fr_Blob_001D50" Size="0x1D50" Offset="0x1D50" /> -->
         <Texture Name="object_fr_Tex_003AA0" OutName="tex_003AA0" Format="i8" Width="16" Height="16" Offset="0x3AA0" />

--- a/assets/xml/objects/object_fsn.xml
+++ b/assets/xml/objects/object_fsn.xml
@@ -57,15 +57,14 @@
         <TextureAnimation Name="gFsnEyeTexAnim" Offset="0xB664" />
         
         <!-- Animations -->
-        <Animation Name="gFsnSlamCounterStartAnim" Offset="0xB9D8" />
-        <Animation Name="gFsnSlamCounterLoopAnim" Offset="0xC26C" />
-        <Animation Name="gFsnTurnAroundAnim" Offset="0xC58C" />
-        <Animation Name="gFsnHandOnFaceStartAnim" Offset="0xCB3C" />
-        <Animation Name="gFsnHandOnFaceLoopAnim" Offset="0xD354" />
-        <Animation Name="gFsnMakeOfferAnim" Offset="0xDE34" />
-        <Animation Name="gFsnHandsOnCounterStartAnim" Offset="0xE3EC" />
-        <Animation Name="gFsnHandsOnCounterLoopAnim" Offset="0xF00C" />
-
+        <Animation Name="gFsnSlamCounterStartAnim" Offset="0xB9D8" /> <!-- Original name is "fsn_dekuwait01" -->
+        <Animation Name="gFsnSlamCounterLoopAnim" Offset="0xC26C" /> <!-- Original name is "fsn_dekuwait02" -->
+        <Animation Name="gFsnTurnAroundAnim" Offset="0xC58C" /> <!-- Original name is "fsn_furimuki" -->
+        <Animation Name="gFsnHandOnFaceStartAnim" Offset="0xCB3C" /> <!-- Original name is "fsn_goronwait01" -->
+        <Animation Name="gFsnHandOnFaceLoopAnim" Offset="0xD354" /> <!-- Original name is "fsn_goronwait02" -->
+        <Animation Name="gFsnMakeOfferAnim" Offset="0xDE34" /> <!-- Original name is "fsn_kane" -->
+        <Animation Name="gFsnHandsOnCounterStartAnim" Offset="0xE3EC" /> <!-- Original name is "fsn_nwait01" -->
+        <Animation Name="gFsnHandsOnCounterLoopAnim" Offset="0xF00C" /> <!-- Original name is "fsn_nwait02" -->
 
         <!-- Glasses DLists -->
         <DList Name="gFsnGlassesFrameDL" Offset="0xF180" />
@@ -78,8 +77,8 @@
         <!-- <Blob Name="object_fsn_Blob_00FB30" Size="0x3040" Offset="0xFB30" /> -->
         
         <!-- Animations -->
-        <Animation Name="gFsnIdleAnim" Offset="0x12C34" />
-        <Animation Name="gFsnScratchBackAnim" Offset="0x131FC" />
+        <Animation Name="gFsnIdleAnim" Offset="0x12C34" /> <!-- Original name is "fsn_wait" -->
+        <Animation Name="gFsnScratchBackAnim" Offset="0x131FC" /> <!-- Original name is "fsn_wait01" -->
 
         <!-- Limbs -->
         <Limb Name="gFsnPelvisLimb" Type="Standard" EnumName="FSN_LIMB_PELVIS" Offset="0x13210" />
@@ -106,7 +105,7 @@
         <Skeleton Name="gFsnSkel" Type="Flex" LimbType="Standard" LimbNone="FSN_LIMB_NONE" LimbMax="FSN_LIMB_MAX" EnumName="FsnLimb" Offset="0x13320" />
 
         <!-- Animations -->
-        <Animation Name="gFsnLeanForwardStartAnim" Offset="0x138B0" />
-        <Animation Name="gFsnLeanForwardLoopAnim" Offset="0x1430C" />
+        <Animation Name="gFsnLeanForwardStartAnim" Offset="0x138B0" /> <!-- Original name is "fsn_zorawait01" -->
+        <Animation Name="gFsnLeanForwardLoopAnim" Offset="0x1430C" /> <!-- Original name is "fsn_zorawait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_fu.xml
+++ b/assets/xml/objects/object_fu.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_fu" Segment="6">
-        <Animation Name="object_fu_Anim_00057C" Offset="0x57C" />
-        <Animation Name="object_fu_Anim_000B04" Offset="0xB04" />
+        <Animation Name="object_fu_Anim_00057C" Offset="0x57C" /> <!-- Original name is "are_are" -->
+        <Animation Name="object_fu_Anim_000B04" Offset="0xB04" /> <!-- Original name is "fu_mawasu" -->
         <DList Name="object_fu_DL_003130" Offset="0x3130" />
         <DList Name="object_fu_DL_003320" Offset="0x3320" />
         <DList Name="object_fu_DL_0036A0" Offset="0x36A0" />

--- a/assets/xml/objects/object_fu_kaiten.xml
+++ b/assets/xml/objects/object_fu_kaiten.xml
@@ -1,18 +1,18 @@
 ﻿<Root>
     <File Name="object_fu_kaiten" Segment="6">
-        <DList Name="object_fu_kaiten_DL_0005D0" Offset="0x5D0" />
+        <DList Name="object_fu_kaiten_DL_0005D0" Offset="0x5D0" /> <!-- Original name is "dai_model" -->
         <Texture Name="object_fu_kaiten_TLUT_000858" OutName="tlut_000858" Format="rgba16" Width="4" Height="4" Offset="0x858" />
         <Texture Name="object_fu_kaiten_Tex_000878" OutName="tex_000878" Format="ci4" Width="64" Height="64" Offset="0x878" />
         <Texture Name="object_fu_kaiten_Tex_001078" OutName="tex_001078" Format="rgba16" Width="16" Height="64" Offset="0x1078" />
         <Texture Name="object_fu_kaiten_Tex_001878" OutName="tex_001878" Format="rgba16" Width="32" Height="32" Offset="0x1878" />
         <Texture Name="object_fu_kaiten_Tex_002078" OutName="tex_002078" Format="rgba16" Width="32" Height="32" Offset="0x2078" />
-        <Collision Name="object_fu_kaiten_Colheader_002D30" Offset="0x2D30" />
-        <DList Name="object_fu_kaiten_DL_002EB0" Offset="0x2EB0" />
+        <Collision Name="object_fu_kaiten_Colheader_002D30" Offset="0x2D30" /> <!-- Original name is "z2_bowling_dai_bgdatainfo" -->
+        <DList Name="object_fu_kaiten_DL_002EB0" Offset="0x2EB0" /> <!-- Original name is "z2_bowling_mizu_modelT" -->
         <DList Name="object_fu_kaiten_DL_002FB0" Offset="0x2FB0" />
         <DList Name="object_fu_kaiten_DL_002FC0" Offset="0x2FC0" />
         <Texture Name="object_fu_kaiten_Tex_002FD0" OutName="tex_002FD0" Format="rgba16" Width="32" Height="32" Offset="0x2FD0" />
         <TextureAnimation Name="object_fu_kaiten_Matanimheader_0037D8" Offset="0x37D8" />
         <!-- <Blob Name="object_fu_kaiten_Blob_0037E0" Size="0x18" Offset="0x37E0" /> -->
-        <Collision Name="object_fu_kaiten_Colheader_0037F8" Offset="0x37F8" />
+        <Collision Name="object_fu_kaiten_Colheader_0037F8" Offset="0x37F8" /> <!-- Original name is "z2_bowling_mizu_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_fu_mato.xml
+++ b/assets/xml/objects/object_fu_mato.xml
@@ -1,21 +1,21 @@
 ﻿<Root>
     <File Name="object_fu_mato" Segment="6">
-        <DList Name="object_fu_mato_DL_0006A0" Offset="0x6A0" />
-        <DList Name="object_fu_mato_DL_000740" Offset="0x740" />
-        <DList Name="object_fu_mato_DL_0007E0" Offset="0x7E0" />
-        <DList Name="object_fu_mato_DL_000880" Offset="0x880" />
-        <DList Name="object_fu_mato_DL_000920" Offset="0x920" />
-        <DList Name="object_fu_mato_DL_0009C0" Offset="0x9C0" />
+        <DList Name="object_fu_mato_DL_0006A0" Offset="0x6A0" /> <!-- Original name is "kago1_model" -->
+        <DList Name="object_fu_mato_DL_000740" Offset="0x740" /> <!-- Original name is "kago2_model" -->
+        <DList Name="object_fu_mato_DL_0007E0" Offset="0x7E0" /> <!-- Original name is "kago3_model" -->
+        <DList Name="object_fu_mato_DL_000880" Offset="0x880" /> <!-- Original name is "kago4_model" -->
+        <DList Name="object_fu_mato_DL_000920" Offset="0x920" /> <!-- Original name is "kago5_model" -->
+        <DList Name="object_fu_mato_DL_0009C0" Offset="0x9C0" /> <!-- Original name is "kago6_model" -->
         <Texture Name="object_fu_mato_Tex_000A60" OutName="tex_000A60" Format="rgba16" Width="32" Height="32" Offset="0xA60" />
-        <Collision Name="object_fu_mato_Colheader_0015C0" Offset="0x15C0" />
-        <DList Name="object_fu_mato_DL_001C80" Offset="0x1C80" />
-        <DList Name="object_fu_mato_DL_001D68" Offset="0x1D68" />
-        <DList Name="object_fu_mato_DL_001E50" Offset="0x1E50" />
-        <DList Name="object_fu_mato_DL_001F38" Offset="0x1F38" />
-        <DList Name="object_fu_mato_DL_002020" Offset="0x2020" />
-        <DList Name="object_fu_mato_DL_002108" Offset="0x2108" />
-        <Collision Name="object_fu_mato_Colheader_0023D4" Offset="0x23D4" />
-        <DList Name="object_fu_mato_DL_002720" Offset="0x2720" />
+        <Collision Name="object_fu_mato_Colheader_0015C0" Offset="0x15C0" /> <!-- Original name is "z2_bowling_kago_bgdatainfo" -->
+        <DList Name="object_fu_mato_DL_001C80" Offset="0x1C80" /> <!-- Original name is "mato1_model" -->
+        <DList Name="object_fu_mato_DL_001D68" Offset="0x1D68" /> <!-- Original name is "mato2_model" -->
+        <DList Name="object_fu_mato_DL_001E50" Offset="0x1E50" /> <!-- Original name is "mato3_model" -->
+        <DList Name="object_fu_mato_DL_001F38" Offset="0x1F38" /> <!-- Original name is "mato4_model" -->
+        <DList Name="object_fu_mato_DL_002020" Offset="0x2020" /> <!-- Original name is "mato5_model" -->
+        <DList Name="object_fu_mato_DL_002108" Offset="0x2108" /> <!-- Original name is "mato6_model" -->
+        <Collision Name="object_fu_mato_Colheader_0023D4" Offset="0x23D4" /> <!-- Original name is "z2_bowling_mato_bgdatainfo" -->
+        <DList Name="object_fu_mato_DL_002720" Offset="0x2720" /> <!-- Original name is "mato_model" -->
         <Texture Name="object_fu_mato_Tex_002850" OutName="tex_002850" Format="rgba16" Width="16" Height="16" Offset="0x2850" />
         <Texture Name="object_fu_mato_Tex_002A50" OutName="tex_002A50" Format="rgba16" Width="16" Height="64" Offset="0x2A50" />
     </File>

--- a/assets/xml/objects/object_funen.xml
+++ b/assets/xml/objects/object_funen.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_funen" Segment="6">
-        <DList Name="object_funen_DL_0000D0" Offset="0xD0" />
+        <DList Name="object_funen_DL_0000D0" Offset="0xD0" /> <!-- Original name is "obj_smork_modelT" -->
         <Texture Name="object_funen_Tex_0001C0" OutName="tex_0001C0" Format="ia8" Width="32" Height="32" Offset="0x1C0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_fusen.xml
+++ b/assets/xml/objects/object_fusen.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_fusen" Segment="6">
-        <DList Name="gMajoraBalloonDL" Offset="0xA00" />
-        <DList Name="gMajoraBalloonKnotDL" Offset="0xD78" />
+        <DList Name="gMajoraBalloonDL" Offset="0xA00" /> <!-- Original name is "sphere1_model" -->
+        <DList Name="gMajoraBalloonKnotDL" Offset="0xD78" /> <!-- Original name is "musubu_model" -->
         <Texture Name="object_fusen_Tex_000E08" OutName="tex_000E08" Format="rgba16" Width="32" Height="32" Offset="0xE08" />
-        <Collision Name="object_fusen_Colheader_002420" Offset="0x2420" />
+        <Collision Name="object_fusen_Colheader_002420" Offset="0x2420" /> <!-- Original name is "zako_fusen_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_fwall.xml
+++ b/assets/xml/objects/object_fwall.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_fwall" Segment="6">
-        <DList Name="object_fwall_DL_000040" Offset="0x40" />
+        <DList Name="object_fwall_DL_000040" Offset="0x40" /> <!-- Original name is "m_Ffirewall_model" -->
         
         <!-- 0xA0 to 0x3520 are leftover textures from the OOT fire jet elevator in Fire Temple -->
         <Texture Name="gFireTempleBigVerticalFlame0Tex" OutName="fwall_fire_temple_big_vertical_flame_0" Format="ia8" Width="24" Height="80" Offset="0xA0" /> 


### PR DESCRIPTION
Pretty similar to my other PRs like this.

"But wait!" you might say. "Where's `object_fz`?" Well, MM3D's `zelda_fz.gar.lzs` looks like this:
![image](https://user-images.githubusercontent.com/12245827/221462253-9f6a0ed6-54c6-4dcc-a18e-ccb92b74fb19.png)

There are two things to note:
- The names actually look like the English name of the enemy.
- This *doesn't* have the Freezard in various "broken" states like the MM64 object has.

Thus, I'm pretty sure these were named by Grezzo, and are *not* the original names of the MM64 assets.

Now to take a big sip of water and check how many objects start with  `object_g*`...