### PR TITLE
Misc cleanup

### DIFF
--- a/include/z64.h
+++ b/include/z64.h
@@ -657,7 +657,7 @@ typedef struct {
 #define FLASHROM_REQUEST_WRITE 1
 #define FLASHROM_REQUEST_READ 2
 
-typedef enum framCommand {
+typedef enum FramCommand {
     /* Does nothing for FRAM_COMMAND_SET_MODE_READ_AND_STATUS, FRAM_MODE_NOP, FRAM_COMMAND_SET_MODE_STATUS_AND_STATUS
        Initializes fram to 0xFF in FRAM_MODE_ERASE
        Writes Contents in FLASHRAM_MODE_WRITE
@@ -681,15 +681,15 @@ typedef enum framCommand {
     FRAM_COMMAND_SET_MODE_READ_AND_STATUS = 0xF0000000,
     /* unk */
     FRAM_COMMAND_UNK_ERASE_OPERATION = 0x3C000000
-} framCommand;
+} FramCommand;
 
-typedef enum framMode {
+typedef enum FramMode {
     /* 0 */ FRAM_MODE_NOP,
     /* 1 */ FRAM_MODE_ERASE,
     /* 2 */ FRAM_MODE_WRITE,
     /* 3 */ FRAM_MODE_READ,
     /* 4 */ FRAM_MODE_STATUS
-} framMode;
+} FramMode;
 
 typedef enum {
     /* 0 */ VI_MODE_EDIT_STATE_INACTIVE,

--- a/src/boot_O2/sleep.c
+++ b/src/boot_O2/sleep.c
@@ -2,10 +2,10 @@
 
 void Sleep_Cycles(u64 time) {
     OSMesgQueue mq;
-    OSMesg msg;
+    OSMesg msg[1];
     OSTimer timer;
 
-    osCreateMesgQueue(&mq, &msg, OS_MESG_BLOCK);
+    osCreateMesgQueue(&mq, msg, ARRAY_COUNT(msg));
     osSetTimer(&timer, time, 0, &mq, NULL);
     osRecvMesg(&mq, NULL, OS_MESG_BLOCK);
 }

--- a/src/overlays/actors/ovl_En_Al/z_en_al.c
+++ b/src/overlays/actors/ovl_En_Al/z_en_al.c
@@ -480,10 +480,10 @@ s32 func_80BDEC2C(EnAl* this, PlayState* play) {
 
     if ((this->unk_4C2 & 7) && Actor_ProcessTalkRequest(&this->actor, &play->state)) {
         this->unk_4C2 &= ~0x1800;
-        if (player->exchangeItemId == 0x33) {
+        if (player->exchangeItemId == PLAYER_IA_LETTER_MAMA) {
             this->unk_4C2 |= 0x800;
             this->unk_4F4 = player->exchangeItemId;
-        } else if (player->exchangeItemId != 0) {
+        } else if (player->exchangeItemId != PLAYER_IA_NONE) {
             this->unk_4C2 |= 0x1000;
             this->unk_4F4 = player->exchangeItemId;
         }

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.c
@@ -67,7 +67,7 @@ void EnEncount1_Init(Actor* thisx, PlayState* play) {
     }
     if (this->type == EN_ENCOUNT1_SKULLFISH_2) {
         this->pathIndex = ENENCOUNT1_GET_PATH_INDEX(&this->actor);
-        this->path = SubS_GetPathByIndex(play, this->pathIndex, 0x3F);
+        this->path = SubS_GetPathByIndex(play, this->pathIndex, ENENCOUNT1_PATH_INDEX_NONE);
         this->spawnTotalMax = -1;
         this->spawnDistanceMax = -1.0f;
     }

--- a/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
+++ b/src/overlays/actors/ovl_En_Encount1/z_en_encount1.h
@@ -10,6 +10,8 @@
 #define ENENCOUNT1_GET_SPAWN_TOTAL_MAX(thisx) ((thisx)->params & 0x3F)
 #define ENENCOUNT1_GET_PATH_INDEX(thisx) ((thisx)->params & 0x3F) // Used only by EN_ENCOUNT1_SKULLFISH_2 which doesn't use SpawnTotalMax
 
+#define ENENCOUNT1_PATH_INDEX_NONE 0x3F
+
 #define ENENCOUNT1_GET_SPAWN_TIME_MIN(thisx) ((thisx)->world.rot.x) // Time to wait between spawning
 #define ENENCOUNT1_GET_SPAWN_UNUSED_PROP(thisx) ((thisx)->world.rot.y) // Unused spawn property
 #define ENENCOUNT1_GET_SPAWN_DISTANCE_MAX(thisx) ((thisx)->world.rot.z) // Negative means infinite distance

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -593,7 +593,7 @@ void func_808F4108(EnIn* this, PlayState* play, u16 textId) {
 }
 
 s32 func_808F4150(PlayState* play, EnIn* this, s32 arg2, MessageContext* msgCtx) {
-    EnIn* this2 = this;
+    Actor* thisx = &this->actor;
 
     if (msgCtx->choiceIndex == 0) {
         func_8019F208();
@@ -604,15 +604,15 @@ s32 func_808F4150(PlayState* play, EnIn* this, s32 arg2, MessageContext* msgCtx)
             } else if (this->unk4AC & 8) {
                 func_808F4108(this, play, 0x3475);
             } else {
-                Actor_ContinueText(play, &this->actor, 0x3475);
+                Actor_ContinueText(play, thisx, 0x3475);
             }
         } else {
             play_sound(NA_SE_SY_ERROR);
-            Actor_ContinueText(play, &this->actor, 0x3473);
+            Actor_ContinueText(play, thisx, 0x3473);
         }
     } else {
         func_8019F230();
-        Actor_ContinueText(play, &this->actor, 0x3472);
+        Actor_ContinueText(play, thisx, 0x3472);
     }
     return 0;
 }

--- a/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
+++ b/src/overlays/actors/ovl_En_Kusa2/z_en_kusa2.c
@@ -960,14 +960,14 @@ void func_80A5D7A4(EnKusa2* this) {
 }
 
 void func_80A5D7C4(EnKusa2* this, PlayState* play) {
-    EnKusa2* this2 = this;
+    Actor* thisx = &this->actor;
     s16 sp2A;
 
     if (Actor_HasParent(&this->actor, play)) {
-        SoundSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 20, NA_SE_PL_PULL_UP_PLANT);
-        this->actor.shape.shadowDraw = ActorShadow_DrawCircle;
-        this->actor.shape.shadowAlpha = 60;
-        this->actor.room = -1;
+        SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 20, NA_SE_PL_PULL_UP_PLANT);
+        thisx->shape.shadowDraw = ActorShadow_DrawCircle;
+        thisx->shape.shadowAlpha = 60;
+        thisx->room = -1;
         func_80A5BD94(this);
         func_80A5D964(this);
         return;
@@ -975,23 +975,23 @@ void func_80A5D7C4(EnKusa2* this, PlayState* play) {
 
     if (!func_80A5BFD8(this, play)) {
         if ((this->unk_1C0 != NULL) && (this->unk_1C0->unk_1BE != 0)) {
-            this->actor.shape.shadowDraw = ActorShadow_DrawCircle;
-            if (this2->unk_1C0 != NULL) {
-                sp2A = Actor_WorldYawTowardActor(&this->unk_1C0->actor, &this->actor);
-                this->actor.home.rot.y = Rand_S16Offset(-1500, 3000) + sp2A;
+            thisx->shape.shadowDraw = ActorShadow_DrawCircle;
+            if (this->unk_1C0 != NULL) {
+                sp2A = Actor_WorldYawTowardActor(&this->unk_1C0->actor, thisx);
+                thisx->home.rot.y = Rand_S16Offset(-1500, 3000) + sp2A;
             }
             this->unk_1C8 = Rand_S16Offset(72, 16);
-            this->actor.velocity.y = 8.8f;
-            Actor_PlaySfx(&this->actor, NA_SE_EN_NUTS_WALK);
+            thisx->velocity.y = 8.8f;
+            Actor_PlaySfx(thisx, NA_SE_EN_NUTS_WALK);
             func_80A5DC70(this);
         }
 
-        if (this->actor.xzDistToPlayer < 600.0f) {
+        if (thisx->xzDistToPlayer < 600.0f) {
             CollisionCheck_SetAC(play, &play->colChkCtx, &this->collider.base);
-            if (this->actor.xzDistToPlayer < 400.0f) {
+            if (thisx->xzDistToPlayer < 400.0f) {
                 CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
-                if (this->actor.xzDistToPlayer < 100.0f) {
-                    Actor_OfferCarry(&this->actor, play);
+                if (thisx->xzDistToPlayer < 100.0f) {
+                    Actor_OfferCarry(thisx, play);
                 }
             }
         }

--- a/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
+++ b/src/overlays/actors/ovl_En_Mushi2/z_en_mushi2.c
@@ -851,14 +851,14 @@ void func_80A6A508(Actor* thisx) {
 }
 
 void func_80A6A5C0(EnMushi2* this, PlayState* play) {
-    EnMushi2* this2 = this;
+    Actor* thisx = &this->actor;
 
     func_80A69D3C(this);
-    Math_SmoothStepToF(&this->actor.speed, this->unk_35C, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&thisx->speed, this->unk_35C, 0.1f, 0.5f, 0.0f);
     if (this->unk_354 < SQ(40.0f)) {
         f32 temp = 1.0f - ((SQ(40.0f) - this->unk_354) * (1.0f / (10.0f * SQ(40.0f))));
 
-        this->actor.speed *= temp;
+        thisx->speed *= temp;
     }
 
     func_80A68ED8(this);
@@ -867,8 +867,8 @@ void func_80A6A5C0(EnMushi2* this, PlayState* play) {
         func_80A69388(this);
     }
 
-    this->skelAnime.playSpeed = this->actor.speed * 1.6f;
-    this2->skelAnime.playSpeed = CLAMP(this2->skelAnime.playSpeed, 0.1f, 1.9f);
+    this->skelAnime.playSpeed = thisx->speed * 1.6f;
+    this->skelAnime.playSpeed = CLAMP(this->skelAnime.playSpeed, 0.1f, 1.9f);
 
     if ((this->unk_36A <= 0) || func_80A68BA0(this)) {
         func_80A6B078(this);
@@ -895,9 +895,9 @@ void func_80A6A794(EnMushi2* this) {
 }
 
 void func_80A6A824(EnMushi2* this, PlayState* play) {
-    EnMushi2* this2 = this;
+    Actor* thisx = &this->actor;
 
-    Math_SmoothStepToF(&this->actor.speed, this->unk_35C, 0.1f, 0.5f, 0.0f);
+    Math_SmoothStepToF(&thisx->speed, this->unk_35C, 0.1f, 0.5f, 0.0f);
     func_80A68ED8(this);
     func_80A697C4(this, play);
 
@@ -905,8 +905,8 @@ void func_80A6A824(EnMushi2* this, PlayState* play) {
         func_80A69388(this);
     }
 
-    this->skelAnime.playSpeed = (Rand_ZeroOne() * 0.8f) + (this->actor.speed * 1.2f);
-    this2->skelAnime.playSpeed = CLAMP(this2->skelAnime.playSpeed, 0.0f, 1.9f);
+    this->skelAnime.playSpeed = (Rand_ZeroOne() * 0.8f) + (thisx->speed * 1.2f);
+    this->skelAnime.playSpeed = CLAMP(this->skelAnime.playSpeed, 0.0f, 1.9f);
 
     if ((this->unk_36A <= 0) || func_80A68BA0(this)) {
         func_80A6B078(this);

--- a/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
+++ b/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
@@ -114,12 +114,12 @@ void EnTimeTag_RooftopOath_Cutscene(EnTimeTag* this, PlayState* play) {
 }
 
 void EnTimeTag_RooftopOath_Wait(EnTimeTag* this, PlayState* play) {
-    EnTimeTag* this2 = this;
+    Actor* thisx = &this->actor;
 
     if ((play->msgCtx.ocarinaMode == 3) && (play->msgCtx.lastPlayedSong == OCARINA_SONG_OATH)) {
-        if (this->actor.csId != CS_ID_NONE) {
+        if (thisx->csId != CS_ID_NONE) {
             this->actionFunc = EnTimeTag_RooftopOath_Cutscene;
-            CutsceneManager_Queue(this2->actor.csId);
+            CutsceneManager_Queue(thisx->csId);
             gSaveContext.timerStates[TIMER_ID_MOON_CRASH] = TIMER_STATE_OFF;
         }
         play->msgCtx.ocarinaMode = 4;

--- a/src/overlays/actors/ovl_En_Tru/z_en_tru.c
+++ b/src/overlays/actors/ovl_En_Tru/z_en_tru.c
@@ -692,10 +692,11 @@ s32 func_80A872AC(EnTru* this, PlayState* play) {
             }
             this->unk_34E &= ~(0x4000 | 0x2000);
 
-            if ((player->exchangeItemId == 35) || (player->exchangeItemId == 36)) {
+            if ((player->exchangeItemId == PLAYER_IA_BOTTLE_POTION_RED) ||
+                (player->exchangeItemId == PLAYER_IA_BOTTLE_POTION_BLUE)) {
                 this->unk_34E |= 0x2000;
                 this->unk_38C = player->exchangeItemId;
-            } else if (player->exchangeItemId != 0) {
+            } else if (player->exchangeItemId != PLAYER_IA_NONE) {
                 this->unk_34E |= 0x4000;
             }
 
@@ -972,8 +973,8 @@ s32 func_80A87B48(Actor* thisx, PlayState* play) {
                     this->actor.shape.shadowDraw = NULL;
                     this->unk_34E |= (0x200 | 0x8);
                     this->unk_34E &= ~0x800;
-                    if (player->exchangeItemId != 0) {
-                        player->exchangeItemId = 0;
+                    if (player->exchangeItemId != PLAYER_IA_NONE) {
+                        player->exchangeItemId = PLAYER_IA_NONE;
                     }
                     EnTru_ChangeAnim(this, KOUME_ANIM_HOVER1);
                 }

--- a/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
+++ b/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
@@ -420,7 +420,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
 
                     case 0x1075:
                     case 0x1078:
-                        player->exchangeItemId = 0;
+                        player->exchangeItemId = PLAYER_IA_NONE;
                         Message_ContinueTextbox(play, play->msgCtx.currentTextId + 1);
                         Animation_MorphToLoop(&this->unk_1D8->skelAnime, &object_tsn_Anim_0092FC, -10.0f);
                         break;
@@ -448,7 +448,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
                         break;
 
                     case 0x107B:
-                        player->exchangeItemId = 0;
+                        player->exchangeItemId = PLAYER_IA_NONE;
                         Message_ContinueTextbox(play, play->msgCtx.currentTextId + 1);
                         Animation_MorphToLoop(&this->unk_1D8->skelAnime, &object_tsn_Anim_0092FC, -10.0f);
                         break;

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.c
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.c
@@ -417,7 +417,7 @@ void func_80BBB8AC(EnZos* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_5) && Message_ShouldAdvance(play)) {
         switch (play->msgCtx.currentTextId) {
             case 0x1237:
-                player->exchangeItemId = 0;
+                player->exchangeItemId = PLAYER_IA_NONE;
 
             case 0x1238:
             case 0x123A:
@@ -436,7 +436,7 @@ void func_80BBB8AC(EnZos* this, PlayState* play) {
 
             case 0x1232:
             case 0x1241:
-                player->exchangeItemId = 0;
+                player->exchangeItemId = PLAYER_IA_NONE;
 
             case 0x1239:
             case 0x1246:

--- a/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.c
+++ b/src/overlays/actors/ovl_Obj_Chan/z_obj_chan.c
@@ -25,7 +25,7 @@ void ObjChan_Destroy(Actor* thisx, PlayState* play);
 void ObjChan_Update(Actor* thisx, PlayState* play);
 void ObjChan_Draw(Actor* thisx, PlayState* play);
 
-void ObjChan_ChandelierAction(ObjChan* this2, PlayState* play);
+void ObjChan_ChandelierAction(ObjChan* this, PlayState* play);
 void ObjChan_PotAction(ObjChan* this, PlayState* play);
 
 ActorInit Obj_Chan_InitVars = {
@@ -64,7 +64,7 @@ static InitChainEntry sInitChain[] = {
     ICHAIN_VEC3F_DIV1000(scale, 100, ICHAIN_STOP),
 };
 
-void ObjChan_InitChandelier(ObjChan* this2, PlayState* play);
+void ObjChan_InitChandelier(ObjChan* this, PlayState* play);
 void ObjChan_InitPot(ObjChan* this, PlayState* play);
 void ObjChan_CreateSmashEffects(ObjChan* this, PlayState* play);
 void ObjChan_DrawPot(Actor* thisx, PlayState* play);
@@ -99,9 +99,13 @@ void ObjChan_Init(Actor* thisx, PlayState* play) {
             this->actor.shape.rot.y = 0;
             ObjChan_InitChandelier(this, play);
             break;
+
         case OBJCHAN_SUBTYPE_POT:
             this->actor.draw = ObjChan_DrawPot;
             ObjChan_InitPot(this, play);
+            break;
+
+        default:
             break;
     }
 }
@@ -150,46 +154,44 @@ void ObjChan_CalculatePotPosition(Vec3f* childPosOut, Vec3s* childRotOut, Vec3f*
     childRotOut->y += childAngle;
 }
 
-//! TODO: Possibly takes actor and recasts
-void ObjChan_InitChandelier(ObjChan* this2, PlayState* play) {
-    ObjChan* this = this2;
+void ObjChan_InitChandelier(ObjChan* this, PlayState* play) {
+    Actor* thisx = &this->actor;
     s32 i;
-    ObjChan* temp_v0;
+    ObjChan* pot;
     Vec3f childPos;
     Vec3s childRot;
     CollisionPoly* sp94;
     s32 sp90;
     Vec3f sp84;
 
-    Math_Vec3f_Copy(&this->unk1C0, &this->actor.world.pos);
+    Math_Vec3f_Copy(&this->unk1C0, &thisx->world.pos);
 
-    Math_Vec3f_Copy(&sp84, &this->actor.world.pos);
+    Math_Vec3f_Copy(&sp84, &thisx->world.pos);
     sp84.y += 1600.0f;
-    if (BgCheck_EntityLineTest1(&play->colCtx, &this->actor.world.pos, &sp84, &this->unk1C0, &sp94, false, false, true,
-                                true, &sp90)) {
-        this->unk1CC = this->actor.world.pos.y - this->unk1C0.y;
+    if (BgCheck_EntityLineTest1(&play->colCtx, &thisx->world.pos, &sp84, &this->unk1C0, &sp94, false, false, true, true,
+                                &sp90)) {
+        this->unk1CC = thisx->world.pos.y - this->unk1C0.y;
     } else {
-        Actor_Kill(&this->actor);
+        Actor_Kill(thisx);
         return;
     }
 
     for (i = 0; i < 5; i++) {
-        ObjChan_CalculatePotPosition(&childPos, &childRot, &this->actor.world.pos, &this->actor.shape.rot,
+        ObjChan_CalculatePotPosition(&childPos, &childRot, &thisx->world.pos, &thisx->shape.rot,
                                      (s32)DEG_TO_BINANG_ALT3(i * 360.0f / 5.0f) + this->rotation);
-        temp_v0 = (ObjChan*)Actor_SpawnAsChildAndCutscene(&play->actorCtx, play, ACTOR_OBJ_CHAN, childPos.x, childPos.y,
-                                                          childPos.z, childRot.x, childRot.y, childRot.z,
-                                                          (this->actor.params & 0xFFF) | 0x1000, this->actor.csId,
-                                                          this->actor.halfDaysBits, &this->actor);
-        if (temp_v0 != NULL) {
-            this->pots[i] = temp_v0;
-            temp_v0->myPotIndex = i;
-            temp_v0->actor.csId = this->actor.csId;
+        pot = (ObjChan*)Actor_SpawnAsChildAndCutscene(
+            &play->actorCtx, play, ACTOR_OBJ_CHAN, childPos.x, childPos.y, childPos.z, childRot.x, childRot.y,
+            childRot.z, (thisx->params & 0xFFF) | 0x1000, thisx->csId, thisx->halfDaysBits, thisx);
+        if (pot != NULL) {
+            this->pots[i] = pot;
+            pot->myPotIndex = i;
+            pot->actor.csId = thisx->csId;
         } else {
-            Actor_Kill(&this->actor);
+            Actor_Kill(thisx);
         }
     }
 
-    if (Flags_GetSwitch(play, this->actor.params & 0x7F)) {
+    if (Flags_GetSwitch(play, thisx->params & 0x7F)) {
         this->stateFlags |= OBJCHAN_STATE_FIRE_DELAY;
         this->stateFlags |= OBJCHAN_STATE_ON_FIRE;
 
@@ -211,9 +213,9 @@ void ObjChan_InitChandelier(ObjChan* this2, PlayState* play) {
 }
 
 //! TODO: More descriptive name than Action?
-void ObjChan_ChandelierAction(ObjChan* this2, PlayState* play) {
-    ObjChan* this = this2;
-    ObjChan* temp;
+void ObjChan_ChandelierAction(ObjChan* this, PlayState* play) {
+    Actor* thisx = &this->actor;
+    ObjChan* pot;
     s32 i;
     Vec3f sp60;
     Vec3s sp58;
@@ -230,7 +232,7 @@ void ObjChan_ChandelierAction(ObjChan* this2, PlayState* play) {
             this->unk1D0 = 0.0f;
         }
     }
-    this->actor.shape.rot.z = (Math_SinS(this->unk1D4) * this->unk1D0);
+    thisx->shape.rot.z = (Math_SinS(this->unk1D4) * this->unk1D0);
     if ((this->stateFlags & OBJCHAN_STATE_START_CUTSCENE) &&
         SubS_StartCutscene(&this->actor, this->csIdList[0], CS_ID_NONE, SUBS_CUTSCENE_WITH_PLAYER)) {
         this->stateFlags |= OBJCHAN_STATE_CUTSCENE;
@@ -240,34 +242,34 @@ void ObjChan_ChandelierAction(ObjChan* this2, PlayState* play) {
         this->stateFlags &= ~OBJCHAN_STATE_CUTSCENE;
         CutsceneManager_Stop(this->csIdList[0]);
     }
-    Matrix_RotateYS(this->actor.shape.rot.y, MTXMODE_NEW);
-    Matrix_RotateXS(this->actor.shape.rot.x, MTXMODE_APPLY);
-    Matrix_RotateZS(this->actor.shape.rot.z, MTXMODE_APPLY);
+    Matrix_RotateYS(thisx->shape.rot.y, MTXMODE_NEW);
+    Matrix_RotateXS(thisx->shape.rot.x, MTXMODE_APPLY);
+    Matrix_RotateZS(thisx->shape.rot.z, MTXMODE_APPLY);
     Matrix_RotateYS(this->rotation, MTXMODE_APPLY);
-    Matrix_MultVecY(this->unk1CC, &this->actor.world.pos);
-    Math_Vec3f_Sum(&this->actor.world.pos, &this->unk1C0, &this->actor.world.pos);
+    Matrix_MultVecY(this->unk1CC, &thisx->world.pos);
+    Math_Vec3f_Sum(&thisx->world.pos, &this->unk1C0, &thisx->world.pos);
     Collider_UpdateCylinder(&this->actor, &this->collider);
     for (i = 0; i < 5; i++) {
-        temp = this->pots[i];
-        if (temp != NULL) {
-            ObjChan_CalculatePotPosition(&sp60, &sp58, &this->actor.world.pos, &this->actor.shape.rot,
+        pot = this->pots[i];
+        if (pot != NULL) {
+            ObjChan_CalculatePotPosition(&sp60, &sp58, &thisx->world.pos, &thisx->shape.rot,
                                          (s32)DEG_TO_BINANG_ALT3(i * 360.0f / 5.0f) + this->rotation);
-            Math_Vec3f_Copy(&temp->actor.world.pos, &sp60);
-            Math_Vec3s_Copy(&temp->actor.shape.rot, &this->actor.shape.rot);
-            temp->actor.shape.rot.y = this->rotation;
-            Math_Vec3f_ToVec3s(&temp->collider.dim.pos, &temp->actor.world.pos);
+            Math_Vec3f_Copy(&pot->actor.world.pos, &sp60);
+            Math_Vec3s_Copy(&pot->actor.shape.rot, &thisx->shape.rot);
+            pot->actor.shape.rot.y = this->rotation;
+            Math_Vec3f_ToVec3s(&pot->collider.dim.pos, &pot->actor.world.pos);
         }
     }
     if ((this->collider.base.acFlags & AC_HIT) && (this->collider.info.acHitInfo->toucher.dmgFlags & 0x800)) {
-        Flags_SetSwitch(play, this->actor.params & 0x7F);
+        Flags_SetSwitch(play, thisx->params & 0x7F);
     }
-    if (Flags_GetSwitch(play, this->actor.params & 0x7F)) {
+    if (Flags_GetSwitch(play, thisx->params & 0x7F)) {
         if (!(this->stateFlags & OBJCHAN_STATE_FIRE_DELAY)) {
             this->rotationSpeed = 0;
             this->flameSize = 0.0f;
             for (i = 0; i < 5; i++) {
-                temp = this->pots[i];
-                if (temp != NULL) {
+                pot = this->pots[i];
+                if (pot != NULL) {
                     this->pots[i]->stateFlags |= OBJCHAN_STATE_FIRE_DELAY;
                     this->pots[i]->fireDelayFrames = 20 + i * 5;
                     this->pots[i]->flameSize = 0.0f;
@@ -338,6 +340,7 @@ void ObjChan_CreateSmashEffects(ObjChan* this, PlayState* play) {
     for (temp_s2 = 0, temp_s1 = 0; temp_s2 != 18; temp_s2++, temp_s1 += 0x4E20) {
         f32 sin = Math_SinS(temp_s1);
         f32 cos = Math_CosS(temp_s1);
+
         spDC.x = sin * 8.0f;
         spDC.y = Rand_ZeroOne() * 12.0f + 2.0f;
         spDC.z = cos * 8.0f;

--- a/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.c
+++ b/src/overlays/actors/ovl_Obj_Dhouse/z_obj_dhouse.c
@@ -167,8 +167,8 @@ void func_80B12A88(Actor* thisx) {
     }
 }
 
-void func_80B12B38(ObjDhouse* this2, PlayState* play) {
-    ObjDhouse* this = this2;
+void func_80B12B38(ObjDhouse* this, PlayState* play) {
+    Actor* thisx = &this->dyna.actor;
     s32 i;
     f32 temp_f0;
     CollisionPoly* sp90;
@@ -201,7 +201,7 @@ void func_80B12B38(ObjDhouse* this2, PlayState* play) {
             phi_s3 = false;
             if (ptr->unk_0C.y < 0.0f) {
                 func_80B12A50(ptr, ptr3, &sp80);
-                temp_f0 = BgCheck_EntityRaycastFloor5(&play->colCtx, &sp90, &sp7C, &this->dyna.actor, &sp80);
+                temp_f0 = BgCheck_EntityRaycastFloor5(&play->colCtx, &sp90, &sp7C, thisx, &sp80);
                 if (((sp80.y - 35.0f) < temp_f0) && (temp_f0 > (BGCHECK_Y_MIN + 1.0f))) {
                     phi_s3 = true;
                 }

--- a/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.c
+++ b/src/overlays/actors/ovl_Obj_Fireshield/z_obj_fireshield.c
@@ -315,8 +315,8 @@ void ObjFireshield_Destroy(Actor* thisx, PlayState* play) {
 }
 
 void ObjFireshield_Update(Actor* thisx, PlayState* play) {
+    s32 pad;
     ObjFireshield* this = THIS;
-    ObjFireshield* this2 = THIS;
     s32 sp44 = OBJFIRESHIELD_GET_ROTX(&this->actor);
     s32 sp40 = OBJFIRESHIELD_GET_7F(&this->actor);
     s32 temp_a0;
@@ -342,12 +342,12 @@ void ObjFireshield_Update(Actor* thisx, PlayState* play) {
         this->collider.base.atFlags &= ~AT_HIT;
     } else if (this->collider.base.atFlags & AT_HIT) {
         this->collider.base.atFlags &= ~AT_HIT;
-        func_800B8D98(play, &this->actor, 5.0f, this->actor.yawTowardsPlayer, 1.0f);
+        func_800B8D98(play, thisx, 5.0f, thisx->yawTowardsPlayer, 1.0f);
     }
 
     func_80A4CE28(this, play);
 
-    this->actor.world.pos.y = ((sp44 ? 144.0f : -144.0f) * (1.0f - this2->unk_198)) + this->actor.home.pos.y;
+    thisx->world.pos.y = ((sp44 ? 144.0f : -144.0f) * (1.0f - this->unk_198)) + thisx->home.pos.y;
 
     this->unk_1A6 = this->unk_198 * 255.0f;
 
@@ -357,13 +357,12 @@ void ObjFireshield_Update(Actor* thisx, PlayState* play) {
         this->collider.dim.height = this->unk_198 * 80.0f;
 
         if (sp44) {
-            this->collider.dim.yShift =
-                (s32)(this->actor.home.pos.y - this->actor.world.pos.y) - this->collider.dim.height;
+            this->collider.dim.yShift = (s32)(thisx->home.pos.y - thisx->world.pos.y) - this->collider.dim.height;
         } else {
-            this->collider.dim.yShift = this->actor.home.pos.y - this->actor.world.pos.y;
+            this->collider.dim.yShift = thisx->home.pos.y - thisx->world.pos.y;
         }
 
-        func_800B9010(&this->actor, NA_SE_EV_BURNING - SFX_FLAG);
+        func_800B9010(thisx, NA_SE_EV_BURNING - SFX_FLAG);
 
         if (player->transformation == PLAYER_FORM_GORON) {
             this->collider.info.toucher.damage = 0;
@@ -373,7 +372,7 @@ void ObjFireshield_Update(Actor* thisx, PlayState* play) {
             this->collider.info.toucher.effect = 1;
         }
 
-        Collider_UpdateCylinder(&this->actor, &this->collider);
+        Collider_UpdateCylinder(thisx, &this->collider);
         CollisionCheck_SetAT(play, &play->colChkCtx, &this->collider.base);
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }

--- a/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
+++ b/src/overlays/actors/ovl_Obj_Flowerpot/z_obj_flowerpot.c
@@ -22,7 +22,7 @@ void func_80A1C838(ObjFlowerpot* this, PlayState* play);
 void func_80A1CBF8(ObjFlowerpot* this);
 void func_80A1CC0C(ObjFlowerpot* this, PlayState* play);
 void func_80A1CD10(ObjFlowerpot* this);
-void func_80A1CEF4(ObjFlowerpot* this2, PlayState* play);
+void func_80A1CEF4(ObjFlowerpot* this, PlayState* play);
 
 u32 D_80A1D830;
 MtxF D_80A1D838[8];
@@ -589,8 +589,8 @@ void func_80A1CD10(ObjFlowerpot* this) {
     }
 }
 
-void func_80A1CEF4(ObjFlowerpot* this2, PlayState* play) {
-    ObjFlowerpot* this = this2;
+void func_80A1CEF4(ObjFlowerpot* this, PlayState* play) {
+    Actor* thisx = &this->actor;
     s32 sp28 = this->collider.elements[0].info.toucherFlags & TOUCH_HIT;
 
     if (sp28) {
@@ -603,7 +603,7 @@ void func_80A1CEF4(ObjFlowerpot* this2, PlayState* play) {
 
     func_80A1C62C(this, play);
 
-    if ((this->actor.bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH | BGCHECKFLAG_WALL)) || sp28 ||
+    if ((thisx->bgCheckFlags & (BGCHECKFLAG_GROUND | BGCHECKFLAG_GROUND_TOUCH | BGCHECKFLAG_WALL)) || sp28 ||
         (this->unk_1E8 <= 0)) {
         if (!(this->unk_1EA & 2)) {
             func_80A1B914(this, play);
@@ -613,11 +613,11 @@ void func_80A1CEF4(ObjFlowerpot* this2, PlayState* play) {
         }
         func_80A1BA44(this, play);
         func_80A1B994(this, play);
-        Actor_Kill(&this->actor);
+        Actor_Kill(thisx);
         return;
     }
 
-    if (this->actor.bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
+    if (thisx->bgCheckFlags & BGCHECKFLAG_WATER_TOUCH) {
         if (!(this->unk_1EA & 2)) {
             func_80A1B914(this, play);
             func_80A1C328(this, play);
@@ -626,22 +626,22 @@ void func_80A1CEF4(ObjFlowerpot* this2, PlayState* play) {
         }
         func_80A1BD80(this, play);
         func_80A1B994(this, play);
-        SoundSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 40, NA_SE_EV_DIVE_INTO_WATER_L);
-        Actor_Kill(&this->actor);
+        SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 40, NA_SE_EV_DIVE_INTO_WATER_L);
+        Actor_Kill(thisx);
         return;
     }
 
-    Actor_MoveWithGravity(&this->actor);
+    Actor_MoveWithGravity(thisx);
 
     if (!(this->unk_1EA & 2)) {
-        D_80A1D3F8 += (s16)(this->actor.shape.rot.x * -0.06f);
+        D_80A1D3F8 += (s16)(thisx->shape.rot.x * -0.06f);
     } else {
         Math_StepToS(&D_80A1D3F8, 0, 80);
         Math_StepToS(&D_80A1D3FC, 0, 20);
     }
 
-    this->actor.shape.rot.x += D_80A1D3F8;
-    this->actor.shape.rot.y += D_80A1D3FC;
+    thisx->shape.rot.x += D_80A1D3F8;
+    thisx->shape.rot.y += D_80A1D3FC;
 
     func_80A1C5E8(this, play);
     CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);

--- a/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
+++ b/src/overlays/actors/ovl_Obj_Grass_Carry/z_obj_grass_carry.c
@@ -208,31 +208,31 @@ void func_809AB474(ObjGrassCarry* this) {
 }
 
 void func_809AB4A8(ObjGrassCarry* this, PlayState* play) {
-    ObjGrassCarry* this2 = this;
+    Actor* thisx = &this->actor;
 
-    if (Actor_HasParent(&this->actor, play)) {
+    if (Actor_HasParent(thisx, play)) {
         func_809AB5FC(this);
         if (this->unk_194 != NULL) {
             this->unk_194->unk_0F |= 4;
         }
-        this->actor.draw = func_809ABB7C;
-        this->actor.shape.shadowDraw = ActorShadow_DrawCircle;
-        this->actor.shape.shadowAlpha = 60;
-        this->actor.shape.shadowScale = 1.0f;
+        thisx->draw = func_809ABB7C;
+        thisx->shape.shadowDraw = ActorShadow_DrawCircle;
+        thisx->shape.shadowAlpha = 60;
+        thisx->shape.shadowScale = 1.0f;
         this->unk_190->unk_3292 ^= 1;
-        this->actor.room = -1;
-        SoundSource_PlaySfxAtFixedWorldPos(play, &this->actor.world.pos, 20, NA_SE_PL_PULL_UP_PLANT);
+        thisx->room = -1;
+        SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 20, NA_SE_PL_PULL_UP_PLANT);
     } else if (this->unk_190->unk_3294 != NULL) {
         Player* player = GET_PLAYER(play);
 
         this->unk_194 = this->unk_190->unk_3294;
-        Math_Vec3f_Copy(&this->actor.world.pos, &this->unk_194->unk_00);
-        this->actor.shape.rot.y = this->actor.world.rot.y = this->unk_194->unk_0C;
-        this->unk_198 = this2->unk_194->unk_0E;
-        this->actor.xzDistToPlayer = Actor_WorldDistXZToActor(&this->actor, &player->actor);
-        this->actor.playerHeightRel = Actor_HeightDiff(&this->actor, &player->actor);
-        this->actor.xyzDistToPlayerSq = SQ(this->actor.xzDistToPlayer) + SQ(this->actor.playerHeightRel);
-        this->actor.yawTowardsPlayer = Actor_WorldYawTowardActor(&this->actor, &player->actor);
+        Math_Vec3f_Copy(&thisx->world.pos, &this->unk_194->unk_00);
+        thisx->shape.rot.y = thisx->world.rot.y = this->unk_194->unk_0C;
+        this->unk_198 = this->unk_194->unk_0E;
+        thisx->xzDistToPlayer = Actor_WorldDistXZToActor(&this->actor, &player->actor);
+        thisx->playerHeightRel = Actor_HeightDiff(&this->actor, &player->actor);
+        thisx->xyzDistToPlayerSq = SQ(thisx->xzDistToPlayer) + SQ(thisx->playerHeightRel);
+        thisx->yawTowardsPlayer = Actor_WorldYawTowardActor(&this->actor, &player->actor);
         Actor_OfferCarry(&this->actor, play);
     }
 }

--- a/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.c
+++ b/src/overlays/actors/ovl_Obj_Iceblock/z_obj_iceblock.c
@@ -239,12 +239,12 @@ void func_80A237A4(ObjIceblock* this) {
         ((this->unk_244 - ((600.0f * this->dyna.actor.scale.y) - 90.0f)) + (sp20 * ptr->unk_08)) + ptr->unk_00;
 }
 
-void func_80A23938(ObjIceblock* this2) {
-    ObjIceblock* this = this2;
+void func_80A23938(ObjIceblock* this) {
+    Actor* thisx = &this->dyna.actor;
 
     if (this->unk_1B0 & 0x80) {
-        Math_ScaledStepToS(&this->dyna.actor.shape.rot.x, 0, 400);
-        Math_ScaledStepToS(&this->dyna.actor.shape.rot.z, 0, 400);
+        Math_ScaledStepToS(&thisx->shape.rot.x, 0, 400);
+        Math_ScaledStepToS(&thisx->shape.rot.z, 0, 400);
     } else {
         ObjIceBlockUnkStruct4* ptr = &this->unk_27C;
         f32 phi_f0;
@@ -252,7 +252,7 @@ void func_80A23938(ObjIceblock* this2) {
 
         if (this->unk_1B0 & 0x20) {
             phi_f0 = 0.3f;
-            ptr->unk_14 = this->dyna.actor.yawTowardsPlayer;
+            ptr->unk_14 = thisx->yawTowardsPlayer;
         } else {
             phi_f0 = 0.08f;
         }
@@ -264,16 +264,15 @@ void func_80A23938(ObjIceblock* this2) {
 
         temp = ptr->unk_16 - ptr->unk_14;
 
-        ptr->unk_18 +=
-            (s16)(temp * -0.04f * this->dyna.actor.xzDistToPlayer * this->dyna.actor.scale.x * (1.0f / 600.0f));
+        ptr->unk_18 += (s16)(temp * -0.04f * thisx->xzDistToPlayer * thisx->scale.x * (1.0f / 600.0f));
         ptr->unk_18 = func_80A23090(ptr->unk_18, 50, 800);
         ptr->unk_16 += ptr->unk_18;
 
-        this->dyna.actor.shape.rot.x = Math_CosS(ptr->unk_16) * ptr->unk_20 * ptr->unk_1C;
-        this->dyna.actor.shape.rot.x = CLAMP(this->dyna.actor.shape.rot.x, -2000, 2000);
+        thisx->shape.rot.x = Math_CosS(ptr->unk_16) * ptr->unk_20 * ptr->unk_1C;
+        thisx->shape.rot.x = CLAMP(thisx->shape.rot.x, -2000, 2000);
 
-        this->dyna.actor.shape.rot.z = -Math_SinS(ptr->unk_16) * ptr->unk_20 * ptr->unk_1C;
-        this->dyna.actor.shape.rot.z = CLAMP(this->dyna.actor.shape.rot.z, -2000, 2000);
+        thisx->shape.rot.z = -Math_SinS(ptr->unk_16) * ptr->unk_20 * ptr->unk_1C;
+        thisx->shape.rot.z = CLAMP(thisx->shape.rot.z, -2000, 2000);
     }
 }
 

--- a/src/overlays/actors/ovl_Obj_Tokei_Step/z_obj_tokei_step.c
+++ b/src/overlays/actors/ovl_Obj_Tokei_Step/z_obj_tokei_step.c
@@ -140,7 +140,7 @@ void ObjTokeiStep_InitTimers(ObjTokeiStep* this) {
 }
 
 s32 ObjTokeiStep_OpenProcess(ObjTokeiStep* this, PlayState* play) {
-    ObjTokeiStep* this2 = this;
+    Actor* thisx = &this->dyna.actor;
     s32 i;
     ObjTokeiStepPanel* panel;
     f32 finalPosY;
@@ -179,8 +179,8 @@ s32 ObjTokeiStep_OpenProcess(ObjTokeiStep* this, PlayState* play) {
                         panel->pos.y += finalPosY;
                     }
                     if (panel->numBounces == 1) {
-                        ObjTokeiStep_SpawnDust(this2, panel, play);
-                        ObjTokeiStep_RequestQuakeAndRumble(this2, play);
+                        ObjTokeiStep_SpawnDust(this, panel, play);
+                        ObjTokeiStep_RequestQuakeAndRumble(this, play);
                     }
                 }
             }


### PR DESCRIPTION
Small misc cleanup, mostly focused on converting instances of `this2` to `thisx` or something similar.

In this PR:
* remove this2's
* Use of exchangeItemId enums
* small clean up of Sleep_Cycles
* add ENENCOUT1_PATH_INDEX_NONE (which I messed up during a merge conflict)
* Capitalize `F` in `fram` enums for PascalCase.