### PR TITLE
Removed ``TransformUpdateIndex`` in z_demo_tre_lgt.c

### DIFF
--- a/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
+++ b/src/overlays/actors/ovl_Demo_Tre_Lgt/z_demo_tre_lgt.c
@@ -47,7 +47,7 @@ ActorInit Demo_Tre_Lgt_InitVars = {
     (ActorFunc)DemoTreLgt_Draw,
 };
 
-static TransformUpdateIndex* sBoxLightAnimations[] = {
+static CurveAnimationHeader* sBoxLightAnimations[] = {
     &gBoxLightAdultCurveAnim,
     &gBoxLightChildCurveAnim,
 };


### PR DESCRIPTION
Noticed this while working on ZAPD, this array uses the old ``TransformUpdateIndex`` instead of ``CurveAnimationHeader``