### PR TITLE
Add original asset names to all `object_g*` files

### DIFF
--- a/assets/xml/objects/object_ge1.xml
+++ b/assets/xml/objects/object_ge1.xml
@@ -3,16 +3,16 @@
     <File Name="object_ge1" Segment="6">
         <!-- White-clothed Gerudo Animations -->
         <Animation Name="gGerudoWhiteStandingHeadBowedAnim" Offset="0x594" /><!-- Original name may be "gb_ie" ("home")? -->
-        <Animation Name="gGerudoWhiteSaluteAnim" Offset="0xABC" /><!-- Original name: "gb_keirei" ("salute/bow") -->
-        <Animation Name="gGerudoWhiteStiffeningAnim" Offset="0xCF8" /><!-- Original name: "gb_kochoku" ("stiffening/rigidity") -->
-        <Animation Name="gGerudoWhiteStiffShiveringAnim" Offset="0x13CC" /><!-- Original name: "gb_kochoku_loop" ("stiffening loop") -->
-        <Animation Name="gGerudoWhiteTrudgingOffAnim" Offset="0x202C" /><!-- Original name: "gb_tobotobo" ("totteringly/trudgingly") -->
-        <Animation Name="gGerudoWhiteGreatBayCutsceneAnim" Offset="0x2148" /><!-- one frame used for each part of Great Bay Temple first entry cutscene. Original name: "gb_twister" -->
-        <Animation Name="gGerudoWhiteExcitedClappingAnim" Offset="0x2954" /><!-- Original name: "gb_wakuwaku", ("excited") -->
-        <Animation Name="gGerudoWhiteUnfoldingArmsAnim" Offset="0x2AD8" /><!-- Original name: "ge1_hanasi" ("talk") -->
+        <Animation Name="gGerudoWhiteSaluteAnim" Offset="0xABC" /><!-- Original name is "gb_keirei" ("salute/bow") -->
+        <Animation Name="gGerudoWhiteStiffeningAnim" Offset="0xCF8" /><!-- Original name is "gb_kochoku" ("stiffening/rigidity") -->
+        <Animation Name="gGerudoWhiteStiffShiveringAnim" Offset="0x13CC" /><!-- Original name is "gb_kochoku_loop" ("stiffening loop") -->
+        <Animation Name="gGerudoWhiteTrudgingOffAnim" Offset="0x202C" /><!-- Original name is "gb_tobotobo" ("totteringly/trudgingly") -->
+        <Animation Name="gGerudoWhiteGreatBayCutsceneAnim" Offset="0x2148" /><!-- one frame used for each part of Great Bay Temple first entry cutscene. Original name is "gb_twister" -->
+        <Animation Name="gGerudoWhiteExcitedClappingAnim" Offset="0x2954" /><!-- Original name is "gb_wakuwaku", ("excited") -->
+        <Animation Name="gGerudoWhiteUnfoldingArmsAnim" Offset="0x2AD8" /><!-- Original name is "ge1_hanasi" ("talk") -->
 
         <!-- From here to the end this file is identical to OoT's object_ge1, offset 0x0-0x9860 -->
-        <Animation Name="gGerudoWhiteArmsFoldedAnim" Offset="0x2B98" /><!-- Original name: "ge1_matsu" ("waiting") -->
+        <Animation Name="gGerudoWhiteArmsFoldedAnim" Offset="0x2B98" /><!-- Original name is "ge1_matsu" ("waiting") -->
 
         <!-- White-clothed Gerudo Limbs -->
         <Limb Name="gGerudoWhiteWaistLimb" Type="Standard" EnumName="GERUDO_WHITE_LIMB_WAIST" Offset="0x2BB0" />

