### PR TITLE
Introduce `SaveContext.gameMode` enum

### DIFF
--- a/include/z64save.h
+++ b/include/z64save.h
@@ -406,6 +406,14 @@ typedef enum SunsSongState {
     /* 3 */ SUNSSONG_SPECIAL // time does not advance, but signals the song was played. used for freezing redeads
 } SunsSongState;
 
+typedef enum {
+    /* 0 */ GAMEMODE_NORMAL,
+    /* 1 */ GAMEMODE_TITLE_SCREEN,
+    /* 2 */ GAMEMODE_FILE_SELECT,
+    /* 3 */ GAMEMODE_END_CREDITS,
+    /* 4 */ GAMEMODE_4,
+} GameMode;
+
 // linkAge still exists in MM, but is always set to 0 (always adult)
 // There are remnants of these macros from OOT, but they are essentially useless
 #define LINK_IS_CHILD (gSaveContext.save.linkAge == 1)

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -411,7 +411,7 @@ typedef enum {
     /* 1 */ GAMEMODE_TITLE_SCREEN,
     /* 2 */ GAMEMODE_FILE_SELECT,
     /* 3 */ GAMEMODE_END_CREDITS,
-    /* 4 */ GAMEMODE_4,
+    /* 4 */ GAMEMODE_OWL_SAVE,
 } GameMode;
 
 // linkAge still exists in MM, but is always set to 0 (always adult)

--- a/include/z64save.h
+++ b/include/z64save.h
@@ -411,7 +411,7 @@ typedef enum {
     /* 1 */ GAMEMODE_TITLE_SCREEN,
     /* 2 */ GAMEMODE_FILE_SELECT,
     /* 3 */ GAMEMODE_END_CREDITS,
-    /* 4 */ GAMEMODE_OWL_SAVE,
+    /* 4 */ GAMEMODE_OWL_SAVE
 } GameMode;
 
 // linkAge still exists in MM, but is always set to 0 (always adult)

