### PR TITLE
Change all uses of "rotational velocity" to "angular velocity"

### DIFF
--- a/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.c
+++ b/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.c
@@ -100,9 +100,9 @@ void BgNumaHana_UpdatePetalPosRots(BgNumaHana* this) {
     s32 i;
 
     innerPetalYPos = this->dyna.actor.world.pos.y + -10.0f;
-    angle = this->petalZRotation - 0x2000;
+    angle = this->petalRotZ - 0x2000;
     outerPetalPosScale = (Math_CosS(angle) * 77.42784f) + 74.95192f;
-    outerPetalYPos = (Math_SinS(this->petalZRotation) * 77.42784f) + this->dyna.actor.world.pos.y + -64.74976f;
+    outerPetalYPos = (Math_SinS(this->petalRotZ) * 77.42784f) + this->dyna.actor.world.pos.y + -64.74976f;
 
     for (i = 0; i < ARRAY_COUNT(this->innerPetalPosRot); i++) {
         innerPetalPosRot = &this->innerPetalPosRot[i];
@@ -114,14 +114,14 @@ void BgNumaHana_UpdatePetalPosRots(BgNumaHana* this) {
         innerPetalPosRot->pos.z = (Math_CosS(angle) * 74.95192f) + this->dyna.actor.world.pos.z;
         innerPetalPosRot->rot.x = this->dyna.actor.shape.rot.x;
         innerPetalPosRot->rot.y = angle - 0x4000;
-        innerPetalPosRot->rot.z = this->dyna.actor.shape.rot.z + this->petalZRotation;
+        innerPetalPosRot->rot.z = this->dyna.actor.shape.rot.z + this->petalRotZ;
 
         outerPetalPosRot->pos.x = (Math_SinS(angle) * outerPetalPosScale) + this->dyna.actor.world.pos.x;
         outerPetalPosRot->pos.y = outerPetalYPos;
         outerPetalPosRot->pos.z = (Math_CosS(angle) * outerPetalPosScale) + this->dyna.actor.world.pos.z;
         outerPetalPosRot->rot.x = innerPetalPosRot->rot.x;
         outerPetalPosRot->rot.y = innerPetalPosRot->rot.y;
-        outerPetalPosRot->rot.z = innerPetalPosRot->rot.z + this->outerPetalZRotation;
+        outerPetalPosRot->rot.z = innerPetalPosRot->rot.z + this->outerPetalRotZ;
     }
 }
 
@@ -130,10 +130,10 @@ void BgNumaHana_UpdatePetalPosRots(BgNumaHana* this) {
  * as if they are "settling" into place. This function is responsible
  * for computing the extra rotation for this "settling".
  */
-void BgNumaHana_UpdateSettleRotation(s16* settleZRotation, s16* settleAngle, f32* settleScale, f32 scaleStep) {
+void BgNumaHana_UpdateSettleRotation(s16* settleRotZ, s16* settleAngle, f32* settleScale, f32 scaleStep) {
     *settleAngle += 0x32C8;
     Math_StepToF(settleScale, 0.0f, scaleStep);
-    *settleZRotation += (s16)(Math_SinS(*settleAngle) * *settleScale);
+    *settleRotZ += (s16)(Math_SinS(*settleAngle) * *settleScale);
 }
 
 void BgNumaHana_Init(Actor* thisx, PlayState* play) {
@@ -164,15 +164,15 @@ void BgNumaHana_Init(Actor* thisx, PlayState* play) {
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_12_01)) {
             DynaPoly_DisableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
 
-            this->petalZRotation = 0x2000;
-            this->innerPetalZRotation = 0x2000;
-            this->innerPetalZRotationalVelocity = 0;
-            this->settleZRotation = 0;
+            this->petalRotZ = 0x2000;
+            this->innerPetalRotZ = 0x2000;
+            this->innerPetalAngularVelocityZ = 0;
+            this->settleRotZ = 0;
             this->settleAngle = 0;
             this->settleScale = 0.0f;
-            this->outerPetalZRotation = -0x4000;
-            this->outerPetalZRotationalVelocity = 0;
-            this->flowerRotationalVelocity = 0x147;
+            this->outerPetalRotZ = -0x4000;
+            this->outerPetalAngularVelocityZ = 0;
+            this->flowerAngularVelocity = 0x147;
 
             this->dyna.actor.world.pos.y = this->dyna.actor.home.pos.y + 210.0f;
             FireObj_SetState2(&this->fire, 0.05f, FIRE_STATE_FULLY_LIT);
@@ -238,13 +238,13 @@ void BgNumaHana_SetupUnfoldInnerPetals(BgNumaHana* this) {
  * parts of the petals that are closest to the stalk.
  */
 void BgNumaHana_UnfoldInnerPetals(BgNumaHana* this, PlayState* play) {
-    Math_StepToS(&this->innerPetalZRotationalVelocity, 240, 14);
-    if (Math_ScaledStepToS(&this->innerPetalZRotation, 0x2000, this->innerPetalZRotationalVelocity)) {
+    Math_StepToS(&this->innerPetalAngularVelocityZ, 240, 14);
+    if (Math_ScaledStepToS(&this->innerPetalRotZ, 0x2000, this->innerPetalAngularVelocityZ)) {
         if (this->transitionTimer >= 11) {
             BgNumaHana_SetupUnfoldOuterPetals(this);
         } else {
             if (this->transitionTimer <= 0) {
-                this->settleZRotation = 0;
+                this->settleRotZ = 0;
                 this->settleAngle = 0;
                 this->settleScale = 420.0f;
                 Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FLOWERPETAL_STOP);
@@ -255,8 +255,8 @@ void BgNumaHana_UnfoldInnerPetals(BgNumaHana* this, PlayState* play) {
         Actor_PlaySfx_Flagged(&this->dyna.actor, NA_SE_EV_FLOWERPETAL_MOVE - SFX_FLAG);
     }
 
-    BgNumaHana_UpdateSettleRotation(&this->settleZRotation, &this->settleAngle, &this->settleScale, 20.0f);
-    this->petalZRotation = this->innerPetalZRotation + this->settleZRotation;
+    BgNumaHana_UpdateSettleRotation(&this->settleRotZ, &this->settleAngle, &this->settleScale, 20.0f);
+    this->petalRotZ = this->innerPetalRotZ + this->settleRotZ;
     BgNumaHana_UpdatePetalPosRots(this);
 }
 
@@ -270,13 +270,13 @@ void BgNumaHana_SetupUnfoldOuterPetals(BgNumaHana* this) {
  * parts of the petals that are furthest to the stalk.
  */
 void BgNumaHana_UnfoldOuterPetals(BgNumaHana* this, PlayState* play) {
-    Math_StepToS(&this->outerPetalZRotationalVelocity, 240, 14);
-    if (Math_ScaledStepToS(&this->outerPetalZRotation, -0x4000, this->outerPetalZRotationalVelocity)) {
+    Math_StepToS(&this->outerPetalAngularVelocityZ, 240, 14);
+    if (Math_ScaledStepToS(&this->outerPetalRotZ, -0x4000, this->outerPetalAngularVelocityZ)) {
         if (this->transitionTimer >= 11) {
             BgNumaHana_SetupRaiseFlower(this);
         } else {
             if (this->transitionTimer <= 0) {
-                this->settleZRotation = 0;
+                this->settleRotZ = 0;
                 this->settleAngle = 0x5120;
                 this->settleScale = 130.0f;
                 Actor_PlaySfx(&this->dyna.actor, NA_SE_EV_FLOWERPETAL_STOP);
@@ -287,8 +287,8 @@ void BgNumaHana_UnfoldOuterPetals(BgNumaHana* this, PlayState* play) {
         Actor_PlaySfx_Flagged(&this->dyna.actor, NA_SE_EV_FLOWERPETAL_MOVE - SFX_FLAG);
     }
 
-    BgNumaHana_UpdateSettleRotation(&this->settleZRotation, &this->settleAngle, &this->settleScale, 7.0f);
-    this->petalZRotation = this->innerPetalZRotation + this->settleZRotation;
+    BgNumaHana_UpdateSettleRotation(&this->settleRotZ, &this->settleAngle, &this->settleScale, 7.0f);
+    this->petalRotZ = this->innerPetalRotZ + this->settleRotZ;
     BgNumaHana_UpdatePetalPosRots(this);
 }
 
@@ -303,10 +303,10 @@ void BgNumaHana_RaiseFlower(BgNumaHana* this, PlayState* play) {
     s32 pad;
     DynaPolyActor* child;
 
-    BgNumaHana_UpdateSettleRotation(&this->settleZRotation, &this->settleAngle, &this->settleScale, 10.0f);
-    this->petalZRotation = this->innerPetalZRotation + this->settleZRotation;
-    Math_StepToS(&this->flowerRotationalVelocity, 0x111, 0xA);
-    this->dyna.actor.shape.rot.y += this->flowerRotationalVelocity;
+    BgNumaHana_UpdateSettleRotation(&this->settleRotZ, &this->settleAngle, &this->settleScale, 10.0f);
+    this->petalRotZ = this->innerPetalRotZ + this->settleRotZ;
+    Math_StepToS(&this->flowerAngularVelocity, 0x111, 0xA);
+    this->dyna.actor.shape.rot.y += this->flowerAngularVelocity;
     Math_StepToF(&this->dyna.actor.velocity.y, 3.0f, 0.3f);
 
     if (Math_StepToF(&this->dyna.actor.world.pos.y, this->dyna.actor.home.pos.y + 210.0f,
@@ -317,14 +317,14 @@ void BgNumaHana_RaiseFlower(BgNumaHana* this, PlayState* play) {
         DynaPoly_EnableCollision(play, &play->colCtx.dyna, child->bgId);
         DynaPoly_DisableCollision(play, &play->colCtx.dyna, this->dyna.bgId);
 
-        this->petalZRotation = 0x2000;
-        this->innerPetalZRotation = 0x2000;
-        this->innerPetalZRotationalVelocity = 0;
-        this->settleZRotation = 0;
+        this->petalRotZ = 0x2000;
+        this->innerPetalRotZ = 0x2000;
+        this->innerPetalAngularVelocityZ = 0;
+        this->settleRotZ = 0;
         this->settleAngle = 0;
-        this->outerPetalZRotation = -0x4000;
-        this->outerPetalZRotationalVelocity = 0;
-        this->flowerRotationalVelocity = 0x147;
+        this->outerPetalRotZ = -0x4000;
+        this->outerPetalAngularVelocityZ = 0;
+        this->flowerAngularVelocity = 0x147;
         this->settleScale = 0.0f;
 
         CutsceneManager_Stop(this->dyna.actor.csId);
@@ -343,8 +343,8 @@ void BgNumaHana_SetupOpenedIdle(BgNumaHana* this) {
  * Spins the "opened" flower around the y-axis.
  */
 void BgNumaHana_OpenedIdle(BgNumaHana* this, PlayState* play) {
-    this->dyna.actor.shape.rot.y += this->flowerRotationalVelocity;
-    this->petalZRotation = this->innerPetalZRotation + this->settleZRotation;
+    this->dyna.actor.shape.rot.y += this->flowerAngularVelocity;
+    this->petalRotZ = this->innerPetalRotZ + this->settleRotZ;
     BgNumaHana_UpdatePetalPosRots(this);
     Actor_PlaySfx_Flagged(&this->dyna.actor, NA_SE_EV_FLOWER_ROLLING - SFX_FLAG);
 }

--- a/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.h
+++ b/src/overlays/actors/ovl_Bg_Numa_Hana/z_bg_numa_hana.h
@@ -29,15 +29,15 @@ typedef struct BgNumaHana {
     /* 0x234 */ BgNumaHanaActionFunc actionFunc;
     /* 0x238 */ WoodenFlowerPetalPosRot innerPetalPosRot[6];
     /* 0x2B0 */ WoodenFlowerPetalPosRot outerPetalPosRot[6];
-    /* 0x328 */ s16 petalZRotation;
-    /* 0x32A */ s16 innerPetalZRotation;
-    /* 0x32C */ s16 innerPetalZRotationalVelocity;
-    /* 0x32E */ s16 settleZRotation;
+    /* 0x328 */ s16 petalRotZ;
+    /* 0x32A */ s16 innerPetalRotZ;
+    /* 0x32C */ s16 innerPetalAngularVelocityZ;
+    /* 0x32E */ s16 settleRotZ;
     /* 0x330 */ s16 settleAngle;
     /* 0x334 */ f32 settleScale;
-    /* 0x338 */ s16 outerPetalZRotation;
-    /* 0x33A */ s16 outerPetalZRotationalVelocity;
-    /* 0x33C */ s16 flowerRotationalVelocity;
+    /* 0x338 */ s16 outerPetalRotZ;
+    /* 0x33A */ s16 outerPetalAngularVelocityZ;
+    /* 0x33C */ s16 flowerAngularVelocity;
     /* 0x33E */ s16 transitionTimer;
 } BgNumaHana; // size = 0x340
 

--- a/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.c
+++ b/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.c
@@ -473,12 +473,12 @@ void EnGrasshopper_Fly(EnGrasshopper* this, PlayState* play) {
             this->targetRot.z = (this->actor.world.rot.y - this->targetRot.y) * 0.2f;
             targetSpeed = (this->index * 0.1f) + 4.0f;
             Math_ApproachF(&this->actor.speed, targetSpeed, 0.4f, 0.7f);
-            Math_ApproachF(&this->rotationalVelocity, 2000.0f, 1.0f, 50.0f);
-            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRot.y, 5, this->rotationalVelocity, 5);
+            Math_ApproachF(&this->angularVelocity, 2000.0f, 1.0f, 50.0f);
+            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRot.y, 5, this->angularVelocity, 5);
             if (this->timer == 0) {
                 if (Rand_ZeroFloat(1.0f) < 0.3f) {
                     this->waitTimer = Rand_S16Offset(10, 10);
-                    this->rotationalVelocity = 0.0f;
+                    this->angularVelocity = 0.0f;
                 }
 
                 this->targetRot.y = Math_Atan2S(diffX, diffZ);
@@ -606,7 +606,7 @@ void EnGrasshopper_Bounced(EnGrasshopper* this, PlayState* play) {
     Math_ApproachF(&this->actor.speed, targetSpeed, 0.4f, 0.8f);
     Math_SmoothStepToS(&this->actor.world.rot.z, this->targetRot.z, 5, 0x3E8, 5);
     this->targetRot.z *= 0.8f;
-    Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRot.y, 5, this->rotationalVelocity, 5);
+    Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRot.y, 5, this->angularVelocity, 5);
     if (this->timer == 0) {
         this->collider.elements[0].info.toucherFlags |= (TOUCH_ON | TOUCH_SFX_WOOD);
         this->timer = 0;

--- a/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.h
+++ b/src/overlays/actors/ovl_En_Grasshopper/z_en_grasshopper.h
@@ -90,7 +90,7 @@ typedef struct EnGrasshopper {
     /* 0x035C */ s16 bankState;
     /* 0x035E */ s16 type;
     /* 0x0360 */ f32 dragonflyScale;
-    /* 0x0364 */ f32 rotationalVelocity;
+    /* 0x0364 */ f32 angularVelocity;
     /* 0x0368 */ f32 endFrame;
     /* 0x036C */ f32 approachSpeed;
     /* 0x0370 */ f32 baseFlyHeight;

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.c
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.c
@@ -556,14 +556,14 @@ void EnPp_Idle(EnPp* this, PlayState* play) {
                 EnPp_ChangeAnim(this, EN_PP_ANIM_WALK);
             }
 
-            if ((this->maskBounceRotationalVelocity < 0x64) &&
+            if ((this->maskBounceAngularVelocity < 0x64) &&
                 (fabsf(this->actor.world.rot.y - this->targetRotY) < 100.0f)) {
                 Math_ApproachF(&this->actor.speed, 1.0f, 0.3f, 1.0f);
             }
 
-            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1,
-                               (this->maskBounceRotationalVelocity + 0x258), 0);
-            Math_SmoothStepToS(&this->maskBounceRotationalVelocity, 0, 1, 0x1F4, 0);
+            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, (this->maskBounceAngularVelocity + 0x258),
+                               0);
+            Math_SmoothStepToS(&this->maskBounceAngularVelocity, 0, 1, 0x1F4, 0);
         }
     }
 }
@@ -602,11 +602,10 @@ void EnPp_Charge(EnPp* this, PlayState* play) {
             this->targetPos.z += distanceFromWorldPos.z;
         }
 
-        Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, (this->maskBounceRotationalVelocity + 0x7D0),
-                           0);
+        Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, (this->maskBounceAngularVelocity + 0x7D0), 0);
     }
 
-    Math_SmoothStepToS(&this->maskBounceRotationalVelocity, 0, 1, 0x1F4, 0);
+    Math_SmoothStepToS(&this->maskBounceAngularVelocity, 0, 1, 0x1F4, 0);
     if (!this->actionVar.isCharging) {
         Math_ApproachZeroF(&this->actor.speed, 0.5f, 1.0f);
         if (fabsf(this->actor.world.rot.y - this->targetRotY) < 100.0f) {
@@ -985,7 +984,7 @@ void EnPp_SetupDead(EnPp* this, PlayState* play) {
         this->targetPos.z += deadVelocity.z;
     }
 
-    this->maskBounceRotationalVelocity = this->actionVar.isCharging = 0;
+    this->maskBounceAngularVelocity = this->actionVar.isCharging = 0;
     EnPp_ChangeAnim(this, EN_PP_ANIM_DAMAGE);
     this->timer = 15;
     if (((this->drawDmgEffType == ACTOR_DRAW_DMGEFF_FROZEN_SFX) ||
@@ -1165,8 +1164,8 @@ void EnPp_BodyPart_SetupMove(EnPp* this) {
     this->actor.velocity.y = Rand_ZeroFloat(5.0f) + 13.0f;
     this->actor.gravity = -2.0f;
     this->timer = Rand_S16Offset(30, 30);
-    this->deadBodyPartRotationalVelocity.x = (this->deadBodyPartIndex * 0x2E) + 0xFF00;
-    this->deadBodyPartRotationalVelocity.z = (this->deadBodyPartIndex * 0x2E) + 0xFF00;
+    this->deadBodyPartAngularVelocity.x = (this->deadBodyPartIndex * 0x2E) + 0xFF00;
+    this->deadBodyPartAngularVelocity.z = (this->deadBodyPartIndex * 0x2E) + 0xFF00;
     if (EN_PP_GET_TYPE(&this->actor) != EN_PP_TYPE_BODY_PART_BODY) {
         this->actor.speed = Rand_ZeroFloat(4.0f) + 4.0f;
         this->actor.world.rot.y = ((s32)Rand_CenteredFloat(223.0f) + 0x1999) * this->deadBodyPartIndex;
@@ -1198,8 +1197,8 @@ void EnPp_BodyPart_Move(EnPp* this, PlayState* play) {
     } else {
         Math_Vec3f_Copy(&this->deadBodyPartsPos[0], &this->deadBodyPartPos);
         this->deadBodyPartCount = 1;
-        this->actor.shape.rot.x += this->deadBodyPartRotationalVelocity.x;
-        this->actor.shape.rot.z += this->deadBodyPartRotationalVelocity.z;
+        this->actor.shape.rot.x += this->deadBodyPartAngularVelocity.x;
+        this->actor.shape.rot.z += this->deadBodyPartAngularVelocity.z;
     }
 
     if (WaterBox_GetSurface1(play, &play->colCtx, this->actor.world.pos.x, this->actor.world.pos.z, &waterSurface,
@@ -1348,12 +1347,12 @@ void EnPp_UpdateDamage(EnPp* this, PlayState* play) {
                                  (this->action == EN_PP_ACTION_ROAR))) {
         this->secondaryTimer = 0;
         this->timer = 10;
-        this->maskBounceRotationalVelocity = 0x20D0;
+        this->maskBounceAngularVelocity = 0x20D0;
         this->actor.speed = 0.0f;
         if (this->action == EN_PP_ACTION_CHARGE) {
             this->actionVar.isCharging = false;
             EnPp_ChangeAnim(this, EN_PP_ANIM_TURN_TO_FACE_PLAYER);
-            this->maskBounceRotationalVelocity = 0x1B58;
+            this->maskBounceAngularVelocity = 0x1B58;
         }
 
         this->targetRotY = this->actor.yawTowardsPlayer;

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.c
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.c
@@ -561,7 +561,7 @@ void EnPp_Idle(EnPp* this, PlayState* play) {
                 Math_ApproachF(&this->actor.speed, 1.0f, 0.3f, 1.0f);
             }
 
-            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, (this->maskBounceAngularVelocity + 0x258),
+            Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, this->maskBounceAngularVelocity + 0x258,
                                0);
             Math_SmoothStepToS(&this->maskBounceAngularVelocity, 0, 1, 0x1F4, 0);
         }
@@ -602,7 +602,7 @@ void EnPp_Charge(EnPp* this, PlayState* play) {
             this->targetPos.z += distanceFromWorldPos.z;
         }
 
-        Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, (this->maskBounceAngularVelocity + 0x7D0), 0);
+        Math_SmoothStepToS(&this->actor.world.rot.y, this->targetRotY, 1, this->maskBounceAngularVelocity + 0x7D0, 0);
     }
 
     Math_SmoothStepToS(&this->maskBounceAngularVelocity, 0, 1, 0x1F4, 0);

--- a/src/overlays/actors/ovl_En_Pp/z_en_pp.h
+++ b/src/overlays/actors/ovl_En_Pp/z_en_pp.h
@@ -73,7 +73,7 @@ typedef struct EnPp {
                     s16 hasLandedFromJump;
                     s16 maskDetachState;
                 } actionVar;
-    /* 0x2D4 */ s16 maskBounceRotationalVelocity; // Controls the speed that the Hiploop rotates to face the player when an attack bounces off the mask.
+    /* 0x2D4 */ s16 maskBounceAngularVelocity; // Controls the speed that the Hiploop rotates to face the player when an attack bounces off the mask.
     /* 0x2D6 */ s16 deadBodyPartsSpawnedCount;
     /* 0x2D8 */ f32 endFrame;
     /* 0x2DC */ f32 chargeAndBounceSpeed;
@@ -88,7 +88,7 @@ typedef struct EnPp {
     /* 0x364 */ Vec3f deadBodyPartPos;
     /* 0x370 */ s32 deadBodyPartCount;
     /* 0x374 */ Vec3f deadBodyPartsPos[EN_PP_DEAD_BODYPART_MAX];
-    /* 0x3EC */ Vec3s deadBodyPartRotationalVelocity;
+    /* 0x3EC */ Vec3s deadBodyPartAngularVelocity;
     /* 0x3F2 */ s16 drawDmgEffTimer;
     /* 0x3F4 */ s16 drawDmgEffType;
     /* 0x3F8 */ f32 drawDmgEffScale;

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -523,7 +523,7 @@ void EnRd_SetupPirouette(EnRd* this) {
     Animation_MorphToLoop(&this->skelAnime, &gGibdoRedeadPirouetteAnim, -6.0f);
     this->action = EN_RD_ACTION_PIROUETTE;
     this->animationJudderTimer = (Rand_ZeroOne() * 10.0f) + 5.0f;
-    this->pirouetteRotationalVelocity = 0x1112;
+    this->pirouetteAngularVelocity = 0x1112;
     this->actor.speed = 0.0f;
     this->actor.world.rot.y = this->actor.shape.rot.y;
     this->actionFunc = EnRd_Pirouette;
@@ -562,12 +562,12 @@ void EnRd_Pirouette(EnRd* this, PlayState* play) {
     }
 
     if (Animation_OnFrame(&this->skelAnime, this->skelAnime.endFrame)) {
-        this->pirouetteRotationalVelocity = 0x1112;
+        this->pirouetteAngularVelocity = 0x1112;
     } else if (Animation_OnFrame(&this->skelAnime, 15.0f)) {
-        this->pirouetteRotationalVelocity = 0x199A;
+        this->pirouetteAngularVelocity = 0x199A;
     }
 
-    this->actor.world.rot.y -= this->pirouetteRotationalVelocity;
+    this->actor.world.rot.y -= this->pirouetteAngularVelocity;
     this->actor.shape.rot.y = this->actor.world.rot.y;
 }
 
@@ -577,13 +577,13 @@ void EnRd_EndPirouetteWhenPlayerIsClose(EnRd* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_REDEAD_CRY);
     }
 
-    this->actor.world.rot.y -= this->pirouetteRotationalVelocity;
+    this->actor.world.rot.y -= this->pirouetteAngularVelocity;
     this->actor.shape.rot.y = this->actor.world.rot.y;
 
-    this->pirouetteRotationalVelocity -= 0x64;
-    if ((this->pirouetteRotationalVelocity < 0x834) && (this->pirouetteRotationalVelocity >= 0x7D0)) {
+    this->pirouetteAngularVelocity -= 0x64;
+    if ((this->pirouetteAngularVelocity < 0x834) && (this->pirouetteAngularVelocity >= 0x7D0)) {
         Animation_Change(&this->skelAnime, &gGibdoRedeadLookBackAnim, 0.0f, 0.0f, 19.0f, ANIMMODE_ONCE, -10.0f);
-    } else if (this->pirouetteRotationalVelocity < 0x3E8) {
+    } else if (this->pirouetteAngularVelocity < 0x3E8) {
         if ((EN_RD_GET_TYPE(&this->actor) != EN_RD_TYPE_CRYING) && (!this->isMourning)) {
             EnRd_SetupAttemptPlayerFreeze(this);
         } else {

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.h
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.h
@@ -76,7 +76,7 @@ typedef struct EnRd {
     /* 0x3E2 */ UNK_TYPE1 unk3E2[0x2];
     /* 0x3E4 */ union {
                     s16 danceEndTimer;
-                    s16 pirouetteRotationalVelocity;
+                    s16 pirouetteAngularVelocity;
                 };
     /* 0x3E6 */ s16 drawDmgEffTimer;
     /* 0x3E8 */ u8 drawDmgEffType;

--- a/src/overlays/actors/ovl_En_Snowman/z_en_snowman.c
+++ b/src/overlays/actors/ovl_En_Snowman/z_en_snowman.c
@@ -692,11 +692,11 @@ void EnSnowman_SetupDamaged(EnSnowman* this) {
  * Otherwise, it will either submerge underground (if it has health remaining) or die.
  */
 void EnSnowman_Damaged(EnSnowman* this, PlayState* play) {
-    s32 rotationalVelocityScale;
+    s32 angularVelocityScale;
 
     SkelAnime_Update(&this->skelAnime);
-    rotationalVelocityScale = CLAMP_MAX(this->work.timer, 10);
-    this->actor.shape.rot.y += rotationalVelocityScale * 0x300;
+    angularVelocityScale = CLAMP_MAX(this->work.timer, 10);
+    this->actor.shape.rot.y += angularVelocityScale * 0x300;
     Math_StepToF(&this->actor.speed, 0.0f, 0.5f);
 
     if (EN_SNOWMAN_GET_TYPE(&this->actor) == EN_SNOWMAN_TYPE_LARGE) {

--- a/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.c
+++ b/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.c
@@ -224,10 +224,10 @@ void EnTanron5_Init(Actor* thisx, PlayState* play) {
             return;
         }
 
-        // fragmentRotationalVelocityX is in a union with itemDropRotZ, so for item drops, this code
+        // fragmentAngularVelocityX is in a union with itemDropRotZ, so for item drops, this code
         // will initialize its z-rotation to a random value.
-        this->fragmentRotationalVelocityX = Rand_CenteredFloat(0x2000);
-        this->fragmentRotationalVelocityY = Rand_CenteredFloat(0x2000);
+        this->fragmentAngularVelocityX = Rand_CenteredFloat(0x2000);
+        this->fragmentAngularVelocityY = Rand_CenteredFloat(0x2000);
 
         if (TWINMOLD_PROP_GET_TYPE(&this->actor) <= TWINMOLD_PROP_TYPE_FRAGMENT_LARGE_7) {
             Actor_SetScale(&this->actor, (Rand_ZeroFloat(0.025f) + 0.085f) * sGiantModeScaleFactor);
@@ -538,8 +538,8 @@ void EnTanron5_RuinFragmentItemDrop_Update(Actor* thisx, PlayState* play2) {
     }
 
     if (TWINMOLD_PROP_GET_TYPE(&this->actor) < TWINMOLD_PROP_TYPE_ITEM_DROP_1) {
-        this->actor.shape.rot.x += this->fragmentRotationalVelocityX;
-        this->actor.shape.rot.y += this->fragmentRotationalVelocityY;
+        this->actor.shape.rot.x += this->fragmentAngularVelocityX;
+        this->actor.shape.rot.y += this->fragmentAngularVelocityY;
         interactionDistSq = SQ(35.0f);
 
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {

--- a/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.h
+++ b/src/overlays/actors/ovl_En_Tanron5/z_en_tanron5.h
@@ -50,10 +50,10 @@ typedef struct EnTanron5 {
     /* 0x148 */ Gfx* dList;
     /* 0x14C */ ColliderCylinder collider;
     /* 0x198 */ union {
-                    s16 fragmentRotationalVelocityX;
+                    s16 fragmentAngularVelocityX;
                     s16 itemDropRotZ;
                 };
-    /* 0x19A */ s16 fragmentRotationalVelocityY;
+    /* 0x19A */ s16 fragmentAngularVelocityY;
     /* 0x19C */ f32 baseScale;
     /* 0x1A0 */ union {
                     u8 hitCount;     // used by destructible ruins

--- a/src/overlays/actors/ovl_En_Wiz/z_en_wiz.c
+++ b/src/overlays/actors/ovl_En_Wiz/z_en_wiz.c
@@ -498,7 +498,7 @@ void EnWiz_HandleIntroCutscene(EnWiz* this, PlayState* play) {
             case EN_WIZ_INTRO_CS_WAIT_BEFORE_RUN:
                 if (this->introCutsceneTimer == 0) {
                     EnWiz_ChangeAnim(this, EN_WIZ_ANIM_RUN, false);
-                    this->rotationalVelocity = 0;
+                    this->angularVelocity = 0;
                     this->introCutsceneTimer = 34;
                     this->introCutsceneState++;
                 }
@@ -510,8 +510,8 @@ void EnWiz_HandleIntroCutscene(EnWiz* this, PlayState* play) {
                     this->animLoopCounter = this->introCutsceneCameraAngle = 0;
                     this->introCutsceneState = EN_WIZ_INTRO_CS_DISAPPEAR;
                 } else {
-                    Math_SmoothStepToS(&this->rotationalVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
-                    this->actor.world.rot.y += this->rotationalVelocity;
+                    Math_SmoothStepToS(&this->angularVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
+                    this->actor.world.rot.y += this->angularVelocity;
                 }
 
                 Math_Vec3f_Copy(&eyeNext, &this->actor.world.pos);
@@ -784,7 +784,7 @@ void EnWiz_Appear(EnWiz* this, PlayState* play) {
 void EnWiz_SetupDance(EnWiz* this) {
     EnWiz_ChangeAnim(this, EN_WIZ_ANIM_DANCE, false);
     Math_ApproachF(&this->scale, 0.015f, 0.05f, 0.001f);
-    this->rotationalVelocity = 0;
+    this->angularVelocity = 0;
     this->animLoopCounter = 0;
     this->action = EN_WIZ_ACTION_DANCE;
     if (this->fightState >= EN_WIZ_FIGHT_STATE_SECOND_PHASE_GHOSTS_COPY_WIZROBE) {
@@ -808,16 +808,16 @@ void EnWiz_Dance(EnWiz* this, PlayState* play) {
     Math_SmoothStepToS(&this->alpha, 255, 1, 5, 0);
     Math_ApproachF(&this->scale, 0.015f, 0.05f, 0.001f);
     Actor_PlaySfx(&this->actor, NA_SE_EN_WIZ_RUN - SFX_FLAG);
-    this->actor.world.rot.y += this->rotationalVelocity;
+    this->actor.world.rot.y += this->angularVelocity;
     if (this->fightState >= EN_WIZ_FIGHT_STATE_SECOND_PHASE_GHOSTS_RUN_AROUND) {
         EnWiz_MoveGhosts(this);
     } else {
         for (i = 0; i < this->platformCount; i++) {
-            this->ghostRot[i].y += this->rotationalVelocity;
+            this->ghostRot[i].y += this->angularVelocity;
         }
     }
 
-    Math_SmoothStepToS(&this->rotationalVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
+    Math_SmoothStepToS(&this->angularVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
     Math_SmoothStepToS(&this->platformLightAlpha, this->targetPlatformLightAlpha, 20, 50, 10);
     if (this->endFrame <= curFrame) {
         if (this->animLoopCounter < 10) {
@@ -997,20 +997,20 @@ void EnWiz_Attack(EnWiz* this, PlayState* play) {
 
 void EnWiz_SetupDisappear(EnWiz* this) {
     if (this->action != EN_WIZ_ACTION_DAMAGED) {
-        this->rotationalVelocity = 0x2710;
+        this->angularVelocity = 0x2710;
         this->timer = 0;
         EnWiz_ChangeAnim(this, EN_WIZ_ANIM_IDLE, false);
         this->action = EN_WIZ_ACTION_DISAPPEAR;
     } else {
-        this->rotationalVelocity = 0x2710;
-        this->actor.world.rot.y += this->rotationalVelocity;
+        this->angularVelocity = 0x2710;
+        this->actor.world.rot.y += this->angularVelocity;
     }
 
     this->targetPlatformLightAlpha = 0;
     this->actor.flags |= ACTOR_FLAG_CANT_LOCK_ON;
     Actor_PlaySfx(&this->actor, NA_SE_EN_WIZ_DISAPPEAR);
-    Math_SmoothStepToS(&this->rotationalVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
-    this->actor.world.rot.y += this->rotationalVelocity;
+    Math_SmoothStepToS(&this->angularVelocity, 0x1388, 0x64, 0x3E8, 0x3E8);
+    this->actor.world.rot.y += this->angularVelocity;
     this->actor.flags &= ~ACTOR_FLAG_TARGETABLE;
     this->actionFunc = EnWiz_Disappear;
 }
@@ -1022,8 +1022,8 @@ void EnWiz_SetupDisappear(EnWiz* this) {
 void EnWiz_Disappear(EnWiz* this, PlayState* play) {
     s32 i;
 
-    Math_SmoothStepToS(&this->rotationalVelocity, 0, 0xA, 0xBB8, 0x14);
-    this->actor.world.rot.y += this->rotationalVelocity;
+    Math_SmoothStepToS(&this->angularVelocity, 0, 0xA, 0xBB8, 0x14);
+    this->actor.world.rot.y += this->angularVelocity;
     if ((this->fightState == EN_WIZ_FIGHT_STATE_FIRST_PHASE) || (this->action == EN_WIZ_ACTION_DAMAGED)) {
         Math_ApproachZeroF(&this->scale, 0.3f, 0.01f);
         Math_SmoothStepToS(&this->platformLightAlpha, this->targetPlatformLightAlpha, 5, 50, 0);
@@ -1031,7 +1031,7 @@ void EnWiz_Disappear(EnWiz* this, PlayState* play) {
         Math_ApproachZeroF(&this->scale, 0.3f, 0.001f);
         Math_SmoothStepToS(&this->platformLightAlpha, this->targetPlatformLightAlpha, 10, 50, 0);
         for (i = 0; i < this->platformCount; i++) {
-            this->ghostRot[i].y += this->rotationalVelocity;
+            this->ghostRot[i].y += this->angularVelocity;
         }
     }
 
@@ -1079,9 +1079,9 @@ void EnWiz_SetupDamaged(EnWiz* this, PlayState* play) {
         this->timer = 0;
     }
 
-    this->rotationalVelocity = 0x4E20;
+    this->angularVelocity = 0x4E20;
     if ((this->drawDmgEffTimer != 0) && (this->drawDmgEffType == ACTOR_DRAW_DMGEFF_FROZEN_SFX)) {
-        this->rotationalVelocity = 0;
+        this->angularVelocity = 0;
         this->timer = 0;
     }
 
@@ -1100,7 +1100,7 @@ void EnWiz_Damaged(EnWiz* this, PlayState* play) {
         Actor_SpawnIceEffects(play, &this->actor, this->bodyPartsPos, EN_WIZ_BODYPART_MAX, 2, 1.0f, 0.7f);
         this->drawDmgEffTimer = 0;
         this->drawDmgEffType = ACTOR_DRAW_DMGEFF_FIRE;
-        this->rotationalVelocity = 0x4E20;
+        this->angularVelocity = 0x4E20;
         this->actor.velocity.y = 30.0f;
         this->actor.gravity = -3.0f;
     }
@@ -1118,10 +1118,10 @@ void EnWiz_Damaged(EnWiz* this, PlayState* play) {
         this->isDead = true;
     }
 
-    this->actor.world.rot.y += this->rotationalVelocity;
-    Math_SmoothStepToS(&this->rotationalVelocity, 0, 0xA, 0xBB8, 0x14);
+    this->actor.world.rot.y += this->angularVelocity;
+    Math_SmoothStepToS(&this->angularVelocity, 0, 0xA, 0xBB8, 0x14);
     for (i = 0; i < this->platformCount; i++) {
-        this->ghostRot[i].y += this->rotationalVelocity;
+        this->ghostRot[i].y += this->angularVelocity;
     }
 
     //! @bug: When the Wizrobe is defeated, it is launched into the air by the code above, and the
@@ -1173,7 +1173,7 @@ void EnWiz_Damaged(EnWiz* this, PlayState* play) {
 
 void EnWiz_SetupDead(EnWiz* this) {
     EnWiz_ChangeAnim(this, EN_WIZ_ANIM_DAMAGE, false);
-    this->rotationalVelocity = 0x2710;
+    this->angularVelocity = 0x2710;
     this->action = EN_WIZ_ACTION_DEAD;
     this->timer = 0;
     this->actionFunc = EnWiz_Dead;
@@ -1186,9 +1186,9 @@ void EnWiz_SetupDead(EnWiz* this) {
 void EnWiz_Dead(EnWiz* this, PlayState* play) {
     s32 i;
 
-    this->actor.world.rot.y += this->rotationalVelocity;
-    Math_SmoothStepToS(&this->rotationalVelocity, 0, 0xA, 0xBB8, 0x14);
-    if (this->rotationalVelocity < 0x1E) {
+    this->actor.world.rot.y += this->angularVelocity;
+    Math_SmoothStepToS(&this->angularVelocity, 0, 0xA, 0xBB8, 0x14);
+    if (this->angularVelocity < 0x1E) {
         Math_SmoothStepToS(&this->alpha, 0, 10, 30, 20);
         for (i = 0; i < this->platformCount; i++) {
             Math_SmoothStepToS(&this->ghostAlpha[i], 0, 10, 30, 20);

--- a/src/overlays/actors/ovl_En_Wiz/z_en_wiz.h
+++ b/src/overlays/actors/ovl_En_Wiz/z_en_wiz.h
@@ -50,7 +50,7 @@ typedef struct EnWiz {
     /* 0x3BA */ s16 hasActiveProjectile;
     /* 0x3BC */ s16 hasRunToEveryPlatform; // used for the second phase cutscene to make sure the Wizrobe visits every platform
     /* 0x3BE */ s16 unk_3BE; // unused, inferred from surrounding members
-    /* 0x3C0 */ s16 rotationalVelocity;
+    /* 0x3C0 */ s16 angularVelocity;
     /* 0x3C2 */ s16 alpha;
     /* 0x3C4 */ s16 platformLightAlpha;
     /* 0x3C6 */ s16 targetPlatformLightAlpha;

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
@@ -99,7 +99,7 @@ void ObjTokeidai_SetupClockOrExteriorGear(ObjTokeidai* this) {
 
     this->clockMinute = currentClockMinute;
     this->minuteRingOrExteriorGearRotation = GET_MINUTE_RING_OR_EXTERIOR_GEAR_ROTATION(currentClockMinute);
-    this->minuteRingOrExteriorGearRotationalVelocity = 0x3C;
+    this->minuteRingOrExteriorGearAngularVelocity = 0x3C;
     this->minuteRingOrExteriorGearRotationTimer = 0;
 }
 
@@ -110,9 +110,9 @@ void ObjTokeidai_Clock_Init(ObjTokeidai* this) {
     currentClockHour = GET_CURRENT_CLOCK_HOUR(this);
     this->clockHour = currentClockHour;
     this->clockFaceRotation = GET_CLOCK_FACE_ROTATION(currentClockHour);
-    this->clockFaceRotationalVelocity = 0;
+    this->clockFaceAngularVelocity = 0;
     this->clockFaceRotationTimer = 0;
-    this->sunMoonPanelRotationalVelocity = 0;
+    this->sunMoonPanelAngularVelocity = 0;
     this->sunMoonPanelRotation = ObjTokeidai_GetTargetSunMoonPanelRotation();
 }
 
@@ -294,8 +294,8 @@ void ObjTokeidai_RotateOnMinuteChange(ObjTokeidai* this, s32 playSfx) {
         if (this->minuteRingOrExteriorGearRotationTimer > 8) {
             // This actually performs the rotation to the next minute
             // for the minute ring or exterior gear.
-            this->minuteRingOrExteriorGearRotationalVelocity += 0x3C;
-            this->minuteRingOrExteriorGearRotation += this->minuteRingOrExteriorGearRotationalVelocity;
+            this->minuteRingOrExteriorGearAngularVelocity += 0x3C;
+            this->minuteRingOrExteriorGearRotation += this->minuteRingOrExteriorGearAngularVelocity;
         } else {
             // This makes the minute ring or exterior gear wiggle in place for a bit
             // before rotating to the next position.
@@ -314,7 +314,7 @@ void ObjTokeidai_RotateOnMinuteChange(ObjTokeidai* this, s32 playSfx) {
              this->minuteRingOrExteriorGearRotation > GET_MINUTE_RING_OR_EXTERIOR_GEAR_ROTATION(currentClockMinute))) {
             this->minuteRingOrExteriorGearRotation = GET_MINUTE_RING_OR_EXTERIOR_GEAR_ROTATION(currentClockMinute);
             this->clockMinute = currentClockMinute;
-            this->minuteRingOrExteriorGearRotationalVelocity = 0x5A;
+            this->minuteRingOrExteriorGearAngularVelocity = 0x5A;
             this->minuteRingOrExteriorGearRotationTimer = 0;
         }
     }
@@ -347,9 +347,9 @@ void ObjTokeidai_ExteriorGear_OpenedIdle(ObjTokeidai* this, PlayState* play) {
  * tower's clock slide off the tower and spin through the air when the moon crashes.
  */
 void ObjTokeidai_TowerClock_Fall(ObjTokeidai* this, PlayState* play) {
-    this->actor.shape.rot.x += this->fallingClockFaceRotationalVelocity;
-    if (this->fallingClockFaceRotationalVelocity > 0xA0) {
-        this->fallingClockFaceRotationalVelocity -= 5;
+    this->actor.shape.rot.x += this->fallingclockFaceAngularVelocity;
+    if (this->fallingclockFaceAngularVelocity > 0xA0) {
+        this->fallingclockFaceAngularVelocity -= 5;
     }
 
     this->actor.world.pos.z += 4.0f;
@@ -377,15 +377,15 @@ void ObjTokeidai_TowerClock_SlideOff(ObjTokeidai* this, PlayState* play) {
 
     if (this->aerialClockFaceSpeed < 0x80) {
         thisx->shape.rot.x = this->slidingClockFaceAngle - 0x4000;
-        this->fallingClockFaceRotationalVelocity = 0x28;
+        this->fallingclockFaceAngularVelocity = 0x28;
     } else {
         if (thisx->shape.rot.x < -0x1000) {
-            thisx->shape.rot.x += this->fallingClockFaceRotationalVelocity;
-            if (this->fallingClockFaceRotationalVelocity < 0x1E0) {
-                this->fallingClockFaceRotationalVelocity += 0xA;
+            thisx->shape.rot.x += this->fallingclockFaceAngularVelocity;
+            if (this->fallingclockFaceAngularVelocity < 0x1E0) {
+                this->fallingclockFaceAngularVelocity += 0xA;
             }
         } else {
-            thisx->shape.rot.x += this->fallingClockFaceRotationalVelocity;
+            thisx->shape.rot.x += this->fallingclockFaceAngularVelocity;
             this->actionFunc = ObjTokeidai_TowerClock_Fall;
             thisx->terminalVelocity = -7.5f;
             thisx->gravity = -0.75f;
@@ -496,9 +496,9 @@ void ObjTokeidai_TowerOpening_Wait(ObjTokeidai* this, PlayState* play) {
 }
 
 void ObjTokeidai_TowerOpening_DropCounterweight(ObjTokeidai* this, PlayState* play) {
-    this->xRotation += this->counterweightRotationalVelocity;
+    this->xRotation += this->counterweightAngularVelocity;
     if (this->xRotation < 0x4000) {
-        this->counterweightRotationalVelocity += this->counterweightRotationalAcceleration;
+        this->counterweightAngularVelocity += this->counterweightRotationalAcceleration;
         return;
     }
 
@@ -522,14 +522,14 @@ void ObjTokeidai_TowerOpening_DropCounterweight(ObjTokeidai* this, PlayState* pl
     }
     this->boundCount++;
 
-    if (this->counterweightRotationalVelocity > 0x190) {
+    if (this->counterweightAngularVelocity > 0x190) {
         // This condition is met for the first bound, causing the counterweight
         // to rebound upwards quickly.
-        this->counterweightRotationalVelocity = -0xC8;
-    } else if (this->counterweightRotationalVelocity > 0x32) {
+        this->counterweightAngularVelocity = -0xC8;
+    } else if (this->counterweightAngularVelocity > 0x32) {
         // This condition is met for the second bound, causing the counterweight
         // to rebound upwards slowly.
-        this->counterweightRotationalVelocity = -(this->counterweightRotationalVelocity >> 1);
+        this->counterweightAngularVelocity = -(this->counterweightAngularVelocity >> 1);
     } else {
         // This condition is met for the third bound, causing the counterweight
         // to stop moving.
@@ -561,7 +561,7 @@ void ObjTokeidai_TowerOpening_FinishRaise(ObjTokeidai* this, PlayState* play) {
         }
         this->yTranslation = 3400;
         this->actionFunc = ObjTokeidai_TowerOpening_DropCounterweight;
-        this->counterweightRotationalVelocity = 0;
+        this->counterweightAngularVelocity = 0;
         this->counterweightRotationalAcceleration = 0xA;
         this->boundCount = 0;
     }
@@ -604,7 +604,7 @@ void ObjTokeidai_TowerOpening_Start(ObjTokeidai* this, PlayState* play) {
  */
 void ObjTokeidai_SetupTowerOpening(ObjTokeidai* this) {
     this->actionFunc = ObjTokeidai_TowerOpening_Start;
-    this->clockFaceRotationalVelocity = 0;
+    this->clockFaceAngularVelocity = 0;
     this->clockFaceRotationTimer = 0;
     this->yTranslation = 0;
     this->xRotation = 0;
@@ -641,8 +641,8 @@ void ObjTokeidai_RotateOnHourChange(ObjTokeidai* this, PlayState* play) {
         if (this->clockFaceRotationTimer > 12) {
             // This actually performs the rotation to the next hour
             // for the clock face.
-            this->clockFaceRotationalVelocity += 0xA;
-            this->clockFaceRotation += this->clockFaceRotationalVelocity;
+            this->clockFaceAngularVelocity += 0xA;
+            this->clockFaceRotation += this->clockFaceAngularVelocity;
         } else {
             // This makes the clock face wiggle in place for a bit
             // before rotating to the next position.
@@ -660,7 +660,7 @@ void ObjTokeidai_RotateOnHourChange(ObjTokeidai* this, PlayState* play) {
             ((currentClockHour != 12) && (this->clockFaceRotation > GET_CLOCK_FACE_ROTATION(currentClockHour)))) {
             this->clockFaceRotation = GET_CLOCK_FACE_ROTATION(currentClockHour);
             this->clockHour = currentClockHour;
-            this->clockFaceRotationalVelocity = 0;
+            this->clockFaceAngularVelocity = 0;
             this->clockFaceRotationTimer = 0;
         }
     }
@@ -669,19 +669,19 @@ void ObjTokeidai_RotateOnHourChange(ObjTokeidai* this, PlayState* play) {
     // just changed), rotate it until it matches the target.
     if (this->sunMoonPanelRotation != ObjTokeidai_GetTargetSunMoonPanelRotation()) {
         if (this->clockHour == 6) {
-            this->sunMoonPanelRotationalVelocity += 0x222;
-            this->sunMoonPanelRotation += this->sunMoonPanelRotationalVelocity;
+            this->sunMoonPanelAngularVelocity += 0x222;
+            this->sunMoonPanelRotation += this->sunMoonPanelAngularVelocity;
             if (this->sunMoonPanelRotation > 0x10000) {
                 this->sunMoonPanelRotation = ObjTokeidai_GetTargetSunMoonPanelRotation();
-                this->sunMoonPanelRotationalVelocity = 0;
+                this->sunMoonPanelAngularVelocity = 0;
             }
         }
         if (this->clockHour == 18) {
-            this->sunMoonPanelRotationalVelocity += 0x222;
-            this->sunMoonPanelRotation += this->sunMoonPanelRotationalVelocity;
+            this->sunMoonPanelAngularVelocity += 0x222;
+            this->sunMoonPanelRotation += this->sunMoonPanelAngularVelocity;
             if (this->sunMoonPanelRotation > 0x8000) {
                 this->sunMoonPanelRotation = ObjTokeidai_GetTargetSunMoonPanelRotation();
-                this->sunMoonPanelRotationalVelocity = 0;
+                this->sunMoonPanelAngularVelocity = 0;
             }
         }
     }

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.c
@@ -347,9 +347,9 @@ void ObjTokeidai_ExteriorGear_OpenedIdle(ObjTokeidai* this, PlayState* play) {
  * tower's clock slide off the tower and spin through the air when the moon crashes.
  */
 void ObjTokeidai_TowerClock_Fall(ObjTokeidai* this, PlayState* play) {
-    this->actor.shape.rot.x += this->fallingclockFaceAngularVelocity;
-    if (this->fallingclockFaceAngularVelocity > 0xA0) {
-        this->fallingclockFaceAngularVelocity -= 5;
+    this->actor.shape.rot.x += this->fallingClockFaceAngularVelocity;
+    if (this->fallingClockFaceAngularVelocity > 0xA0) {
+        this->fallingClockFaceAngularVelocity -= 5;
     }
 
     this->actor.world.pos.z += 4.0f;
@@ -377,15 +377,15 @@ void ObjTokeidai_TowerClock_SlideOff(ObjTokeidai* this, PlayState* play) {
 
     if (this->aerialClockFaceSpeed < 0x80) {
         thisx->shape.rot.x = this->slidingClockFaceAngle - 0x4000;
-        this->fallingclockFaceAngularVelocity = 0x28;
+        this->fallingClockFaceAngularVelocity = 0x28;
     } else {
         if (thisx->shape.rot.x < -0x1000) {
-            thisx->shape.rot.x += this->fallingclockFaceAngularVelocity;
-            if (this->fallingclockFaceAngularVelocity < 0x1E0) {
-                this->fallingclockFaceAngularVelocity += 0xA;
+            thisx->shape.rot.x += this->fallingClockFaceAngularVelocity;
+            if (this->fallingClockFaceAngularVelocity < 0x1E0) {
+                this->fallingClockFaceAngularVelocity += 0xA;
             }
         } else {
-            thisx->shape.rot.x += this->fallingclockFaceAngularVelocity;
+            thisx->shape.rot.x += this->fallingClockFaceAngularVelocity;
             this->actionFunc = ObjTokeidai_TowerClock_Fall;
             thisx->terminalVelocity = -7.5f;
             thisx->gravity = -0.75f;

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
@@ -28,13 +28,13 @@ typedef struct ObjTokeidai {
     /* 0x144 */ Gfx* opaDList;
     /* 0x148 */ Gfx* xluDList;
     /* 0x14C */ s16 minuteRingOrExteriorGearRotation;
-    /* 0x14E */ s16 minuteRingOrExteriorGearRotationalVelocity;
+    /* 0x14E */ s16 minuteRingOrExteriorGearAngularVelocity;
     /* 0x150 */ s16 minuteRingOrExteriorGearRotationTimer;
     /* 0x152 */ s16 clockFaceRotation;
     /* 0x154 */ union {
-                    s16 clockFaceRotationalVelocity;
+                    s16 clockFaceAngularVelocity;
                     s16 settleTimer;
-                    s16 counterweightRotationalVelocity;
+                    s16 counterweightAngularVelocity;
                     s16 openingWaitTimer;
                     s16 slidingClockFaceAngle;
                 };
@@ -46,8 +46,8 @@ typedef struct ObjTokeidai {
                 };
     /* 0x158 */ s32 sunMoonPanelRotation;
     /* 0x15C */ union {
-                    s16 sunMoonPanelRotationalVelocity;
-                    s16 fallingClockFaceRotationalVelocity;
+                    s16 sunMoonPanelAngularVelocity;
+                    s16 fallingclockFaceAngularVelocity;
                 };
     /* 0x15E */ s16 yTranslation;
     /* 0x160 */ s16 xRotation;

--- a/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
+++ b/src/overlays/actors/ovl_Obj_Tokeidai/z_obj_tokeidai.h
@@ -47,7 +47,7 @@ typedef struct ObjTokeidai {
     /* 0x158 */ s32 sunMoonPanelRotation;
     /* 0x15C */ union {
                     s16 sunMoonPanelAngularVelocity;
-                    s16 fallingclockFaceAngularVelocity;
+                    s16 fallingClockFaceAngularVelocity;
                 };
     /* 0x15E */ s16 yTranslation;
     /* 0x160 */ s16 xRotation;


### PR DESCRIPTION
In #1319, someone noted that "angular velocity" is the correct term for what I was calling "rotational velocity". However, the whole codebase was using "rotational velocity", so I said I'd stick with it for that PR and then fix it once the PR got merged. I then proceeded to forget about that until just now.

Besides changing "rotational velocity" to "angular velocity", this PR also cleans up some rotation names in BgNumaHana, since they were a bit weird.