### PR TITLE
Add original asset names to all `object_h*` files

### DIFF
--- a/assets/xml/objects/object_ha.xml
+++ b/assets/xml/objects/object_ha.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_ha" Segment="6">
-        <Animation Name="object_ha_Anim_0000C4" Offset="0xC4" />
+        <Animation Name="object_ha_Anim_0000C4" Offset="0xC4" /> <!-- Original name is "ha_default" -->
         <DList Name="object_ha_DL_0030C0" Offset="0x30C0" />
         <DList Name="object_ha_DL_003418" Offset="0x3418" />
         <DList Name="object_ha_DL_0035D8" Offset="0x35D8" />
@@ -64,15 +64,15 @@
         <Limb Name="object_ha_Standardlimb_008BEC" Type="Standard" EnumName="OBJECT_HA_1_LIMB_18" Offset="0x8BEC" />
         <Limb Name="object_ha_Standardlimb_008BF8" Type="Standard" EnumName="OBJECT_HA_1_LIMB_19" Offset="0x8BF8" />
         <Skeleton Name="object_ha_Skel_008C68" Type="Flex" LimbType="Standard" LimbNone="OBJECT_HA_1_LIMB_NONE" LimbMax="OBJECT_HA_1_LIMB_MAX" EnumName="ObjectHa1Limb" Offset="0x8C68" />
-        <Animation Name="object_ha_Anim_009208" Offset="0x9208" />
-        <Animation Name="object_ha_Anim_009858" Offset="0x9858" />
-        <Animation Name="object_ha_Anim_00A05C" Offset="0xA05C" />
-        <Animation Name="object_ha_Anim_00A650" Offset="0xA650" />
-        <Animation Name="object_ha_Anim_00B00C" Offset="0xB00C" />
-        <Animation Name="object_ha_Anim_00B9C8" Offset="0xB9C8" />
-        <Animation Name="object_ha_Anim_00C850" Offset="0xC850" />
-        <Animation Name="object_ha_Anim_00CE70" Offset="0xCE70" />
-        <Animation Name="object_ha_Anim_00D648" Offset="0xD648" />
+        <Animation Name="object_ha_Anim_009208" Offset="0x9208" /> <!-- Original name is "ha_fastrun" -->
+        <Animation Name="object_ha_Anim_009858" Offset="0x9858" /> <!-- Original name is "ha_jump100" -->
+        <Animation Name="object_ha_Anim_00A05C" Offset="0xA05C" /> <!-- Original name is "ha_jump200" -->
+        <Animation Name="object_ha_Anim_00A650" Offset="0xA650" /> <!-- Original name is "ha_slowrun" -->
+        <Animation Name="object_ha_Anim_00B00C" Offset="0xB00C" /> <!-- Original name is "ha_stand" -->
+        <Animation Name="object_ha_Anim_00B9C8" Offset="0xB9C8" /> <!-- Original name is "ha_stop" -->
+        <Animation Name="object_ha_Anim_00C850" Offset="0xC850" /> <!-- Original name is "ha_wait" -->
+        <Animation Name="object_ha_Anim_00CE70" Offset="0xCE70" /> <!-- Original name is "ha_wait02" -->
+        <Animation Name="object_ha_Anim_00D648" Offset="0xD648" /> <!-- Original name is "ha_walk" -->
         <DList Name="object_ha_DL_0100B0" Offset="0x100B0" />
         <DList Name="object_ha_DL_010258" Offset="0x10258" />
         <DList Name="object_ha_DL_0103F0" Offset="0x103F0" />

--- a/assets/xml/objects/object_haka_obj.xml
+++ b/assets/xml/objects/object_haka_obj.xml
@@ -1,14 +1,14 @@
 ﻿<Root>
     <File Name="object_haka_obj" Segment="6">
-        <DList Name="object_haka_obj_DL_000040" Offset="0x40" />
-        <Collision Name="object_haka_obj_Colheader_000148" Offset="0x148" />
-        <DList Name="object_haka_obj_DL_0007B0" Offset="0x7B0" />
-        <Collision Name="object_haka_obj_Colheader_000EE8" Offset="0xEE8" />
-        <DList Name="object_haka_obj_DL_000F70" Offset="0xF70" />
-        <DList Name="object_haka_obj_DL_001200" Offset="0x1200" />
-        <DList Name="object_haka_obj_DL_001410" Offset="0x1410" />
-        <Collision Name="object_haka_obj_Colheader_001588" Offset="0x1588" />
-        <DList Name="object_haka_obj_DL_001680" Offset="0x1680" />
+        <DList Name="object_haka_obj_DL_000040" Offset="0x40" /> <!-- Original name is "Y2_bakuKABE_model" -->
+        <Collision Name="object_haka_obj_Colheader_000148" Offset="0x148" /> <!-- Original name is "Y2_bakuKABE_bgdatainfo" -->
+        <DList Name="object_haka_obj_DL_0007B0" Offset="0x7B0" /> <!-- Original name is "Y2_hakaishi_model" -->
+        <Collision Name="object_haka_obj_Colheader_000EE8" Offset="0xEE8" /> <!-- Original name is "Y2_hakaishi_bgdatainfo" -->
+        <DList Name="object_haka_obj_DL_000F70" Offset="0xF70" /> <!-- Original name is "Y2_hakashita00_meganeOBJ_model" -->
+        <DList Name="object_haka_obj_DL_001200" Offset="0x1200" /> <!-- Original name is "Y2_hakashita03_meganeOBJ_model" -->
+        <DList Name="object_haka_obj_DL_001410" Offset="0x1410" /> <!-- Original name is "Y2_hakashitaMAKU_model" -->
+        <Collision Name="object_haka_obj_Colheader_001588" Offset="0x1588" /> <!-- Original name is "Y2_hakashitaMAKU_bgdatainfo" -->
+        <DList Name="object_haka_obj_DL_001680" Offset="0x1680" /> <!-- Original name is "Y2_kakera_model" -->
         <Texture Name="object_haka_obj_TLUT_001800" OutName="tlut_001800" Format="rgba16" Width="16" Height="16" Offset="0x1800" />
         <Texture Name="object_haka_obj_TLUT_001A00" OutName="tlut_001A00" Format="rgba16" Width="4" Height="4" Offset="0x1A00" />
         <Texture Name="object_haka_obj_TLUT_001A20" OutName="tlut_001A20" Format="rgba16" Width="4" Height="4" Offset="0x1A20" />