--- a/assets/xml/objects/object_geldb.xml
+++ b/assets/xml/objects/object_geldb.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_geldb" Segment="6">
-        <Animation Name="object_geldb_Anim_000734" Offset="0x734" />
-        <Animation Name="object_geldb_Anim_000CB0" Offset="0xCB0" />
-        <Animation Name="object_geldb_Anim_000EE0" Offset="0xEE0" />
-        <Animation Name="object_geldb_Anim_0014CC" Offset="0x14CC" />
-        <Animation Name="object_geldb_Anim_001AC8" Offset="0x1AC8" />
-        <Animation Name="object_geldb_Anim_001DFC" Offset="0x1DFC" />
-        <Animation Name="object_geldb_Anim_001EFC" Offset="0x1EFC" />
-        <Animation Name="object_geldb_Anim_0028A0" Offset="0x28A0" />
+        <Animation Name="object_geldb_Anim_000734" Offset="0x734" /> <!-- Original name is "ga_asonde" -->
+        <Animation Name="object_geldb_Anim_000CB0" Offset="0xCB0" /> <!-- Original name is "ga_hayaku" -->
+        <Animation Name="object_geldb_Anim_000EE0" Offset="0xEE0" /> <!-- Original name is "ga_matu" -->
+        <Animation Name="object_geldb_Anim_0014CC" Offset="0x14CC" /> <!-- Original name is "ga_matu_loop" -->
+        <Animation Name="object_geldb_Anim_001AC8" Offset="0x1AC8" /> <!-- Original name is "ga_naniyatte" -->
+        <Animation Name="object_geldb_Anim_001DFC" Offset="0x1DFC" /> <!-- Original name is "ga_nigedasu" -->
+        <Animation Name="object_geldb_Anim_001EFC" Offset="0x1EFC" /> <!-- Original name is "gelb_wait" -->
+        <Animation Name="object_geldb_Anim_0028A0" Offset="0x28A0" /> <!-- Original name is "gelb_walk" -->
         <Texture Name="object_geldb_TLUT_0028B0" OutName="tlut_0028B0" Format="rgba16" Width="16" Height="16" Offset="0x28B0" />
         <Texture Name="object_geldb_Tex_002AB0" OutName="tex_002AB0" Format="ci8" Width="8" Height="8" Offset="0x2AB0" />
         <Texture Name="object_geldb_Tex_002AF0" OutName="tex_002AF0" Format="ci8" Width="8" Height="8" Offset="0x2AF0" />
@@ -72,7 +72,7 @@
         <Limb Name="object_geldb_Standardlimb_00A794" Type="Standard" EnumName="OBJECT_GELDB_LIMB_16" Offset="0xA794" />
         <Limb Name="object_geldb_Standardlimb_00A7A0" Type="Standard" EnumName="OBJECT_GELDB_LIMB_17" Offset="0xA7A0" />
         <Skeleton Name="object_geldb_Skel_00A808" Type="Flex" LimbType="Standard" LimbNone="OBJECT_GELDB_LIMB_NONE" LimbMax="OBJECT_GELDB_LIMB_MAX" EnumName="ObjectGeldbLimb" Offset="0xA808" />
-        <Animation Name="object_geldb_Anim_00AA8C" Offset="0xAA8C" />
-        <Animation Name="object_geldb_Anim_00B0E4" Offset="0xB0E4" />
+        <Animation Name="object_geldb_Anim_00AA8C" Offset="0xAA8C" /> <!-- Original name is "geldB_talk" -->
+        <Animation Name="object_geldb_Anim_00B0E4" Offset="0xB0E4" /> <!-- Original name is "geldB_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_gg.xml
+++ b/assets/xml/objects/object_gg.xml
@@ -39,19 +39,19 @@
         <Texture Name="object_gg_Tex_009660" OutName="tex_009660" Format="i8" Width="32" Height="32" Offset="0x9660" />
         <Texture Name="object_gg_Tex_009A60" OutName="tex_009A60" Format="i8" Width="32" Height="32" Offset="0x9A60" />
         <Texture Name="object_gg_Tex_009E60" OutName="tex_009E60" Format="i8" Width="32" Height="32" Offset="0x9E60" />
-        <Animation Name="object_gg_Anim_00A4B4" Offset="0xA4B4" />
+        <Animation Name="object_gg_Anim_00A4B4" Offset="0xA4B4" /> <!-- Original name is "gg_2um" -->
         <TextureAnimation Name="object_gg_Matanimheader_00A4F4" Offset="0xA4F4" />
