### PR TITLE
Use proper sequence names in certain actors

### DIFF
--- a/src/code/z_actor.c
+++ b/src/code/z_actor.c
@@ -2656,11 +2656,11 @@ void func_800B9D1C(Actor* actor) {
     if (sfxId) {}
 
     if (actor->audioFlags & 0x40) {
-        func_801A1FB4(3, &actor->projectedPos, NA_BGM_MUSIC_BOX_HOUSE, 1500.0f);
+        func_801A1FB4(SEQ_PLAYER_BGM_SUB, &actor->projectedPos, NA_BGM_MUSIC_BOX_HOUSE, 1500.0f);
     }
 
     if (actor->audioFlags & 0x20) {
-        func_801A1FB4(0, &actor->projectedPos, NA_BGM_KAMARO_DANCE, 900.0f);
+        func_801A1FB4(SEQ_PLAYER_BGM_MAIN, &actor->projectedPos, NA_BGM_KAMARO_DANCE, 900.0f);
     }
 }
 

--- a/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
+++ b/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
@@ -355,7 +355,7 @@ void func_80B0FD8C(EnGb2* this, PlayState* play) {
 }
 
 void func_80B0FE18(PlayState* play) {
-    func_800FD750(0x38);
+    func_800FD750(NA_BGM_MINI_BOSS);
     play->nextEntrance = ENTRANCE(GHOST_HUT, 1);
     play->transitionType = TRANS_TYPE_64;
     gSaveContext.nextTransitionType = TRANS_TYPE_64;

--- a/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
+++ b/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
@@ -284,7 +284,7 @@ void func_80C1410C(EnJgameTsn* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     player->stateFlags1 |= PLAYER_STATE1_20;
-    Audio_PlaySubBgm(0x25);
+    Audio_PlaySubBgm(NA_BGM_TIMED_MINI_GAME);
     play->interfaceCtx.minigameState = MINIGAME_STATE_COUNTDOWN_SETUP_3;
     Interface_InitMinigame(play);
     SET_WEEKEVENTREG(WEEKEVENTREG_90_20);

--- a/src/overlays/actors/ovl_En_Rz/z_en_rz.c
+++ b/src/overlays/actors/ovl_En_Rz/z_en_rz.c
@@ -446,7 +446,7 @@ void func_80BFC078(EnRz* this, PlayState* play) {
         sp28.x = this->actor.projectedPos.x;
         sp28.y = this->actor.projectedPos.y;
         sp28.z = this->actor.projectedPos.z;
-        func_801A1FB4(3, &sp28, NA_BGM_ROSA_SISTERS, 900.0f);
+        func_801A1FB4(SEQ_PLAYER_BGM_SUB, &sp28, NA_BGM_ROSA_SISTERS, 900.0f);
     }
 }
 
@@ -547,7 +547,7 @@ void func_80BFC3F8(EnRz* this, PlayState* play) {
             bgmPos.x = this->actor.projectedPos.x;
             bgmPos.y = this->actor.projectedPos.y;
             bgmPos.z = this->actor.projectedPos.z;
-            func_801A1FB4(3, &bgmPos, NA_BGM_ROSA_SISTERS, 900.0f);
+            func_801A1FB4(SEQ_PLAYER_BGM_SUB, &bgmPos, NA_BGM_ROSA_SISTERS, 900.0f);
         }
     }
 }

--- a/src/overlays/actors/ovl_En_Zob/z_en_zob.c
+++ b/src/overlays/actors/ovl_En_Zob/z_en_zob.c
@@ -588,7 +588,7 @@ void func_80BA0728(EnZob* this, PlayState* play) {
     sp28.x = this->actor.projectedPos.x;
     sp28.y = this->actor.projectedPos.y;
     sp28.z = this->actor.projectedPos.z;
-    func_801A1FB4(3, &sp28, 0x6C, 1000.0f);
+    func_801A1FB4(3, &sp28, NA_BGM_BASS_PLAY, 1000.0f);
 }
 
 void func_80BA08E8(EnZob* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zob/z_en_zob.c
+++ b/src/overlays/actors/ovl_En_Zob/z_en_zob.c
@@ -588,7 +588,7 @@ void func_80BA0728(EnZob* this, PlayState* play) {
     sp28.x = this->actor.projectedPos.x;
     sp28.y = this->actor.projectedPos.y;
     sp28.z = this->actor.projectedPos.z;
-    func_801A1FB4(3, &sp28, NA_BGM_BASS_PLAY, 1000.0f);
+    func_801A1FB4(SEQ_PLAYER_BGM_SUB, &sp28, NA_BGM_BASS_PLAY, 1000.0f);
 }
 
 void func_80BA08E8(EnZob* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zod/z_en_zod.c
+++ b/src/overlays/actors/ovl_En_Zod/z_en_zod.c
@@ -387,7 +387,7 @@ void EnZod_PlayDrumsSequence(EnZod* this, PlayState* play) {
     seqPos.y = this->actor.projectedPos.y;
     seqPos.z = this->actor.projectedPos.z;
 
-    func_801A1FB4(3, &seqPos, NA_BGM_DRUMS_PLAY, 700.0f);
+    func_801A1FB4(SEQ_PLAYER_BGM_SUB, &seqPos, NA_BGM_DRUMS_PLAY, 700.0f);
 }
 
 void func_80BAFA44(EnZod* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.c
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.c
@@ -582,7 +582,7 @@ void func_80BBBDE0(EnZos* this, PlayState* play) {
     sp28.x = this->actor.projectedPos.x;
     sp28.y = this->actor.projectedPos.y;
     sp28.z = this->actor.projectedPos.z;
-    func_801A1FB4(3, &sp28, 110, 1000.0f);
+    func_801A1FB4(3, &sp28, NA_BGM_PIANO_PLAY, 1000.0f);
 }
 
 void func_80BBBFBC(EnZos* this, PlayState* play) {

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.c
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.c
@@ -582,7 +582,7 @@ void func_80BBBDE0(EnZos* this, PlayState* play) {
     sp28.x = this->actor.projectedPos.x;
     sp28.y = this->actor.projectedPos.y;
     sp28.z = this->actor.projectedPos.z;
-    func_801A1FB4(3, &sp28, NA_BGM_PIANO_PLAY, 1000.0f);
+    func_801A1FB4(SEQ_PLAYER_BGM_SUB, &sp28, NA_BGM_PIANO_PLAY, 1000.0f);
 }
 
 void func_80BBBFBC(EnZos* this, PlayState* play) {


### PR DESCRIPTION
I went through `functions.h` and looked at all functions that had `seqId` has a parameter. Then, I looked at callers to these functions to make sure they weren't using raw integers. I only found four, but the one in EnAob01 is already covered in #1234, so I just left it alone.