--- a/assets/xml/objects/object_hakaisi.xml
+++ b/assets/xml/objects/object_hakaisi.xml
@@ -5,11 +5,11 @@
         <Texture Name="object_hakaisi_Tex_000300" OutName="tex_000300" Format="rgba16" Width="16" Height="16" Offset="0x300" />
         <Texture Name="object_hakaisi_Tex_000500" OutName="tex_000500" Format="rgba16" Width="32" Height="64" Offset="0x500" />
         <Texture Name="object_hakaisi_Tex_001500" OutName="tex_001500" Format="rgba16" Width="16" Height="64" Offset="0x1500" />
-        <DList Name="object_hakaisi_DL_001F10" Offset="0x1F10" />
-        <DList Name="object_hakaisi_DL_0021B0" Offset="0x21B0" />
-        <DList Name="object_hakaisi_DL_002650" Offset="0x2650" />
-        <DList Name="object_hakaisi_DL_0029C0" Offset="0x29C0" />
-        <DList Name="object_hakaisi_DL_002CC0" Offset="0x2CC0" />
-        <Collision Name="object_hakaisi_Colheader_002FC4" Offset="0x2FC4" />
+        <DList Name="object_hakaisi_DL_001F10" Offset="0x1F10" /> <!-- Original name is "hahen01_model" -->
+        <DList Name="object_hakaisi_DL_0021B0" Offset="0x21B0" /> <!-- Original name is "hahen02_model" -->
+        <DList Name="object_hakaisi_DL_002650" Offset="0x2650" /> <!-- Original name is "haka_model" -->
+        <DList Name="object_hakaisi_DL_0029C0" Offset="0x29C0" /> <!-- Original name is "haka02_model" -->
+        <DList Name="object_hakaisi_DL_002CC0" Offset="0x2CC0" /> <!-- Original name is "haka03_model" -->
+        <Collision Name="object_hakaisi_Colheader_002FC4" Offset="0x2FC4" /> <!-- Original name is "z2_haka_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hakugin_demo.xml
+++ b/assets/xml/objects/object_hakugin_demo.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <!-- Animations for Gorons during the arrival of spring cutscene -->
     <File Name="object_hakugin_demo" Segment="6">
-        <Animation Name="gGoronSpringShowAnim" Offset="0x1420" />
-        <Animation Name="gGoronSpringShowLoopAnim" Offset="0x1A4C" />
-        <Animation Name="gGoronSpringLookAroundAnim" Offset="0x2704" />
-        <Animation Name="gGoronSpringLookAroundLoopAnim" Offset="0x3378" />
+        <Animation Name="gGoronSpringShowAnim" Offset="0x1420" /> <!-- Original name is "goron_hora" -->
+        <Animation Name="gGoronSpringShowLoopAnim" Offset="0x1A4C" /> <!-- Original name is "goron_hora_loop" -->
+        <Animation Name="gGoronSpringLookAroundAnim" Offset="0x2704" /> <!-- Original name is "goron_mimawasu" -->
+        <Animation Name="gGoronSpringLookAroundLoopAnim" Offset="0x3378" /> <!-- Original name is "goron_mimawasu_loop" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hakugin_obj.xml
+++ b/assets/xml/objects/object_hakugin_obj.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_hakugin_obj" Segment="6">
         <DList Name="object_hakugin_obj_DL_000120" Offset="0x120" />
-        <DList Name="object_hakugin_obj_DL_000128" Offset="0x128" />
+        <DList Name="object_hakugin_obj_DL_000128" Offset="0x128" /> <!-- Original name is "i2_H_shutter1_model" -->
         <Texture Name="object_hakugin_obj_TLUT_000310" OutName="tlut_000310" Format="rgba16" Width="4" Height="4" Offset="0x310" />
         <Texture Name="object_hakugin_obj_Tex_000330" OutName="tex_000330" Format="ci4" Width="64" Height="64" Offset="0x330" />
         <DList Name="object_hakugin_obj_DL_000D30" Offset="0xD30" />
@@ -10,27 +10,27 @@
         <Texture Name="object_hakugin_obj_TLUT_000E50" OutName="tlut_000E50" Format="rgba16" Width="4" Height="4" Offset="0xE50" />
         <Texture Name="object_hakugin_obj_Tex_000E70" OutName="tex_000E70" Format="ci4" Width="64" Height="64" Offset="0xE70" />
         <DList Name="object_hakugin_obj_DL_0016D0" Offset="0x16D0" />
-        <DList Name="object_hakugin_obj_DL_0016D8" Offset="0x16D8" />
+        <DList Name="object_hakugin_obj_DL_0016D8" Offset="0x16D8" /> <!-- Original name is "i2_haku041_model" -->
         <TextureAnimation Name="object_hakugin_obj_Matanimheader_0017A8" Offset="0x17A8" />
         <Texture Name="object_hakugin_obj_TLUT_0017B0" OutName="tlut_0017B0" Format="rgba16" Width="4" Height="4" Offset="0x17B0" />
         <Texture Name="object_hakugin_obj_Tex_0017D0" OutName="tex_0017D0" Format="ci4" Width="64" Height="64" Offset="0x17D0" />
         <DList Name="object_hakugin_obj_DL_002010" Offset="0x2010" />
-        <DList Name="object_hakugin_obj_DL_002018" Offset="0x2018" />
+        <DList Name="object_hakugin_obj_DL_002018" Offset="0x2018" /> <!-- Original name is "i2_haku071_model" -->
         <TextureAnimation Name="object_hakugin_obj_Matanimheader_0020E8" Offset="0x20E8" />
         <Texture Name="object_hakugin_obj_TLUT_0020F0" OutName="tlut_0020F0" Format="rgba16" Width="4" Height="4" Offset="0x20F0" />
         <Texture Name="object_hakugin_obj_Tex_002110" OutName="tex_002110" Format="ci4" Width="64" Height="64" Offset="0x2110" />
         <DList Name="object_hakugin_obj_DL_002970" Offset="0x2970" />
-        <DList Name="object_hakugin_obj_DL_002978" Offset="0x2978" />
+        <DList Name="object_hakugin_obj_DL_002978" Offset="0x2978" /> <!-- Original name is "i2_haku081_model" -->
         <TextureAnimation Name="object_hakugin_obj_Matanimheader_002A58" Offset="0x2A58" />
         <DList Name="object_hakugin_obj_DL_0035A0" Offset="0x35A0" />