-        <Animation Name="object_gg_Anim_00AF40" Offset="0xAF40" />
-        <Animation Name="object_gg_Anim_00B560" Offset="0xB560" />
-        <Animation Name="object_gg_Anim_00BAF0" Offset="0xBAF0" />
-        <Animation Name="object_gg_Anim_00CDA0" Offset="0xCDA0" />
-        <Animation Name="object_gg_Anim_00D174" Offset="0xD174" />
-        <Animation Name="object_gg_Anim_00D528" Offset="0xD528" />
-        <Animation Name="object_gg_Anim_00D99C" Offset="0xD99C" />
-        <Animation Name="object_gg_Anim_00E2A4" Offset="0xE2A4" />
-        <Animation Name="object_gg_Anim_00E86C" Offset="0xE86C" />
-        <Animation Name="object_gg_Anim_00ECC0" Offset="0xECC0" />
-        <Animation Name="object_gg_Anim_00F578" Offset="0xF578" />
+        <Animation Name="object_gg_Anim_00AF40" Offset="0xAF40" /> <!-- Original name is "gg_fly" -->
+        <Animation Name="object_gg_Anim_00B560" Offset="0xB560" /> <!-- Original name is "gg_gokyu" -->
+        <Animation Name="object_gg_Anim_00BAF0" Offset="0xBAF0" /> <!-- Original name is "gg_kongan" -->
+        <Animation Name="object_gg_Anim_00CDA0" Offset="0xCDA0" /> <!-- Original name is "gg_kyorokyoro" -->
+        <Animation Name="object_gg_Anim_00D174" Offset="0xD174" /> <!-- Original name is "gg_munen" -->
+        <Animation Name="object_gg_Anim_00D528" Offset="0xD528" /> <!-- Original name is "gg_odoroki" -->
+        <Animation Name="object_gg_Anim_00D99C" Offset="0xD99C" /> <!-- Original name is "gg_otakebi" -->
+        <Animation Name="object_gg_Anim_00E2A4" Offset="0xE2A4" /> <!-- Original name is "gg_otakebi_loop" -->
+        <Animation Name="object_gg_Anim_00E86C" Offset="0xE86C" /> <!-- Original name is "gg_um" -->
+        <Animation Name="object_gg_Anim_00ECC0" Offset="0xECC0" /> <!-- Original name is "gg_unadareru" -->
+        <Animation Name="object_gg_Anim_00F578" Offset="0xF578" /> <!-- Original name is "gg_wait" -->
         <Limb Name="object_gg_Standardlimb_00F590" Type="Standard" EnumName="OBJECT_GG_LIMB_01" Offset="0xF590" />
         <Limb Name="object_gg_Standardlimb_00F59C" Type="Standard" EnumName="OBJECT_GG_LIMB_02" Offset="0xF59C" />
         <Limb Name="object_gg_Standardlimb_00F5A8" Type="Standard" EnumName="OBJECT_GG_LIMB_03" Offset="0xF5A8" />
@@ -72,6 +72,6 @@
         <Limb Name="object_gg_Standardlimb_00F65C" Type="Standard" EnumName="OBJECT_GG_LIMB_12" Offset="0xF65C" />
         <Limb Name="object_gg_Standardlimb_00F668" Type="Standard" EnumName="OBJECT_GG_LIMB_13" Offset="0xF668" />
         <Skeleton Name="object_gg_Skel_00F6C0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_GG_LIMB_NONE" LimbMax="OBJECT_GG_LIMB_MAX" EnumName="ObjectGgLimb" Offset="0xF6C0" />
-        <Animation Name="object_gg_Anim_0100C8" Offset="0x100C8" />
+        <Animation Name="object_gg_Anim_0100C8" Offset="0x100C8" /> <!-- Original name is "gg_yurayura" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_ghaka.xml
+++ b/assets/xml/objects/object_ghaka.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_ghaka" Segment="6">
-        <Collision Name="object_ghaka_Colheader_0000E8" Offset="0xE8" />
+        <Collision Name="object_ghaka_Colheader_0000E8" Offset="0xE8" /> <!-- Original name is "goron_hakaisi_bgdatainfo" -->
         <DList Name="object_ghaka_DL_001980" Offset="0x1980" />
-        <DList Name="object_ghaka_DL_001A20" Offset="0x1A20" />
+        <DList Name="object_ghaka_DL_001A20" Offset="0x1A20" /> <!-- Original name is "z2_goron_hakaisi_model" -->
         <Texture Name="object_ghaka_Tex_002020" OutName="tex_002020" Format="i8" Width="32" Height="64" Offset="0x2020" />
         <Texture Name="object_ghaka_Tex_002820" OutName="tex_002820" Format="ia16" Width="16" Height="16" Offset="0x2820" />
         <Texture Name="object_ghaka_Tex_002A20" OutName="tex_002A20" Format="rgba16" Width="32" Height="32" Offset="0x2A20" />
         <Texture Name="object_ghaka_Tex_003220" OutName="tex_003220" Format="rgba16" Width="32" Height="32" Offset="0x3220" />
