### PR TITLE
RequiredScopeTemp Cleanup

### DIFF
--- a/src/code/game.c
+++ b/src/code/game.c
@@ -85,19 +85,14 @@ void GameState_Draw(GameState* gameState, GraphicsContext* gfxCtx) {
     Graph_BranchDlist(polyOpa, nextDisplayList);
     POLY_OPA_DISP = nextDisplayList;
 
-    // Block prevents reordering, if(1) around the above block don't seem to help unlike in OoT
-    {
-        s32 requiredScopeTemp;
+    CLOSE_DISPS(gfxCtx);
 
-        Debug_DrawText(gfxCtx);
-    }
+    Debug_DrawText(gfxCtx);
 
     if (R_ENABLE_ARENA_DBG != 0) {
         SpeedMeter_DrawTimeEntries(&D_801F7FF0, gfxCtx);
         SpeedMeter_DrawAllocEntries(&D_801F7FF0, gfxCtx, gameState);
     }
-
-    CLOSE_DISPS(gfxCtx);
 }
 
 void GameState_SetFrameBuffer(GraphicsContext* gfxCtx) {
@@ -207,20 +202,21 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
         s32 requiredScopeTemp;
 
         GameAlloc_Init(&gameState->alloc);
-        GameState_InitArena(gameState, 0x100000);
-        Game_SetFramerateDivisor(gameState, 3);
-
-        init(gameState);
-
-        VisCvg_Init(&D_801F8010);
-        VisZbuf_Init(&sVisZbuf);
-        VisMono_Init(&sMonoColors);
-        ViMode_Init(&D_801F8048);
-        func_801773A0(&D_801F7FF0);
-        Rumble_Init();
-
-        osSendMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
     }