-        <DList Name="object_hakugin_obj_DL_0035A8" Offset="0x35A8" />
+        <DList Name="object_hakugin_obj_DL_0035A8" Offset="0x35A8" /> <!-- Original name is "i2_haku091_model" -->
         <TextureAnimation Name="object_hakugin_obj_Matanimheader_003888" Offset="0x3888" />
         <Texture Name="object_hakugin_obj_TLUT_003890" OutName="tlut_003890" Format="rgba16" Width="4" Height="4" Offset="0x3890" />
         <Texture Name="object_hakugin_obj_TLUT_0038B0" OutName="tlut_0038B0" Format="rgba16" Width="4" Height="4" Offset="0x38B0" />
         <Texture Name="object_hakugin_obj_Tex_0038D0" OutName="tex_0038D0" Format="ci4" Width="64" Height="64" Offset="0x38D0" />
         <Texture Name="object_hakugin_obj_Tex_0040D0" OutName="tex_0040D0" Format="ci4" Width="64" Height="64" Offset="0x40D0" />
         <DList Name="object_hakugin_obj_DL_004920" Offset="0x4920" />
-        <DList Name="object_hakugin_obj_DL_004928" Offset="0x4928" />
+        <DList Name="object_hakugin_obj_DL_004928" Offset="0x4928" /> <!-- Original name is "i2_haku0a1_model" -->
         <TextureAnimation Name="object_hakugin_obj_Matanimheader_0049F8" Offset="0x49F8" />
         <Texture Name="object_hakugin_obj_TLUT_004A00" OutName="tlut_004A00" Format="rgba16" Width="4" Height="4" Offset="0x4A00" />
         <Texture Name="object_hakugin_obj_Tex_004A20" OutName="tex_004A20" Format="ci4" Width="64" Height="64" Offset="0x4A20" />
@@ -40,7 +40,7 @@
         <Texture Name="object_hakugin_obj_TLUT_005340" OutName="tlut_005340" Format="rgba16" Width="4" Height="4" Offset="0x5340" />
         <Texture Name="object_hakugin_obj_Tex_005360" OutName="tex_005360" Format="ci4" Width="64" Height="64" Offset="0x5360" />
         <DList Name="object_hakugin_obj_DL_006120" Offset="0x6120" />
-        <DList Name="object_hakugin_obj_DL_006128" Offset="0x6128" />
+        <DList Name="object_hakugin_obj_DL_006128" Offset="0x6128" /> <!-- Original name is "i2_H_RASENsita_model" -->
         <Texture Name="object_hakugin_obj_TLUT_0064C0" OutName="tlut_0064C0" Format="rgba16" Width="4" Height="4" Offset="0x64C0" />
         <Texture Name="object_hakugin_obj_TLUT_0064E0" OutName="tlut_0064E0" Format="rgba16" Width="4" Height="4" Offset="0x64E0" />
         <Texture Name="object_hakugin_obj_TLUT_006500" OutName="tlut_006500" Format="rgba16" Width="4" Height="4" Offset="0x6500" />
@@ -50,11 +50,11 @@
         <Texture Name="object_hakugin_obj_Tex_007D20" OutName="tex_007D20" Format="rgba16" Width="32" Height="32" Offset="0x7D20" />
         <Texture Name="object_hakugin_obj_Tex_008520" OutName="tex_008520" Format="ci4" Width="64" Height="64" Offset="0x8520" />
         <DList Name="object_hakugin_obj_DL_009270" Offset="0x9270" />
-        <DList Name="object_hakugin_obj_DL_009278" Offset="0x9278" />
+        <DList Name="object_hakugin_obj_DL_009278" Offset="0x9278" /> <!-- Original name is "i2_H_RASENue_model" -->
         <DList Name="object_hakugin_obj_DL_009650" Offset="0x9650" />
-        <DList Name="object_hakugin_obj_DL_009658" Offset="0x9658" />
-        <Collision Name="object_hakugin_obj_Colheader_009768" Offset="0x9768" />
-        <DList Name="object_hakugin_obj_DL_009830" Offset="0x9830" />
+        <DList Name="object_hakugin_obj_DL_009658" Offset="0x9658" /> <!-- Original name is "i2_bomH1_model" -->
+        <Collision Name="object_hakugin_obj_Colheader_009768" Offset="0x9768" /> <!-- Original name is "i2_bomH1_bgdatainfo" -->
+        <DList Name="object_hakugin_obj_DL_009830" Offset="0x9830" /> <!-- Original name is "i2_bomH1_sep_model" -->
         <DList Name="object_hakugin_obj_DL_0099A0" Offset="0x99A0" />
         <DList Name="object_hakugin_obj_DL_0099A8" Offset="0x99A8" />
         <Collision Name="object_hakugin_obj_Colheader_009AF0" Offset="0x9AF0" />
@@ -63,22 +63,22 @@
         <Texture Name="object_hakugin_obj_Tex_009B60" OutName="tex_009B60" Format="ci4" Width="64" Height="64" Offset="0x9B60" />
         <Texture Name="object_hakugin_obj_Tex_00A360" OutName="tex_00A360" Format="ci4" Width="64" Height="64" Offset="0xA360" />
         <DList Name="object_hakugin_obj_DL_00ACB0" Offset="0xACB0" />
-        <DList Name="object_hakugin_obj_DL_00ACB8" Offset="0xACB8" />
+        <DList Name="object_hakugin_obj_DL_00ACB8" Offset="0xACB8" /> <!-- Original name is "i2_elvH1_model" -->
         <Texture Name="object_hakugin_obj_TLUT_00AE18" OutName="tlut_00AE18" Format="rgba16" Width="4" Height="4" Offset="0xAE18" />
         <Texture Name="object_hakugin_obj_TLUT_00AE38" OutName="tlut_00AE38" Format="rgba16" Width="4" Height="4" Offset="0xAE38" />
         <Texture Name="object_hakugin_obj_Tex_00AE58" OutName="tex_00AE58" Format="ci4" Width="64" Height="64" Offset="0xAE58" />
         <Texture Name="object_hakugin_obj_Tex_00B658" OutName="tex_00B658" Format="ci4" Width="64" Height="64" Offset="0xB658" />
-        <Collision Name="object_hakugin_obj_Colheader_00BF40" Offset="0xBF40" />
+        <Collision Name="object_hakugin_obj_Colheader_00BF40" Offset="0xBF40" /> <!-- Original name is "i2_elvH1_bgdatainfo" -->
         <DList Name="object_hakugin_obj_DL_00C1A0" Offset="0xC1A0" />