-        <Collision Name="object_ghaka_Colheader_003CD0" Offset="0x3CD0" />
+        <Collision Name="object_ghaka_Colheader_003CD0" Offset="0x3CD0" /> <!-- Original name is "z2_goron_hakaisi_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_gk.xml
+++ b/assets/xml/objects/object_gk.xml
@@ -19,10 +19,10 @@
         <DList Name="object_gk_DL_004DA0" Offset="0x4DA0" />
         <DList Name="object_gk_DL_004ED0" Offset="0x4ED0" />
         <TextureAnimation Name="object_gk_Matanimheader_005144" Offset="0x5144" />
-        <Animation Name="object_gk_Anim_005EDC" Offset="0x5EDC" />
+        <Animation Name="object_gk_Anim_005EDC" Offset="0x5EDC" /> <!-- Original name is "gk_furafura" -->
         <DList Name="object_gk_DL_006680" Offset="0x6680" />
-        <DList Name="object_gk_DL_006688" Offset="0x6688" />
-        <Animation Name="object_gk_Anim_00787C" Offset="0x787C" />
+        <DList Name="object_gk_DL_006688" Offset="0x6688" /> <!-- Original name is "gk_iwa_obj_model" -->
+        <Animation Name="object_gk_Anim_00787C" Offset="0x787C" /> <!-- Oriignal name is "gk_naki" -->
         <Limb Name="object_gk_Standardlimb_007890" Type="Standard" EnumName="OBJECT_GK_LIMB_01" Offset="0x7890" />
         <Limb Name="object_gk_Standardlimb_00789C" Type="Standard" EnumName="OBJECT_GK_LIMB_02" Offset="0x789C" />
         <Limb Name="object_gk_Standardlimb_0078A8" Type="Standard" EnumName="OBJECT_GK_LIMB_03" Offset="0x78A8" />
@@ -43,17 +43,17 @@
         <Limb Name="object_gk_Standardlimb_00795C" Type="Standard" EnumName="OBJECT_GK_LIMB_12" Offset="0x795C" />
         <Limb Name="object_gk_Standardlimb_007968" Type="Standard" EnumName="OBJECT_GK_LIMB_13" Offset="0x7968" />
         <Skeleton Name="object_gk_Skel_0079C0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_GK_LIMB_NONE" LimbMax="OBJECT_GK_LIMB_MAX" EnumName="ObjectGkLimb" Offset="0x79C0" />
-        <Animation Name="object_gk_Anim_007DC4" Offset="0x7DC4" />
-        <Animation Name="object_gk_Anim_008774" Offset="0x8774" />
-        <Animation Name="object_gk_Anim_0092C0" Offset="0x92C0" />
-        <Animation Name="object_gk_Anim_009638" Offset="0x9638" />
-        <Animation Name="object_gk_Anim_009858" Offset="0x9858" />
-        <Animation Name="object_gk_Anim_009D88" Offset="0x9D88" />
-        <Animation Name="object_gk_Anim_00A21C" Offset="0xA21C" />
-        <Animation Name="object_gk_Anim_00AAEC" Offset="0xAAEC" />
-        <Animation Name="object_gk_Anim_00AE34" Offset="0xAE34" />
-        <Animation Name="object_gk_Anim_00BD90" Offset="0xBD90" />
-        <Animation Name="object_gk_Anim_00C308" Offset="0xC308" />
+        <Animation Name="object_gk_Anim_007DC4" Offset="0x7DC4" /> <!-- Original name is "gk_sleep" -->
+        <Animation Name="object_gk_Anim_008774" Offset="0x8774" /> <!-- Original name is "gk_stand_wait" -->
+        <Animation Name="object_gk_Anim_0092C0" Offset="0x92C0" /> <!-- Original name is "gk_talk" -->
+        <Animation Name="object_gk_Anim_009638" Offset="0x9638" /> <!-- Original name is "gk_wait" -->
+        <Animation Name="object_gk_Anim_009858" Offset="0x9858" /> <!-- Original name is "gkid_dada" -->
+        <Animation Name="object_gk_Anim_009D88" Offset="0x9D88" /> <!-- Original name is "gkid_dada_loop" -->
+        <Animation Name="object_gk_Anim_00A21C" Offset="0xA21C" /> <!-- Original name is "gkid_dada_modori" -->
+        <Animation Name="object_gk_Anim_00AAEC" Offset="0xAAEC" /> <!-- Original name is "gkid_dakko" -->
+        <Animation Name="object_gk_Anim_00AE34" Offset="0xAE34" /> <!-- Original name is "gkid_run_loop" -->
+        <Animation Name="object_gk_Anim_00BD90" Offset="0xBD90" /> <!-- Original name is "gkid_utau" -->
+        <Animation Name="object_gk_Anim_00C308" Offset="0xC308" /> <!-- Original name is "gkid_utau_loop" -->
         <Texture Name="object_gk_TLUT_00C320" OutName="tlut_00C320" Format="rgba16" Width="16" Height="16" Offset="0xC320" />
         <!-- <Blob Name="object_gk_Blob_00C520" Size="0x1900" Offset="0xC520" /> -->
         <Texture Name="object_gk_Tex_00DE20" OutName="tex_00DE20" Format="ci8" Width="8" Height="8" Offset="0xDE20" />