+
+    GameState_InitArena(gameState, 0x100000);
+    Game_SetFramerateDivisor(gameState, 3);
+
+    init(gameState);
+
+    VisCvg_Init(&D_801F8010);
+    VisZbuf_Init(&sVisZbuf);
+    VisMono_Init(&sMonoColors);
+    ViMode_Init(&D_801F8048);
+    func_801773A0(&D_801F7FF0);
+    Rumble_Init();
+
+    osSendMesg(&gameState->gfxCtx->queue, NULL, OS_MESG_BLOCK);
 }
 
 void GameState_Destroy(GameState* gameState) {

--- a/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Bombwall/z_bg_hakugin_bombwall.c
@@ -343,10 +343,10 @@ void BgHakuginBombwall_Destroy(Actor* thisx, PlayState* play) {
 }
 
 s32 func_80ABCB5C(BgHakuginBombwall* this, PlayState* play) {
-    Actor* thisx = &this->dyna.actor;
-
     if (this->collider.base.acFlags & AC_HIT) {
         if (this->collider.base.ac != NULL) {
+            Actor* thisx = &this->dyna.actor;
+
             if (Math3D_Vec3fDistSq(&thisx->world.pos, &this->collider.base.ac->world.pos) <
                 D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(thisx)].unk_1C) {
                 SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 60, NA_SE_EV_WALL_BROKEN);
@@ -361,11 +361,11 @@ s32 func_80ABCC00(BgHakuginBombwall* this, PlayState* play) {
     if (this->collider.base.acFlags & AC_HIT) {
         if (this->collider.info.acHitInfo->toucher.dmgFlags & 8) {
             if (this->collider.base.ac != NULL) {
-                s32 requiredScopeTemp;
+                Actor* thisx = &this->dyna.actor;
 
-                if (Math3D_Vec3fDistSq(&this->dyna.actor.world.pos, &this->collider.base.ac->world.pos) <
-                    D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(&this->dyna.actor)].unk_1C) {
-                    SoundSource_PlaySfxAtFixedWorldPos(play, &this->dyna.actor.world.pos, 50, NA_SE_EV_WALL_BROKEN);
+                if (Math3D_Vec3fDistSq(&thisx->world.pos, &this->collider.base.ac->world.pos) <
+                    D_80ABCFC0[BGHAKUGIN_BOMBWALL_100(thisx)].unk_1C) {
+                    SoundSource_PlaySfxAtFixedWorldPos(play, &thisx->world.pos, 50, NA_SE_EV_WALL_BROKEN);
                     return true;
                 }
             }

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -1333,7 +1333,6 @@ s32 func_808F5674(PlayState* play, EnIn* this, s32 arg2) {
 s32 func_808F5728(PlayState* play, EnIn* this, s32 arg2, s32* arg3) {
     s16 rotDiff;
     s16 yawDiff;
-    Player* player;
 
     if (*arg3 == 4) {
         return 0;
@@ -1353,9 +1352,8 @@ s32 func_808F5728(PlayState* play, EnIn* this, s32 arg2, s32* arg3) {
         return 1;
     }
     if (*arg3 == 1) {
-        s32 requiredScopeTemp;
+        Player* player = GET_PLAYER(play);
 
-        player = GET_PLAYER(play);
         func_808F5994(this, play, &player->actor.world.pos, 0xC80);
     } else {
         rotDiff = this->actor.home.rot.y - this->actor.world.rot.y;

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -308,8 +308,6 @@ void EnMinislime_SetupIceArrowDamage(EnMinislime* this) {
 void EnMinislime_IceArrowDamage(EnMinislime* this, PlayState* play) {
     f32 invFrozenTimer;
     s32 pad;
-    f32 randFloat;
-    s32 randSign;
 
     if (this->frozenTimer == 80) {
         this->frozenAlpha += 10;
@@ -324,7 +322,8 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, PlayState* play) {
             Math_Vec3f_Copy(&this->shakeRefPos, &this->actor.world.pos);
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
-                s32 requiredScopeTemp;
+                f32 randFloat;
+                s32 randSign;
 
                 invFrozenTimer = 1.0f / this->frozenTimer;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);

--- a/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
+++ b/src/overlays/actors/ovl_En_Minislime/z_en_minislime.c
@@ -306,9 +306,6 @@ void EnMinislime_SetupIceArrowDamage(EnMinislime* this) {
 }
 
 void EnMinislime_IceArrowDamage(EnMinislime* this, PlayState* play) {
-    f32 invFrozenTimer;
-    s32 pad;
-
     if (this->frozenTimer == 80) {
         this->frozenAlpha += 10;
         Actor_PlaySfx_Flagged(&this->actor, NA_SE_EV_ICE_FREEZE - SFX_FLAG);
@@ -322,12 +319,11 @@ void EnMinislime_IceArrowDamage(EnMinislime* this, PlayState* play) {
             Math_Vec3f_Copy(&this->shakeRefPos, &this->actor.world.pos);
         } else if (this->frozenTimer > 0) {
             if ((this->frozenTimer < 20) || ((this->frozenTimer < 40) && ((this->frozenTimer % 2) != 0))) {
-                f32 randFloat;
-                s32 randSign;
+                f32 invFrozenTimer = 1.0f / this->frozenTimer;
+                s32 pad;
+                f32 randFloat = Rand_ZeroFloat(invFrozenTimer);
+                s32 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;
 
-                invFrozenTimer = 1.0f / this->frozenTimer;
-                randFloat = Rand_ZeroFloat(invFrozenTimer);
-                randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;
                 this->actor.world.pos.x = randSign * (invFrozenTimer + randFloat) + this->shakeRefPos.x;
                 randFloat = Rand_ZeroFloat(invFrozenTimer);
                 randSign = Rand_ZeroOne() < 0.5f ? -1 : 1;

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -427,10 +427,9 @@ void EnRailgibud_SetupGrab(EnRailgibud* this) {
 }
 
 void EnRailgibud_Grab(EnRailgibud* this, PlayState* play) {
-    Player* player2 = GET_PLAYER(play);
-    Player* player = player2;
+    Actor* playerActor = &GET_PLAYER(play)->actor;
+    Player* player = (Player*)playerActor;
     s32 inPositionToAttack;
-    u16 damageSfxId;
 
     switch (this->grabState) {
         case EN_RAILGIBUD_GRAB_START:
@@ -448,9 +447,8 @@ void EnRailgibud_Grab(EnRailgibud* this, PlayState* play) {
 
         case EN_RAILGIBUD_GRAB_ATTACK:
             if (this->grabDamageTimer == 20) {
-                s16 requiredScopeTemp;
+                u16 damageSfxId = player->ageProperties->voiceSfxIdOffset + NA_SE_VO_LI_DAMAGE_S;
 
-                damageSfxId = player->ageProperties->voiceSfxIdOffset + NA_SE_VO_LI_DAMAGE_S;
                 play->damagePlayer(play, -8);
                 Player_PlaySfx(player, damageSfxId);
                 Rumble_Request(this->actor.xzDistToPlayer, 240, 1, 12);

--- a/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
+++ b/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
@@ -390,10 +390,9 @@ void EnTalkGibud_SetupGrab(EnTalkGibud* this) {
 }
 
 void EnTalkGibud_Grab(EnTalkGibud* this, PlayState* play) {
-    Player* player2 = GET_PLAYER(play);
-    Player* player = player2;
+    Actor* playerActor = &GET_PLAYER(play)->actor;
+    Player* player = (Player*)playerActor;
     s32 inPositionToAttack;
-    u16 damageSfxId;
 
     switch (this->grabState) {
         case EN_TALK_GIBUD_GRAB_START:
@@ -406,9 +405,8 @@ void EnTalkGibud_Grab(EnTalkGibud* this, PlayState* play) {
 
         case EN_TALK_GIBUD_GRAB_ATTACK:
             if (this->grabDamageTimer == 20) {
-                s16 requiredScopeTemp;
+                u16 damageSfxId = player->ageProperties->voiceSfxIdOffset + NA_SE_VO_LI_DAMAGE_S;
 
-                damageSfxId = player->ageProperties->voiceSfxIdOffset + NA_SE_VO_LI_DAMAGE_S;
                 play->damagePlayer(play, -8);
                 Player_PlaySfx(player, damageSfxId);
                 Rumble_Request(this->actor.xzDistToPlayer, 240, 1, 12);

--- a/src/overlays/actors/ovl_En_Zot/z_en_zot.c
+++ b/src/overlays/actors/ovl_En_Zot/z_en_zot.c
@@ -533,6 +533,7 @@ void func_80B9765C(EnZot* this, PlayState* play) {
             case 0x126B:
                 Message_ContinueTextbox(play, play->msgCtx.currentTextId + 1);
                 break;
+
             default:
                 Message_CloseTextbox(play);
                 this->actionFunc = func_80B97708;

--- a/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
+++ b/src/overlays/actors/ovl_Obj_Raillift/z_obj_raillift.c
@@ -215,8 +215,6 @@ void ObjRaillift_StartCutscene(ObjRaillift* this, PlayState* play) {
 
 void ObjRaillift_Update(Actor* thisx, PlayState* play) {
     ObjRaillift* this = THIS;
-    f32 target;
-    f32 step;
 
     this->actionFunc(this, play);
     Actor_SetFocus(thisx, 10.0f);
@@ -227,7 +225,8 @@ void ObjRaillift_Update(Actor* thisx, PlayState* play) {
         }
     }
     if (OBJRAILLIFT_REACT_TO_PLAYER_ON_TOP(thisx)) {
-        s32 requiredScopeTemp;
+        f32 target;
+        f32 step;
 
         this->isPlayerOnTopPrev = this->isPlayerOnTop;
         this->isPlayerOnTop = DynaPolyActor_IsPlayerOnTop(&this->dyna) ? true : false;

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -4938,14 +4938,14 @@ PlayerMeleeWeaponAnimation func_808335F4(Player* this) {
 
     temp_a1 = this->unk_AE3[this->unk_ADE];
     if ((this->transformation == PLAYER_FORM_ZORA) || (this->transformation == PLAYER_FORM_GORON)) {
-        s32 requiredScopeTemp;
+        s8* meleeWeaponAnims = (this->transformation == PLAYER_FORM_ZORA) ? D_8085D094[0] : D_8085D094[1];
+        s32 unk_ADD = this->unk_ADD;
 
-        // yikes
-        meleeWeaponAnim = ((this->transformation == PLAYER_FORM_ZORA) ? D_8085D094[0] : D_8085D094[1])[this->unk_ADD];
+        meleeWeaponAnim = meleeWeaponAnims[unk_ADD];
 
-        if (this->unk_ADD != 0) {
+        if (unk_ADD != 0) {
             this->meleeWeaponAnimation = meleeWeaponAnim;
-            if (this->unk_ADD >= 2) {
+            if (unk_ADD >= 2) {
                 this->unk_ADD = -1;
             }
         }


### PR DESCRIPTION
Does some clean up regarding `requiredScopeTemp`s by converting them to actual used variables where appropriate, or in 1 case changing scope so it was no longer needed.