-        <DList Name="object_hakugin_obj_DL_00C1A8" Offset="0xC1A8" />
+        <DList Name="object_hakugin_obj_DL_00C1A8" Offset="0xC1A8" /> <!-- Original name is "i2_icecol1_model" -->
         <DList Name="object_hakugin_obj_DL_00C560" Offset="0xC560" />
-        <DList Name="object_hakugin_obj_DL_00C568" Offset="0xC568" />
+        <DList Name="object_hakugin_obj_DL_00C568" Offset="0xC568" /> <!-- Original name is "i2_icecol2_model" -->
         <DList Name="object_hakugin_obj_DL_00CA30" Offset="0xCA30" />
-        <DList Name="object_hakugin_obj_DL_00CA38" Offset="0xCA38" />
+        <DList Name="object_hakugin_obj_DL_00CA38" Offset="0xCA38" /> <!-- Original name is "i2_icecolA_model" -->
         <DList Name="object_hakugin_obj_DL_00CEC0" Offset="0xCEC0" />
-        <DList Name="object_hakugin_obj_DL_00CEC8" Offset="0xCEC8" />
+        <DList Name="object_hakugin_obj_DL_00CEC8" Offset="0xCEC8" /> <!-- Original name is "i2_icecolB_model" -->
         <DList Name="object_hakugin_obj_DL_00D090" Offset="0xD090" />
-        <DList Name="object_hakugin_obj_DL_00D098" Offset="0xD098" />
+        <DList Name="object_hakugin_obj_DL_00D098" Offset="0xD098" /> <!-- Original name is "i2_icecolB_sep_model" -->
         <Collision Name="object_hakugin_obj_Colheader_00D3B0" Offset="0xD3B0" />
         <Texture Name="object_hakugin_obj_TLUT_00D3E0" OutName="tlut_00D3E0" Format="rgba16" Width="4" Height="4" Offset="0xD3E0" />
         <!-- <Blob Name="object_hakugin_obj_Blob_00D400" Size="0x40" Offset="0xD400" /> -->

--- a/assets/xml/objects/object_hana.xml
+++ b/assets/xml/objects/object_hana.xml
@@ -8,6 +8,6 @@
         <DList Name="object_hana_DL_000320" Offset="0x320" />
         <DList Name="object_hana_DL_0003C0" Offset="0x3C0" />
         <DList Name="object_hana_DL_000460" Offset="0x460" />
-        <DList Name="object_hana_DL_000500" Offset="0x500" />
+        <DList Name="object_hana_DL_000500" Offset="0x500" /> <!-- Original name is "flower1_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_harfgibud.xml
+++ b/assets/xml/objects/object_harfgibud.xml
@@ -3,11 +3,11 @@
     <File Name="object_harfgibud" Segment="6">
 
         <!-- Gibdo Form -->
-        <Animation Name="gPamelasFatherLeanForwardAnim" Offset="0x370" />
-        <Animation Name="gPamelasFatherReachForwardAnim" Offset="0x1138" />
-        <Animation Name="gPamelasFatherCurlUpAnim" Offset="0x15D4" />
-        <Animation Name="gPamelasFatherCrouchedPanicAnim" Offset="0x1960" />
-        <Animation Name="gPamelasFatherIdleAnim" Offset="0x260C" />
+        <Animation Name="gPamelasFatherLeanForwardAnim" Offset="0x370" /> <!-- Original name is "hg_garuru" -->
+        <Animation Name="gPamelasFatherReachForwardAnim" Offset="0x1138" /> <!-- Original name is "hg_garuru_loop" -->
+        <Animation Name="gPamelasFatherCurlUpAnim" Offset="0x15D4" /> <!-- Original name is "hg_kurusimu" -->
+        <Animation Name="gPamelasFatherCrouchedPanicAnim" Offset="0x1960" /> <!-- Original name is "hg_kurusimu_loop" -->
+        <Animation Name="gPamelasFatherIdleAnim" Offset="0x260C" /> <!-- Original name is "hg_wait" -->
 
         <DList Name="gPamelasFatherGibdoPelvisDL" Offset="0x5790" />
         <DList Name="gPamelasFatherGibdoRightFootDL" Offset="0x5878" />
@@ -61,11 +61,11 @@
         <Limb Name="gPamelasFatherGibdoRightFootLimb" Type="Standard" EnumName="PAMELAS_FATHER_GIBDO_LIMB_RIGHT_FOOT" Offset="0x852C" />
         <Skeleton Name="gPamelasFatherGibdoSkel" Type="Flex" LimbType="Standard" LimbNone="PAMELAS_FATHER_GIBDO_LIMB_NONE" LimbMax="PAMELAS_FATHER_GIBDO_LIMB_MAX" EnumName="PamelasFatherGibdoLimb" Offset="0x8580" />
 
-        <Animation Name="gPamelasFatherLurchForwardAnim" Offset="0x9D44" />
-        <Animation Name="gPamelasFatherRecoilFromHitAnim" Offset="0xA164" />
-        <Animation Name="gPamelasFatherPanicAnim" Offset="0xAE1C" />
+        <Animation Name="gPamelasFatherLurchForwardAnim" Offset="0x9D44" /> <!-- Original name is "hg_walk" -->
+        <Animation Name="gPamelasFatherRecoilFromHitAnim" Offset="0xA164" /> <!-- Original name is "hg_yarare" -->
+        <Animation Name="gPamelasFatherPanicAnim" Offset="0xAE1C" /> <!-- Original name is "hg_yurayura" -->
         <TextureAnimation Name="gPamelasFatherEyeTexAnim" Offset="0xAE50" />
-        <Animation Name="gPamelasFatherArmsFoldedAnim" Offset="0xB644" />
+        <Animation Name="gPamelasFatherArmsFoldedAnim" Offset="0xB644" /> <!-- Original name is "hgo_wait" -->
 
         <DList Name="gPamelasFatherHumanPelvisDL" Offset="0xE860" />
         <DList Name="gPamelasFatherHumanRightFootDL" Offset="0xE9E0" />
@@ -121,11 +121,11 @@
         <Limb Name="gPamelasFatherHumanRightFootLimb" Type="Standard" EnumName="PAMELAS_FATHER_HUMAN_LIMB_RIGHT_FOOT" Offset="0x12A04" />
         <Skeleton Name="gPamelasFatherHumanSkel" Type="Flex" LimbType="Standard" LimbNone="PAMELAS_FATHER_HUMAN_LIMB_NONE" LimbMax="PAMELAS_FATHER_HUMAN_LIMB_MAX" EnumName="PamelasFatherHumanLimb" Offset="0x12A58" />
 