--- a/assets/xml/objects/object_gla.xml
+++ b/assets/xml/objects/object_gla.xml
@@ -1,15 +1,15 @@
 ﻿<Root>
     <!-- object for the assets for ovl_En_Ge2 (Purple-clad Gerudo) -->
     <File Name="object_gla" Segment="6">
-        <Animation Name="gGerudoPurpleRunningAwayCutsceneAnim" Offset="0x30C" /><!-- Original name: g_yari_nigedasu -->
-        <Animation Name="gGerudoPurpleGreatBayCutsceneAnim" Offset="0x460" /><!-- Original name: g_yari_twister -->
+        <Animation Name="gGerudoPurpleRunningAwayCutsceneAnim" Offset="0x30C" /><!-- Original name is "g_yari_nigedasu" -->
+        <Animation Name="gGerudoPurpleGreatBayCutsceneAnim" Offset="0x460" /><!-- Original name is "g_yari_twister" -->
 
         <!-- Identical to OoT's object_gla from here to the end -->
-        <Animation Name="gGerudoPurpleHorizontalSlashAnim" Offset="0x794" /><!-- Unused. Original name: geldA_attack -->
-        <Animation Name="gGerudoPurpleSlashToStandingAnim" Offset="0xBF0" /><!-- Usused. Original name: geldA_attack_end -->
-        <Animation Name="gGerudoPurpleFallingToGroundAnim" Offset="0x1664" /><!-- Original name: geldA_down -->
-        <Animation Name="gGerudoPurpleStandingToCrouchAnim" Offset="0x1A40" /><!-- Unused. Original name: geldA_find -->
-        <Animation Name="gGerudoPurpleCrouchingLookAroundAnim" Offset="0x1FAC" /><!-- Unused. Original name: geldA_find_wait -->
+        <Animation Name="gGerudoPurpleHorizontalSlashAnim" Offset="0x794" /><!-- Unused. Original name is "geldA_attack" -->
+        <Animation Name="gGerudoPurpleSlashToStandingAnim" Offset="0xBF0" /><!-- Usused. Original name is "geldA_attack_end" -->
+        <Animation Name="gGerudoPurpleFallingToGroundAnim" Offset="0x1664" /><!-- Original name is "geldA_down" -->
+        <Animation Name="gGerudoPurpleStandingToCrouchAnim" Offset="0x1A40" /><!-- Unused. Original name is "geldA_find" -->
+        <Animation Name="gGerudoPurpleCrouchingLookAroundAnim" Offset="0x1FAC" /><!-- Unused. Original name is "geldA_find_wait" -->
 
         <DList Name="gGerudoPurpleTorsoDL" Offset="0x39B0" />
         <DList Name="gGerudoPurpleLeftUpperArmDL" Offset="0x3E50" />
