### PR TITLE
Add  `--convert-statics=global-with-filename` flag to asm-processor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ OBJCOPY    := $(MIPS_BINUTILS_PREFIX)objcopy
 OBJDUMP    := $(MIPS_BINUTILS_PREFIX)objdump
 ASM_PROC   := python3 tools/asm-processor/build.py
 
-ASM_PROC_FLAGS := --input-enc=utf-8 --output-enc=euc-jp
+ASM_PROC_FLAGS := --input-enc=utf-8 --output-enc=euc-jp --convert-statics=global-with-filename
 
 IINC       := -Iinclude -Isrc -Iassets -Ibuild -I.
 


### PR DESCRIPTION
This flag makes the map file to actually have the static symbols and its corresponding addresses.

For example, having a `static` symbol like this:
```c
static struct_801F58B0 D_801F58B0[3][3];
```
Produces this in the map file
```
                0x00000000801f58b0                build/src/code/z_player_lib.o:D_801F58B0
```
Which should allow us to have less problems with static bss symbols.

It works by prefixing the filename to the symbol name.

It also works with in-function-static symbols