-        <Animation Name="gPamelasFatherAstonishedAnim" Offset="0x13684" />
-        <Animation Name="gPamelasFatherReachDownToLiftAnim" Offset="0x14220" />
-        <Animation Name="gPamelasFatherTossAnim" Offset="0x14A9C" />
-        <Animation Name="gPamelasFatherKneelDownAndHugAnim" Offset="0x152EC" />
-        <Animation Name="gPamelasFatherConsoleAnim" Offset="0x15C70" />
-        <Animation Name="gPamelasFatherConsoleHeadUpAnim" Offset="0x165F0" />
+        <Animation Name="gPamelasFatherAstonishedAnim" Offset="0x13684" /> <!-- Original name is "ho_bozen_loop" -->
+        <Animation Name="gPamelasFatherReachDownToLiftAnim" Offset="0x14220" /> <!-- Original name is "ho_siawase" -->
+        <Animation Name="gPamelasFatherTossAnim" Offset="0x14A9C" /> <!-- Original name is "ho_siawase_loop" -->
+        <Animation Name="gPamelasFatherKneelDownAndHugAnim" Offset="0x152EC" /> <!-- Original name is "ho_uketome" -->
+        <Animation Name="gPamelasFatherConsoleAnim" Offset="0x15C70" /> <!-- Original name is "ho_uketome_loop" -->
+        <Animation Name="gPamelasFatherConsoleHeadUpAnim" Offset="0x165F0" /> <!-- Original name is "ho_watasiwa" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hariko.xml
+++ b/assets/xml/objects/object_hariko.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <!-- Object for the Clock Town cow statues -->
     <File Name="object_hariko" Segment="6">
-        <DList Name="gHarikoBodyDL" Offset="0x80" />
-        <DList Name="gHarikoFaceDL" Offset="0x110" />
+        <DList Name="gHarikoBodyDL" Offset="0x80" /> <!-- Original name is "hariko_body_model" -->
+        <DList Name="gHarikoFaceDL" Offset="0x110" /> <!-- Original name is "hariko_atamaT_model" -->
         <Texture Name="gHarikoBodyTex" OutName="hariko_body" Format="rgba16" Width="8" Height="8" Offset="0x1A0" />
         <Texture Name="gHarikoFaceTex" OutName="hariko_face" Format="rgba16" Width="16" Height="16" Offset="0x220" />
     </File>

--- a/assets/xml/objects/object_hata.xml
+++ b/assets/xml/objects/object_hata.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_hata" Segment="6">
         <!-- Flagpole Collision -->
-        <Collision Name="gFlagpoleCol" Offset="0xC0" />
+        <Collision Name="gFlagpoleCol" Offset="0xC0" /> <!-- Original name is "hata_bgdatainfo" -->
 
         <!-- Flagpole Animation -->
-        <Animation Name="gFlagpoleFlapAnim" Offset="0x444" />
+        <Animation Name="gFlagpoleFlapAnim" Offset="0x444" /> <!-- Original name is "ht_hata" -->
 
         <!-- Flagpole Textures -->
         <Texture Name="gFlagpolePoleTex" OutName="flagpole_pole" Format="rgba16" Width="32" Height="32" Offset="0x460" />

--- a/assets/xml/objects/object_hgdoor.xml
+++ b/assets/xml/objects/object_hgdoor.xml
@@ -3,11 +3,11 @@
         <Texture Name="object_hgdoor_Tex_000000" OutName="tex_000000" Format="rgba16" Width="16" Height="32" Offset="0x0" />
         <Texture Name="object_hgdoor_Tex_000400" OutName="tex_000400" Format="rgba16" Width="32" Height="64" Offset="0x400" />
         <Texture Name="object_hgdoor_Tex_001400" OutName="tex_001400" Format="i8" Width="8" Height="32" Offset="0x1400" />
-        <DList Name="object_hgdoor_DL_001670" Offset="0x1670" />
-        <DList Name="object_hgdoor_DL_001768" Offset="0x1768" />
-        <Collision Name="object_hgdoor_Colheader_0018C0" Offset="0x18C0" />
-        <DList Name="object_hgdoor_DL_001AB0" Offset="0x1AB0" />
-        <DList Name="object_hgdoor_DL_001BA8" Offset="0x1BA8" />
-        <Collision Name="object_hgdoor_Colheader_001D10" Offset="0x1D10" />
+        <DList Name="object_hgdoor_DL_001670" Offset="0x1670" /> <!-- Original name is "tobira_left_model" -->
+        <DList Name="object_hgdoor_DL_001768" Offset="0x1768" /> <!-- Original name is "huda_l_model" -->
+        <Collision Name="object_hgdoor_Colheader_0018C0" Offset="0x18C0" /> <!-- Original name is "z2_music_box_house_t_l_bgdatainfo" -->
+        <DList Name="object_hgdoor_DL_001AB0" Offset="0x1AB0" /> <!-- Original name is "tobira_right_model" -->
+        <DList Name="object_hgdoor_DL_001BA8" Offset="0x1BA8" /> <!-- Original name is "huda_r_model" -->
+        <Collision Name="object_hgdoor_Colheader_001D10" Offset="0x1D10" /> <!-- Original name is "z2_music_box_house_t_r_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hintnuts.xml
+++ b/assets/xml/objects/object_hintnuts.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_hintnuts" Segment="6">
-        <Animation Name="object_hintnuts_Anim_000168" Offset="0x168" />
+        <Animation Name="object_hintnuts_Anim_000168" Offset="0x168" /> <!-- Original name is "dnh_atack" -->
         <DList Name="object_hintnuts_DL_000B30" Offset="0xB30" />
         <DList Name="object_hintnuts_DL_000C68" Offset="0xC68" />
         <DList Name="object_hintnuts_DL_000D10" Offset="0xD10" />
@@ -10,7 +10,7 @@
         <DList Name="object_hintnuts_DL_001028" Offset="0x1028" />
         <DList Name="object_hintnuts_DL_0010C8" Offset="0x10C8" />
         <DList Name="object_hintnuts_DL_001208" Offset="0x1208" />