@@ -71,8 +71,8 @@
         <Limb Name="gGerudoPurpleWaistLimb" Type="Standard" EnumName="GERUDO_PURPLE_WAIST_LIMB" Offset="0x8D78" />
         <Skeleton Name="gGerudoPurpleSkel" Type="Flex" LimbType="Standard" LimbNone="GERUDO_PURPLE_LIMB_NONE" LimbMax="GERUDO_PURPLE_LIMB_MAX" EnumName="GerudoPurpleLimb" Offset="0x8DD8" />
 
-        <Animation Name="gGerudoPurpleChargingAnim" Offset="0x91D0" /><!-- Original name: geldA_run -->
-        <Animation Name="gGerudoPurpleLookingAboutAnim" Offset="0x9D1C" /><!-- Original name: geldA_wait -->
-        <Animation Name="gGerudoPurpleWalkingAnim" Offset="0xA344" /><!-- Original name: geldA_walk -->
+        <Animation Name="gGerudoPurpleChargingAnim" Offset="0x91D0" /><!-- Original name is "geldA_run" -->
+        <Animation Name="gGerudoPurpleLookingAboutAnim" Offset="0x9D1C" /><!-- Original name is "geldA_wait" -->
+        <Animation Name="gGerudoPurpleWalkingAnim" Offset="0xA344" /><!-- Original name is "geldA_walk" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_goroiwa.xml
+++ b/assets/xml/objects/object_goroiwa.xml
@@ -1,26 +1,26 @@
 ﻿<Root>
     <File Name="object_goroiwa" Segment="6">
-        <DList Name="object_goroiwa_DL_0003B0" Offset="0x3B0" />
+        <DList Name="object_goroiwa_DL_0003B0" Offset="0x3B0" /> <!-- Original name is "Z2_goron_hahenAT_model" -->
         <Texture Name="object_goroiwa_Tex_000520" OutName="tex_000520" Format="rgba16" Width="32" Height="32" Offset="0x520" />
         <Texture Name="object_goroiwa_Tex_000D20" OutName="tex_000D20" Format="rgba16" Width="32" Height="32" Offset="0xD20" />
         <Texture Name="object_goroiwa_Tex_001520" OutName="tex_001520" Format="rgba16" Width="32" Height="64" Offset="0x1520" />
-        <DList Name="object_goroiwa_DL_0028E0" Offset="0x28E0" />
-        <DList Name="object_goroiwa_DL_002D70" Offset="0x2D70" />
-        <DList Name="object_goroiwa_DL_0032E0" Offset="0x32E0" />
-        <DList Name="object_goroiwa_DL_003B40" Offset="0x3B40" />
-        <DList Name="object_goroiwa_DL_0042B0" Offset="0x42B0" />
-        <DList Name="object_goroiwa_DL_004960" Offset="0x4960" />
-        <DList Name="object_goroiwa_DL_004EF0" Offset="0x4EF0" />
-        <DList Name="object_goroiwa_DL_005C20" Offset="0x5C20" />
+        <DList Name="object_goroiwa_DL_0028E0" Offset="0x28E0" /> <!-- Original name is "Z2_goron_hahenBT_model" -->
+        <DList Name="object_goroiwa_DL_002D70" Offset="0x2D70" /> <!-- Original name is "Z2_goron_hahenCT_model" -->
+        <DList Name="object_goroiwa_DL_0032E0" Offset="0x32E0" /> <!-- Original name is "Z2_goron_halfAT_model" -->
+        <DList Name="object_goroiwa_DL_003B40" Offset="0x3B40" /> <!-- Original name is "Z2_gorongoroiwa_model" -->
+        <DList Name="object_goroiwa_DL_0042B0" Offset="0x42B0" /> <!-- Original name is "Z2_new_hahenA_model" -->
+        <DList Name="object_goroiwa_DL_004960" Offset="0x4960" /> <!-- Original name is "Z2_new_hahenB_model" -->
+        <DList Name="object_goroiwa_DL_004EF0" Offset="0x4EF0" /> <!-- Original name is "Z2_new_hahenC_model" -->
+        <DList Name="object_goroiwa_DL_005C20" Offset="0x5C20" /> <!-- Original name is "Z2_newgoroiwa_model" -->
         <Texture Name="object_goroiwa_TLUT_005EE0" OutName="tlut_005EE0" Format="rgba16" Width="4" Height="4" Offset="0x5EE0" />
         <Texture Name="object_goroiwa_TLUT_005F00" OutName="tlut_005F00" Format="rgba16" Width="4" Height="4" Offset="0x5F00" />
         <Texture Name="object_goroiwa_Tex_005F20" OutName="tex_005F20" Format="ci4" Width="64" Height="64" Offset="0x5F20" />
         <Texture Name="object_goroiwa_Tex_006720" OutName="tex_006720" Format="ci4" Width="64" Height="64" Offset="0x6720" />
