### PR TITLE
Ensure all boss title cards are extracted as IA8

### DIFF
--- a/assets/xml/objects/object_boss03.xml
+++ b/assets/xml/objects/object_boss03.xml
@@ -46,7 +46,7 @@
         <DList Name="gGyorgBubbleModelDL" Offset="0x7EB0" />
 
         <!-- Gyorg Title Card -->
-        <Texture Name="gGyorgTitleCardTex" OutName="gyorg_title_card" Format="i8" Width="128" Height="40" Offset="0x7EC8" />
+        <Texture Name="gGyorgTitleCardTex" OutName="gyorg_title_card" Format="ia8" Width="128" Height="40" Offset="0x7EC8" />
 
         <!-- Gyorg Limbs -->
         <Limb Name="gGyorgRootLimb" Type="Standard" EnumName="GYORG_LIMB_ROOT" Offset="0x92C8" />

--- a/assets/xml/objects/object_boss07.xml
+++ b/assets/xml/objects/object_boss07.xml
@@ -200,9 +200,9 @@
         <DList Name="gMajorasWrathSpinningTopDL" Offset="0x2F640" />
 
         <!-- Majora Title Cards -->
-        <Texture Name="gMajorasMaskTitleCardTex" OutName="majoras_mask_title_card" Format="i8" Width="128" Height="40" Offset="0x2F840" />
-        <Texture Name="gMajorasIncarnationTitleCardTex" OutName="majoras_incarnation_title_card" Format="i8" Width="128" Height="40" Offset="0x30C40" />
-        <Texture Name="gMajorasWrathTitleCardTex" OutName="majoras_wrath_title_card" Format="i8" Width="128" Height="40" Offset="0x32040" />
+        <Texture Name="gMajorasMaskTitleCardTex" OutName="majoras_mask_title_card" Format="ia8" Width="128" Height="40" Offset="0x2F840" />
+        <Texture Name="gMajorasIncarnationTitleCardTex" OutName="majoras_incarnation_title_card" Format="ia8" Width="128" Height="40" Offset="0x30C40" />
+        <Texture Name="gMajorasWrathTitleCardTex" OutName="majoras_wrath_title_card" Format="ia8" Width="128" Height="40" Offset="0x32040" />
 
         <!-- Majora's Wrath Limbs -->
         <Limb Name="gMajorasWrathRootLimb" Type="Standard" EnumName="MAJORAS_WRATH_LIMB_ROOT" Offset="0x33440" />

--- a/assets/xml/objects/object_boss_hakugin.xml
+++ b/assets/xml/objects/object_boss_hakugin.xml
@@ -101,6 +101,6 @@
         <Animation Name="gGohtGetUpFromSideAnim" Offset="0x14024" /> <!-- Unused. Original name is "iceb_up" -->
 
         <!-- Goht Title Card -->
-        <Texture Name="gGohtTitleCardTex" OutName="goht_title_card" Format="i8" Width="128" Height="40" Offset="0x14040" />
+        <Texture Name="gGohtTitleCardTex" OutName="goht_title_card" Format="ia8" Width="128" Height="40" Offset="0x14040" />
     </File>
 </Root>


### PR DESCRIPTION
Tharo noticed on discord that some of the boss title cards were being extracted as I8 when they *should* be IA8, as per this displaylist:
```c
gDPLoadTextureBlock(OVERLAY_DISP++, (s32*)titleCtx->texture, G_IM_FMT_IA, G_IM_SIZ_8b, width, height, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
```

I made sure all boss title cards were being extracted as IA8 here; if you don't see the title card in this PR, then it was *already* an IA8.