-        <DList Name="object_hintnuts_DL_0012F0" Offset="0x12F0" />
+        <DList Name="object_hintnuts_DL_0012F0" Offset="0x12F0" /> <!-- Original name is "dnh_ball_model" -->
         <DList Name="object_hintnuts_DL_0014E0" Offset="0x14E0" />
         <Texture Name="object_hintnuts_Tex_0015A8" OutName="tex_0015A8" Format="rgba16" Width="32" Height="32" Offset="0x15A8" />
         <Texture Name="object_hintnuts_Tex_001DA8" OutName="tex_001DA8" Format="rgba16" Width="16" Height="16" Offset="0x1DA8" />
@@ -28,13 +28,13 @@
         <Limb Name="object_hintnuts_Standardlimb_00237C" Type="Standard" EnumName="OBJECT_HINTNUTS_LIMB_08" Offset="0x237C" />
         <Limb Name="object_hintnuts_Standardlimb_002388" Type="Standard" EnumName="OBJECT_HINTNUTS_LIMB_09" Offset="0x2388" />
         <Skeleton Name="object_hintnuts_Skel_0023B8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_HINTNUTS_LIMB_NONE" LimbMax="OBJECT_HINTNUTS_LIMB_MAX" EnumName="ObjectHintnutsLimb" Offset="0x23B8" />
-        <Animation Name="object_hintnuts_Anim_0024CC" Offset="0x24CC" />
-        <Animation Name="object_hintnuts_Anim_0026C4" Offset="0x26C4" />
-        <Animation Name="object_hintnuts_Anim_002894" Offset="0x2894" />
-        <Animation Name="object_hintnuts_Anim_0029BC" Offset="0x29BC" />
-        <Animation Name="object_hintnuts_Anim_002B90" Offset="0x2B90" />
-        <Animation Name="object_hintnuts_Anim_002E84" Offset="0x2E84" />
-        <Animation Name="object_hintnuts_Anim_002F7C" Offset="0x2F7C" />
-        <Animation Name="object_hintnuts_Anim_003128" Offset="0x3128" />
+        <Animation Name="object_hintnuts_Anim_0024CC" Offset="0x24CC" /> <!-- Original name is "dnh_dig" -->
+        <Animation Name="object_hintnuts_Anim_0026C4" Offset="0x26C4" /> <!-- Original name is "dnh_jump" -->
+        <Animation Name="object_hintnuts_Anim_002894" Offset="0x2894" /> <!-- Original name is "dnh_lookaround" -->
+        <Animation Name="object_hintnuts_Anim_0029BC" Offset="0x29BC" /> <!-- Original name is "dnh_mahi" -->
+        <Animation Name="object_hintnuts_Anim_002B90" Offset="0x2B90" /> <!-- Original name is "dnh_start" -->
+        <Animation Name="object_hintnuts_Anim_002E84" Offset="0x2E84" /> <!-- Original name is "dnh_talk" -->
+        <Animation Name="object_hintnuts_Anim_002F7C" Offset="0x2F7C" /> <!-- Original name is "dnh_wait" -->
+        <Animation Name="object_hintnuts_Anim_003128" Offset="0x3128" /> <!-- Original name is "dnh_walk" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_horse_game_check.xml
+++ b/assets/xml/objects/object_horse_game_check.xml
@@ -8,9 +8,9 @@
         <Texture Name="object_horse_game_check_Tex_001D90" OutName="tex_001D90" Format="rgba16" Width="32" Height="32" Offset="0x1D90" />
         <Texture Name="object_horse_game_check_Tex_002590" OutName="tex_002590" Format="i8" Width="64" Height="32" Offset="0x2590" />
         <Collision Name="object_horse_game_check_Colheader_002FB8" Offset="0x2FB8" />
-        <DList Name="object_horse_game_check_DL_003030" Offset="0x3030" />
+        <DList Name="object_horse_game_check_DL_003030" Offset="0x3030" /> <!-- Original name is "z2_umajamp_modelT" -->
         <DList Name="object_horse_game_check_DL_0030C0" Offset="0x30C0" />
         <Texture Name="object_horse_game_check_Tex_0030C8" OutName="tex_0030C8" Format="rgba16" Width="32" Height="32" Offset="0x30C8" />
-        <Collision Name="object_horse_game_check_Colheader_003918" Offset="0x3918" />
+        <Collision Name="object_horse_game_check_Colheader_003918" Offset="0x3918" /> <!-- Original name is "z2_umajamp_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_horse_link_child.xml
+++ b/assets/xml/objects/object_horse_link_child.xml
@@ -20,15 +20,15 @@
         <Texture Name="object_horse_link_child_Tex_002568" OutName="tex_002568" Format="rgba16" Width="4" Height="4" Offset="0x2568" />
         <Texture Name="object_horse_link_child_Tex_002588" OutName="tex_002588" Format="rgba16" Width="8" Height="32" Offset="0x2588" />
         <Texture Name="object_horse_link_child_Tex_002788" OutName="tex_002788" Format="rgba16" Width="16" Height="16" Offset="0x2788" />
-        <Animation Name="object_horse_link_child_Anim_002F98" Offset="0x2F98" />
-        <Animation Name="object_horse_link_child_Anim_0035B0" Offset="0x35B0" />
-        <Animation Name="object_horse_link_child_Anim_003D38" Offset="0x3D38" />
-        <Animation Name="object_horse_link_child_Anim_0043AC" Offset="0x43AC" />
-        <Animation Name="object_horse_link_child_Anim_004DE8" Offset="0x4DE8" />
-        <Animation Name="object_horse_link_child_Anim_005F64" Offset="0x5F64" />
-        <Animation Name="object_horse_link_child_Anim_006D44" Offset="0x6D44" />
-        <Animation Name="object_horse_link_child_Anim_007468" Offset="0x7468" />
-        <Animation Name="object_horse_link_child_Anim_007D50" Offset="0x7D50" />
+        <Animation Name="object_horse_link_child_Anim_002F98" Offset="0x2F98" /> <!-- Original name is "hlc_anim_fastrun_30" -->
+        <Animation Name="object_horse_link_child_Anim_0035B0" Offset="0x35B0" /> <!-- Original name is "hlc_anim_jump100" -->
+        <Animation Name="object_horse_link_child_Anim_003D38" Offset="0x3D38" /> <!-- Original name is "hlc_anim_jump200" -->
+        <Animation Name="object_horse_link_child_Anim_0043AC" Offset="0x43AC" /> <!-- Original name is "hlc_anim_slowrun_30" -->
+        <Animation Name="object_horse_link_child_Anim_004DE8" Offset="0x4DE8" /> <!-- Original name is "hlc_anim_stand" -->
+        <Animation Name="object_horse_link_child_Anim_005F64" Offset="0x5F64" /> <!-- Original name is "hlc_anim_stop" -->
+        <Animation Name="object_horse_link_child_Anim_006D44" Offset="0x6D44" /> <!-- Original name is "hlc_anim_wait" -->
+        <Animation Name="object_horse_link_child_Anim_007468" Offset="0x7468" /> <!-- Original name is "hlc_anim_wait02" -->
+        <Animation Name="object_horse_link_child_Anim_007D50" Offset="0x7D50" /> <!-- Original name is "hlc_anim_walk_30" -->
         <!-- <Blob Name="object_horse_link_child_Blob_007D60" Size="0x2388" Offset="0x7D60" /> -->
         <Limb Name="object_horse_link_child_Skinlimb_00A0E8" Type="Skin" EnumName="OBJECT_HORSE_LINK_CHILD_LIMB_01" Offset="0xA0E8" />
         <Limb Name="object_horse_link_child_Skinlimb_00A0F8" Type="Skin" EnumName="OBJECT_HORSE_LINK_CHILD_LIMB_02" Offset="0xA0F8" />