-        <DList Name="object_goroiwa_DL_0072F0" Offset="0x72F0" />
-        <DList Name="object_goroiwa_DL_0077D0" Offset="0x77D0" />
-        <DList Name="object_goroiwa_DL_007C60" Offset="0x7C60" />
-        <DList Name="object_goroiwa_DL_0082D0" Offset="0x82D0" />
-        <DList Name="object_goroiwa_DL_008B90" Offset="0x8B90" />
+        <DList Name="object_goroiwa_DL_0072F0" Offset="0x72F0" /> <!-- Original name is "Z2_snow_hahenA_model" -->
+        <DList Name="object_goroiwa_DL_0077D0" Offset="0x77D0" /> <!-- Original name is "Z2_snow_hahenB_model" -->
+        <DList Name="object_goroiwa_DL_007C60" Offset="0x7C60" /> <!-- Original name is "Z2_snow_hahenC_model" -->
+        <DList Name="object_goroiwa_DL_0082D0" Offset="0x82D0" /> <!-- Original name is "Z2_snow_halfA_model" -->
+        <DList Name="object_goroiwa_DL_008B90" Offset="0x8B90" /> <!-- Original name is "Z2_snowgoroniwa_model" -->
         <!-- <Blob Name="object_goroiwa_Blob_008D80" Size="0x20" Offset="0x8D80" /> -->
         <Texture Name="object_goroiwa_Tex_008DA0" OutName="tex_008DA0" Format="rgba16" Width="32" Height="64" Offset="0x8DA0" />
         <!-- <Blob Name="object_goroiwa_Blob_009DA0" Size="0x800" Offset="0x9DA0" /> -->

--- a/assets/xml/objects/object_goronswitch.xml
+++ b/assets/xml/objects/object_goronswitch.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_goronswitch" Segment="6">
-        <DList Name="object_goronswitch_DL_000260" Offset="0x260" />
-        <DList Name="object_goronswitch_DL_000268" Offset="0x268" />
-        <Collision Name="object_goronswitch_Colheader_0005C8" Offset="0x5C8" />
-        <DList Name="object_goronswitch_DL_0007D0" Offset="0x7D0" />
-        <DList Name="object_goronswitch_DL_0007D8" Offset="0x7D8" />
+        <DList Name="object_goronswitch_DL_000260" Offset="0x260" /> <!-- Original name is "i2_H_swit1_modelT" -->
+        <DList Name="object_goronswitch_DL_000268" Offset="0x268" /> <!-- Original name is "i2_H_swit1_model" -->
+        <Collision Name="object_goronswitch_Colheader_0005C8" Offset="0x5C8" /> <!-- Original name is "i2_h_swit1_bgdatainfo" -->
+        <DList Name="object_goronswitch_DL_0007D0" Offset="0x7D0" /> <!-- Original name is "i2_H_swit2_modelT" -->
+        <DList Name="object_goronswitch_DL_0007D8" Offset="0x7D8" /> <!-- Original name is "i2_H_swit2_model" -->
         <Texture Name="object_goronswitch_TLUT_000970" OutName="tlut_000970" Format="rgba16" Width="4" Height="4" Offset="0x970" />
         <Texture Name="object_goronswitch_TLUT_000990" OutName="tlut_000990" Format="rgba16" Width="4" Height="4" Offset="0x990" />
         <Texture Name="object_goronswitch_Tex_0009B0" OutName="tex_0009B0" Format="i8" Width="64" Height="64" Offset="0x9B0" />


### PR DESCRIPTION
I was waiting for #1072 to be merged before starting this, but at this point it has a lot of conflicts, so what's one more?

This adds the original names from MM3D for objects that start with `object_g*`. Do note that I skipped all the GI objects, since I firmly believe that those are original Grezzo names, so I don't think they're very useful. I also skipped `object_gm` (because it's empty) and `object_gs` (because, like the GI objects, it seems to have been completely redone by Grezzo and named with their own naming scheme). Thus, this is a pretty small list of changes.