### PR TITLE
Add a Couple Disasm Hacks (Fix NON_MATCHING Builds)

### DIFF
--- a/src/code/z_collision_check.c
+++ b/src/code/z_collision_check.c
@@ -23,16 +23,24 @@ Vec3f D_801EE0D8;
 TriNorm D_801EE0E8[2];
 TriNorm D_801EE150;
 TriNorm D_801EE188;
+
+#ifndef NON_MATCHING
 Vec3f D_801EE1C0;
 Vec3f D_801EE1D0;
 Vec3f D_801EE1E0;
 Vec3f D_801EE1F0;
 EffectSparkInit D_801EE200;
+#endif
+
 TriNorm D_801EE6C8;
 TriNorm D_801EE700;
+
+#ifndef NON_MATCHING
 EffectSparkInit D_801EE738;
 EffectSparkInit D_801EEC00;
 EffectSparkInit D_801EF0C8;
+#endif
+
 TriNorm D_801EF590;
 TriNorm D_801EF5C8;
 TriNorm D_801EF600;

--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -2342,6 +2342,3 @@ void Play_Init(GameState* thisx) {
     sBombersNotebookOpen = false;
     BombersNotebook_Init(&sBombersNotebook);
 }
-
-//! TODO: fake symbol, remove when BombersNotebook_Update is matching
-u16 D_801D0D78[] = { 0, 0, 0, 0 };

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -177,6 +177,8 @@ def proper_name(symbol, in_data=False, is_symbol=True):
         return variables_ast[0x809C46DC][0] + " + 0x14"
     elif symbol == 0x801EF66D:  # z_message_nes constant-folding stray fairy array
         return variables_ast[0x801EF670][0] + f" - 0x{0x801EF670 - 0x801EF66D:X}"
+    elif symbol == 0x801EF51D:  # z_message constant-folding stray fairy array
+        return variables_ast[0x801EF670][0] + f" - 0x{0x801EF670 - 0x801EF51D:X}"
     elif symbol == 0x80A09740:  # boss_07 symbol with large addend folded into %lo
         return variables_ast[0x80A09A60][0] + f" - 0x{0x80A09A60 - 0x80A09740:X}"
     # bg_ikana_mirror symbol with large addend folded into %lo

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -179,6 +179,8 @@ def proper_name(symbol, in_data=False, is_symbol=True):
         return variables_ast[0x801EF670][0] + f" - 0x{0x801EF670 - 0x801EF66D:X}"
     elif symbol == 0x801EF51D:  # z_message constant-folding stray fairy array
         return variables_ast[0x801EF670][0] + f" - 0x{0x801EF670 - 0x801EF51D:X}"
+    elif symbol == 0x801D0D7A:  # play_hireso constant-folding D_801D0D80 array
+        return variables_ast[0x801D0D80][0] + f" - 0x{0x801D0D80 - 0x801D0D7A:X}"
     elif symbol == 0x80A09740:  # boss_07 symbol with large addend folded into %lo
         return variables_ast[0x80A09A60][0] + f" - 0x{0x80A09A60 - 0x80A09740:X}"
     # bg_ikana_mirror symbol with large addend folded into %lo

--- a/tools/disasm/variables.txt
+++ b/tools/disasm/variables.txt
@@ -2138,7 +2138,6 @@
     0x801D0D5C:("sIsCameraUnderwater","UNK_TYPE2","",0x2),
     0x801D0D60:("D_801D0D60","Input*","",0x4),
     0x801D0D64:("sPlayerCsIdToCsCamId","s16","[10]",0x14),
-    0x801D0D78:("D_801D0D78","u16","[4]",0x4),
     0x801D0D80:("D_801D0D80","UNK_TYPE1","",0x1),
     0x801D11F4:("D_801D11F4","UNK_TYPE1","",0x1),
     0x801D1230:("D_801D1230","UNK_TYPE1","",0x1),


### PR DESCRIPTION
This adds a couple of disasm hacks to 1 fix up the collision check bss for non-matchings, and 2 remove a fake symbol from play.

Main motivation was to fix up the collision check bss, as when building with NON_MATCHING it would error out the first time due to duplicate bss symbols from the in static function ones. Since I needed to add a hack for that, I thought I would just add one to remove the fake symbol from play, rather than wait for the function to be matched.