@@ -77,12 +77,12 @@
         <Limb Name="object_horse_link_child_Skinlimb_00A3A8" Type="Skin" EnumName="OBJECT_HORSE_LINK_CHILD_LIMB_2D" Offset="0xA3A8" />
         <Limb Name="object_horse_link_child_Skinlimb_00A3B8" Type="Skin" EnumName="OBJECT_HORSE_LINK_CHILD_LIMB_2E" Offset="0xA3B8" />
         <Skeleton Name="object_horse_link_child_Skel_00A480" Type="Normal" LimbType="Standard" LimbNone="OBJECT_HORSE_LINK_CHILD_LIMB_NONE" LimbMax="OBJECT_HORSE_LINK_CHILD_LIMB_MAX" EnumName="ObjectHorseLinkChildLimb" Offset="0xA480" />
-        <Animation Name="object_horse_link_child_Anim_00A8DC" Offset="0xA8DC" />
-        <Animation Name="object_horse_link_child_Anim_00AD08" Offset="0xAD08" />
-        <Animation Name="object_horse_link_child_Anim_00B3E0" Offset="0xB3E0" />
-        <Animation Name="object_horse_link_child_Anim_00BDE0" Offset="0xBDE0" />
-        <Animation Name="object_horse_link_child_Anim_00D178" Offset="0xD178" />
-        <Animation Name="object_horse_link_child_Anim_00D4E8" Offset="0xD4E8" />
+        <Animation Name="object_horse_link_child_Anim_00A8DC" Offset="0xA8DC" /> <!-- Original name is "hlc_inanaki" -->
+        <Animation Name="object_horse_link_child_Anim_00AD08" Offset="0xAD08" /> <!-- Original name is "hlc_inanaki_modori" -->
+        <Animation Name="object_horse_link_child_Anim_00B3E0" Offset="0xB3E0" /> <!-- Original name is "hlc_inanaki_wait" -->
+        <Animation Name="object_horse_link_child_Anim_00BDE0" Offset="0xBDE0" /> <!-- Original name is "hlc_lost_house2" -->
+        <Animation Name="object_horse_link_child_Anim_00D178" Offset="0xD178" /> <!-- Original name is "hlc_lost_house_inanaki" -->
+        <Animation Name="object_horse_link_child_Anim_00D4E8" Offset="0xD4E8" /> <!-- Original name is "hlc_lost_house_inanaki_run" -->
         <DList Name="object_horse_link_child_DL_00D500" Offset="0xD500" />
         <Texture Name="object_horse_link_child_Tex_00DAF0" OutName="tex_00DAF0" Format="rgba16" Width="16" Height="16" Offset="0xDAF0" />
         <Texture Name="object_horse_link_child_Tex_00DCF0" OutName="tex_00DCF0" Format="rgba16" Width="32" Height="32" Offset="0xDCF0" />

--- a/assets/xml/objects/object_hs.xml
+++ b/assets/xml/objects/object_hs.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <!-- Grog: the Cucco keeper, you raise his Cucco chicks into adults to earn the Bunny Hood mask -->
     <File Name="object_hs" Segment="6">
-        <Animation Name="gHsShiveringAnim" Offset="0x304" /> <!-- unused, "h_purupuru" japanese onomatopoeic for 'shivering' -->
-        <Animation Name="gHsPleadingAnim" Offset="0x528" /> <!-- unused, "h_tanomuu" japanese for 'to beg' -->
-        <Animation Name="gHsIdleAnim" Offset="0x5C0" /> <!-- "h_matsu" japanese for 'to wait' -->
+        <Animation Name="gHsShiveringAnim" Offset="0x304" /> <!-- Original name is "h_purupuru" (onomatopoeic for "shivering"), unused -->
+        <Animation Name="gHsPleadingAnim" Offset="0x528" /> <!-- Original name is "h_tanomuu" ("to beg"), unused -->
+        <Animation Name="gHsIdleAnim" Offset="0x5C0" /> <!-- Original name is "h_matsu" ("to wait") -->
         <DList Name="object_hs_DL_003760" Offset="0x3760" />
         <DList Name="object_hs_DL_003AB0" Offset="0x3AB0" />
         <DList Name="object_hs_DL_004140" Offset="0x4140" />

--- a/assets/xml/objects/object_hsstump.xml
+++ b/assets/xml/objects/object_hsstump.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_hsstump" Segment="6">
         <DList Name="object_hsstump_DL_0003B0" Offset="0x3B0" />
-        <DList Name="object_hsstump_DL_0003B8" Offset="0x3B8" />
+        <DList Name="object_hsstump_DL_0003B8" Offset="0x3B8" /> <!-- Original name is "z2_miki_model" -->
         <Texture Name="object_hsstump_Tex_0005A0" OutName="tex_0005A0" Format="rgba16" Width="16" Height="16" Offset="0x5A0" />
         <Texture Name="object_hsstump_TLUT_0007A0" OutName="tlut_0007A0" Format="rgba16" Width="4" Height="4" Offset="0x7A0" />
         <Texture Name="object_hsstump_Tex_0007C0" OutName="tex_0007C0" Format="ci4" Width="64" Height="64" Offset="0x7C0" />
