### PR TITLE
Added some missing includes in ZAPD

### DIFF
--- a/tools/ZAPD/ZAPD/CrashHandler.cpp
+++ b/tools/ZAPD/ZAPD/CrashHandler.cpp
@@ -7,6 +7,7 @@
 #define HAS_POSIX 0
 #endif
 
+#include <stdint.h>
 #include <array>
 #include <cstdio>
 #include <cstdlib>

--- a/tools/ZAPD/ZAPD/Declaration.h
+++ b/tools/ZAPD/ZAPD/Declaration.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <string>
 #include <vector>
 

--- a/tools/ZAPD/ZAPD/OutputFormatter.h
+++ b/tools/ZAPD/ZAPD/OutputFormatter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <map>
 #include <string>
 #include <vector>


### PR DESCRIPTION
I have added some includes of the `stdint` header in three files from ZAPD. Without these includes, ZAPD did not compile on my machine, showing the error message "unknown type name`uint32_t`".
I hope this can be useful to other contributors :)