--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -559,7 +559,7 @@ void Cutscene_TerminatorImpl(PlayState* play, CutsceneContext* csCtx, CsCmdBase*
     Audio_SetCutsceneFlag(false);
     gSaveContext.cutsceneTransitionControl = 1;
 
-    if ((gSaveContext.gameMode != 0) && (csCtx->frames != cmd->startFrame)) {
+    if ((gSaveContext.gameMode != GAMEMODE_NORMAL) && (csCtx->frames != cmd->startFrame)) {
         gSaveContext.hudVisibilityForceButtonAlphasByStatus = true;
     }
 
@@ -568,7 +568,7 @@ void Cutscene_TerminatorImpl(PlayState* play, CutsceneContext* csCtx, CsCmdBase*
         play->nextEntrance = play->csCtx.sceneCsList[play->csCtx.currentCsIndex].nextEntrance;
         gSaveContext.nextCutsceneIndex = 0;
         play->transitionTrigger = TRANS_TRIGGER_START;
-        if (gSaveContext.gameMode != 1) {
+        if (gSaveContext.gameMode != GAMEMODE_TITLE_SCREEN) {
             Scene_SetExitFade(play);
         } else {
             D_801BB12C++;
@@ -1417,7 +1417,7 @@ void func_800EDA04(PlayState* play, CutsceneContext* csCtx) {
         }
 
         gSaveContext.save.cutscene = 0;
-        gSaveContext.gameMode = 0;
+        gSaveContext.gameMode = GAMEMODE_NORMAL;
         ActorCutscene_Stop(0x7F);
         Audio_SetCutsceneFlag(false);
         csCtx->state = CS_STATE_0;
@@ -1470,7 +1470,8 @@ void func_800EDBE0(PlayState* play) {
     SceneTableEntry* sp24;
     s32 temp_v0_3;
 
-    if (((gSaveContext.gameMode == 0) || (gSaveContext.gameMode == 1)) && (gSaveContext.respawnFlag <= 0)) {
+    if (((gSaveContext.gameMode == GAMEMODE_NORMAL) || (gSaveContext.gameMode == GAMEMODE_TITLE_SCREEN)) &&
+        (gSaveContext.respawnFlag <= 0)) {
         sp2A = func_800F21CC();
         if (sp2A != -1) {
             temp_v0_3 = func_800F2138(sp2A);

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -2933,7 +2933,7 @@ void Magic_Update(PlayState* play) {
             // Add magic until magicFillTarget is reached
             gSaveContext.save.playerData.magic += 0x10;
 
-            if ((gSaveContext.gameMode == 0) && (gSaveContext.sceneLayer < 4)) {
+            if ((gSaveContext.gameMode == GAMEMODE_NORMAL) && (gSaveContext.sceneLayer < 4)) {
                 play_sound(NA_SE_SY_GAUGE_UP - SFX_FLAG);
             }
 
@@ -3263,7 +3263,7 @@ void Interface_DrawClock(PlayState* play) {
     if (R_TIME_SPEED != 0) {
         if ((msgCtx->msgMode == 0) || ((play->actorCtx.flags & ACTORCTX_FLAG_1) && !Play_InCsMode(play)) ||
             (msgCtx->msgMode == 0) || ((msgCtx->currentTextId >= 0x100) && (msgCtx->currentTextId <= 0x200)) ||
-            (gSaveContext.gameMode == 3)) {
+            (gSaveContext.gameMode == GAMEMODE_END_CREDITS)) {
             if (!FrameAdvance_IsEnabled(&play->state) && !Environment_IsTimeStopped() && (gSaveContext.save.day < 4)) {
                 /**
                  * Changes Clock's transparancy depending if Player is moving or not and possibly other things

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -687,10 +687,10 @@ void Play_UpdateTransition(PlayState* this) {
                         D_801D0D54 = false;
                     }
 
-                    if (gSaveContext.gameMode == 4) {
+                    if (gSaveContext.gameMode == GAMEMODE_4) {
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
-                    } else if (gSaveContext.gameMode != 2) {
+                    } else if (gSaveContext.gameMode != GAMEMODE_FILE_SELECT) {
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, Play_Init, sizeof(PlayState));
                         gSaveContext.save.entrance = this->nextEntrance;
@@ -698,7 +698,7 @@ void Play_UpdateTransition(PlayState* this) {
                         if (gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE) {
                             gSaveContext.minigameStatus = MINIGAME_STATUS_END;
                         }
-                    } else { // 2
+                    } else { // GAMEMODE_FILE_SELECT
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, FileSelect_Init, sizeof(FileSelectState));
                     }
@@ -944,7 +944,7 @@ void Play_UpdateMain(PlayState* this) {
         }
         Play_UpdateTransition(this);
         if (gTransitionTileState != TRANS_TILE_READY) {
-            if ((gSaveContext.gameMode == 0) &&
+            if ((gSaveContext.gameMode == GAMEMODE_NORMAL) &&
                 (((this->msgCtx.msgMode == 0)) ||
                  ((this->msgCtx.currentTextId == 0xFF) && (this->msgCtx.msgMode == 0x42) &&
                   (this->msgCtx.unk12020 == 0x41)) ||
@@ -1074,7 +1074,7 @@ void Play_PostWorldDraw(PlayState* this) {
         KaleidoScopeCall_Draw(this);
     }
 
-    if (gSaveContext.gameMode == 0) {
+    if (gSaveContext.gameMode == GAMEMODE_NORMAL) {
         Interface_Draw(this);
     }
 
@@ -2201,7 +2201,8 @@ void Play_Init(GameState* thisx) {
 
     func_800EDDB0(this);
 
-    if (((gSaveContext.gameMode != 0) && (gSaveContext.gameMode != 1)) || (gSaveContext.save.cutscene >= 0xFFF0)) {
+    if (((gSaveContext.gameMode != GAMEMODE_NORMAL) && (gSaveContext.gameMode != GAMEMODE_TITLE_SCREEN)) ||
+        (gSaveContext.save.cutscene >= 0xFFF0)) {
         gSaveContext.unk_3DC0 = 0;
         Magic_Reset(this);
         gSaveContext.sceneLayer = (gSaveContext.save.cutscene & 0xF) + 1;
@@ -2262,7 +2263,7 @@ void Play_Init(GameState* thisx) {
     this->haltAllActors = false;
     this->unk_18844 = false;
 
-    if (gSaveContext.gameMode != 1) {
+    if (gSaveContext.gameMode != GAMEMODE_TITLE_SCREEN) {
         if (gSaveContext.nextTransitionType == TRANS_NEXT_TYPE_DEFAULT) {
             this->transitionType =
                 (Entrance_GetTransitionFlags(((void)0, gSaveContext.save.entrance) + sceneLayer) >> 7) & 0x7F;

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -687,7 +687,7 @@ void Play_UpdateTransition(PlayState* this) {
                         D_801D0D54 = false;
                     }
 
-                    if (gSaveContext.gameMode == GAMEMODE_4) {
+                    if (gSaveContext.gameMode == GAMEMODE_OWL_SAVE) {
                         STOP_GAMESTATE(&this->state);
                         SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));
                     } else if (gSaveContext.gameMode != GAMEMODE_FILE_SELECT) {

--- a/src/overlays/actors/ovl_En_Light/z_en_light.c
+++ b/src/overlays/actors/ovl_En_Light/z_en_light.c
@@ -52,7 +52,7 @@ void EnLight_Init(Actor* thisx, PlayState* play) {
     EnLight* this = THIS;
 
     if (!ENLIGHT_GET_4000(&this->actor)) {
-        if ((gSaveContext.gameMode == 3) || ENLIGHT_GET_2000(&this->actor)) {
+        if ((gSaveContext.gameMode == GAMEMODE_END_CREDITS) || ENLIGHT_GET_2000(&this->actor)) {
             Lights_PointNoGlowSetInfo(&this->lightInfo, this->actor.world.pos.x,
                                       ((this->actor.params < 0) ? 1 : 40) + (s32)this->actor.world.pos.y,
                                       this->actor.world.pos.z, 255, 255, 180, -1);

--- a/src/overlays/actors/ovl_En_Mag/z_en_mag.c
+++ b/src/overlays/actors/ovl_En_Mag/z_en_mag.c
@@ -388,7 +388,7 @@ void EnMag_Update(Actor* thisx, PlayState* play) {
                                     D_801BB12C = 0;
                                 }
                                 play_sound(NA_SE_SY_PIECE_OF_HEART);
-                                gSaveContext.gameMode = 2; // Go to FileChoose
+                                gSaveContext.gameMode = GAMEMODE_FILE_SELECT;
                                 play->transitionTrigger = TRANS_TRIGGER_START;
                                 play->transitionType = TRANS_TYPE_FADE_BLACK;
                                 play->nextEntrance = ENTRANCE(CUTSCENE, 0);

--- a/src/overlays/actors/ovl_En_Test4/z_en_test4.c
+++ b/src/overlays/actors/ovl_En_Test4/z_en_test4.c
@@ -315,7 +315,7 @@ void EnTest4_Init(Actor* thisx, PlayState* play) {
         if (CURRENT_DAY == 0) {
             if (gSaveContext.save.time < CLOCK_TIME(6, 1)) {
                 gSaveContext.save.time = CLOCK_TIME(6, 0);
-                gSaveContext.gameMode = 0;
+                gSaveContext.gameMode = GAMEMODE_NORMAL;
                 STOP_GAMESTATE(&play->state);
                 SET_NEXT_GAMESTATE(&play->state, DayTelop_Init, sizeof(DayTelopState));
                 this->unk_144 = 1;

--- a/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
+++ b/src/overlays/gamestates/ovl_daytelop/z_daytelop.c
@@ -73,7 +73,7 @@ void DayTelop_Update(DayTelopState* this, GameState* thisx) {
     this->transitionCountdown--;
     if (this->transitionCountdown == 0) {
         if (gSaveContext.save.day < 9) {
-            gSaveContext.gameMode = 0;
+            gSaveContext.gameMode = GAMEMODE_NORMAL;
         } else {
             gSaveContext.nextCutsceneIndex = 0xFFF6;
             gSaveContext.save.day = 1;

--- a/src/overlays/gamestates/ovl_opening/z_opening.c
+++ b/src/overlays/gamestates/ovl_opening/z_opening.c
@@ -13,7 +13,7 @@ void TitleSetup_SetupTitleScreen(TitleSetupState* this) {
     static s32 sOpeningCutscenes[] = { 0xFFFA, 0xFFFA };
 
     CLEAR_EVENTINF(EVENTINF_17);
-    gSaveContext.gameMode = 1;
+    gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
 
     Sram_InitNewSave();
 

--- a/src/overlays/gamestates/ovl_title/z_title.c
+++ b/src/overlays/gamestates/ovl_title/z_title.c
@@ -132,7 +132,7 @@ void ConsoleLogo_Main(GameState* thisx) {
     if (this->exit) {
         gSaveContext.seqId = (u8)NA_BGM_DISABLED;
         gSaveContext.ambienceId = AMBIENCE_ID_DISABLED;
-        gSaveContext.gameMode = 1;
+        gSaveContext.gameMode = GAMEMODE_TITLE_SCREEN;
 
         STOP_GAMESTATE(&this->state);
         SET_NEXT_GAMESTATE(&this->state, TitleSetup_Init, sizeof(TitleSetupState));


### PR DESCRIPTION
 `GAMEMODE_OWL_SAVE` is a new gamemode comparing to OoT and is set in z_message while processing the owl save. It can be seen here:

https://github.com/Decompollaborate/mm/blob/bd4086f0b80612e2f4c5ab4d58e4234ebcd8b4ee/src/code/z_message.c#L4885

Interestingly, `GAMEMODE_END_CREDITS` never seems to be set with the current decompiled code, although its usage is inferred from OoT (it's set in z_demo in OoT).