-        <Collision Name="object_hsstump_Colheader_0011B0" Offset="0x11B0" />
+        <Collision Name="object_hsstump_Colheader_0011B0" Offset="0x11B0" /> <!-- Original name is "z2_miki_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hunsui.xml
+++ b/assets/xml/objects/object_hunsui.xml
@@ -3,8 +3,8 @@
         <DList Name="object_hunsui_DL_000220" Offset="0x220" /> <!-- Original name might be "m2_SEAhunsui_4_modelT" -->
         <Texture Name="object_hunsui_Tex_0003E0" OutName="tex_0003E0" Format="rgba16" Width="32" Height="32" Offset="0x3E0" />
         <TextureAnimation Name="object_hunsui_Matanimheader_000BF0" Offset="0xBF0" />
-        <Collision Name="object_hunsui_Colheader_000C74" Offset="0xC74" /> <!-- Original name is "m2_SEAhunsui_4_bgdatainfo" -->
-        <DList Name="object_hunsui_DL_000EC0" Offset="0xEC0" /> <!-- Original name is "m2_SEAhunsui20_5_modelT" -->
+        <Collision Name="object_hunsui_Colheader_000C74" Offset="0xC74" /> <!-- Original name might be "m2_SEAhunsui_4_bgdatainfo" -->
+        <DList Name="object_hunsui_DL_000EC0" Offset="0xEC0" /> <!-- Original name might be "m2_SEAhunsui20_5_modelT" -->
         <Texture Name="object_hunsui_Tex_001078" OutName="tex_001078" Format="rgba16" Width="32" Height="32" Offset="0x1078" />
         <TextureAnimation Name="object_hunsui_Matanimheader_001888" Offset="0x1888" />
         <Collision Name="object_hunsui_Colheader_00190C" Offset="0x190C" /> <!-- Original name might be "m2_SEAhunsui20_5_bgdatainfo". Unused duplicate of object_hunsui_Colheader_000C74 -->

--- a/assets/xml/objects/object_hunsui.xml
+++ b/assets/xml/objects/object_hunsui.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_hunsui" Segment="6">
-        <DList Name="object_hunsui_DL_000220" Offset="0x220" /> <!-- Original name is "m2_SEAhunsui_4_modelT" -->
+        <DList Name="object_hunsui_DL_000220" Offset="0x220" /> <!-- Original name might be "m2_SEAhunsui_4_modelT" -->
         <Texture Name="object_hunsui_Tex_0003E0" OutName="tex_0003E0" Format="rgba16" Width="32" Height="32" Offset="0x3E0" />
         <TextureAnimation Name="object_hunsui_Matanimheader_000BF0" Offset="0xBF0" />
         <Collision Name="object_hunsui_Colheader_000C74" Offset="0xC74" /> <!-- Original name is "m2_SEAhunsui_4_bgdatainfo" -->
         <DList Name="object_hunsui_DL_000EC0" Offset="0xEC0" /> <!-- Original name is "m2_SEAhunsui20_5_modelT" -->
         <Texture Name="object_hunsui_Tex_001078" OutName="tex_001078" Format="rgba16" Width="32" Height="32" Offset="0x1078" />
         <TextureAnimation Name="object_hunsui_Matanimheader_001888" Offset="0x1888" />
-        <Collision Name="object_hunsui_Colheader_00190C" Offset="0x190C" /> <!-- Original name is "m2_SEAhunsui20_5_bgdatainfo". Unused duplicate of object_hunsui_Colheader_000C74 -->
+        <Collision Name="object_hunsui_Colheader_00190C" Offset="0x190C" /> <!-- Original name might be "m2_SEAhunsui20_5_bgdatainfo". Unused duplicate of object_hunsui_Colheader_000C74 -->
     </File>
 </Root>

--- a/assets/xml/objects/object_hunsui.xml
+++ b/assets/xml/objects/object_hunsui.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_hunsui" Segment="6">
-        <DList Name="object_hunsui_DL_000220" Offset="0x220" />
+        <DList Name="object_hunsui_DL_000220" Offset="0x220" /> <!-- Original name is "m2_SEAhunsui_4_modelT" -->
         <Texture Name="object_hunsui_Tex_0003E0" OutName="tex_0003E0" Format="rgba16" Width="32" Height="32" Offset="0x3E0" />
         <TextureAnimation Name="object_hunsui_Matanimheader_000BF0" Offset="0xBF0" />
-        <Collision Name="object_hunsui_Colheader_000C74" Offset="0xC74" />
-        <DList Name="object_hunsui_DL_000EC0" Offset="0xEC0" />
+        <Collision Name="object_hunsui_Colheader_000C74" Offset="0xC74" /> <!-- Original name is "m2_SEAhunsui_4_bgdatainfo" -->
+        <DList Name="object_hunsui_DL_000EC0" Offset="0xEC0" /> <!-- Original name is "m2_SEAhunsui20_5_modelT" -->
         <Texture Name="object_hunsui_Tex_001078" OutName="tex_001078" Format="rgba16" Width="32" Height="32" Offset="0x1078" />
         <TextureAnimation Name="object_hunsui_Matanimheader_001888" Offset="0x1888" />
-        <Collision Name="object_hunsui_Colheader_00190C" Offset="0x190C" />
+        <Collision Name="object_hunsui_Colheader_00190C" Offset="0x190C" /> <!-- Original name is "m2_SEAhunsui20_5_bgdatainfo". Unused duplicate of object_hunsui_Colheader_000C74 -->
     </File>
 </Root>


### PR DESCRIPTION
The most interesting (and potentially controversial) one of these in `object_hunsui`. In MM3D, they actually included some original N64 assets in the object:

![image](https://github.com/zeldaret/mm/assets/12245827/fa6601cf-5911-4a0f-b5a9-bec8084a6202)

The one actually used by MM3D stuck a "20" in the name like so:

![image](https://github.com/zeldaret/mm/assets/12245827/291492c0-5a93-46b2-bf22-e4f3ac47403c)

But that raises some questions. Did the original N64 one have "20" in the name? If it did, why is there a collision file *without* "20" in the name? And speaking of collision, one of the collision files in MM64 is an unused duplicate. MM3D has two collision files...that are *also* duplicates. I just named the collision files after the DLs they are near, since that made the most sense, but perhaps we don't want to name either of them, given that we can't really know how the MM3D ones are supposed to map to the N64 ones since they're both duplicates.