### PR TITLE
Add original asset names to all `object_k*` files

### DIFF
--- a/assets/xml/objects/object_az.xml
+++ b/assets/xml/objects/object_az.xml
@@ -65,7 +65,7 @@
         <Animation Name="gBeaverLaughLeftAnim" Offset="0x7D3C" /> <!-- Original name is "bev_chukletoL" -->
         <Animation Name="gBeaverLaughRightAnim" Offset="0x86AC" /> <!-- Original name is "bev_chukletoR" -->
         <Animation Name="gBeaverSwimWithSpinningTail" Offset="0x8960" /> <!-- Original name is "bev_propellerswim" -->
-        <Animation Name="gBeaverSwimWithRaisedTail" Offset="0x8BB4" /> <!-- Original name is "bev_propellerswim2". Unused variation of gBeaverSwimWithSpinningTail where the tail just stays upright. -->
+        <Animation Name="gBeaverSwimWithRaisedTail" Offset="0x8BB4" /> <!-- Unused variation of gBeaverSwimWithSpinningTail where the tail just stays upright. Original name is "bev_propellerswim2" -->
         <Animation Name="gBeaverSwimAnim" Offset="0x8EAC" /> <!-- Original name is "bev_swim" -->
         <Animation Name="gBeaverTalkAnim" Offset="0x925C" /> <!-- Original name is "bev_talk1" -->
         <Animation Name="gBeaverTalkWaveArmsAnim" Offset="0x9B4C" /> <!-- Original name is "bev_talk2" -->

--- a/assets/xml/objects/object_boss03.xml
+++ b/assets/xml/objects/object_boss03.xml
@@ -5,7 +5,7 @@
         whip assets, along with an unused duplicate of the small fishes.
     -->
     <File Name="object_boss03" Segment="6">
-        <Animation Name="gGyorgIdleAnim" Offset="0x88" /> <!-- Original name is "bus_base". Maybe unused? -->
+        <Animation Name="gGyorgIdleAnim" Offset="0x88" /> <!-- Unused. Original name is "bus_base" -->
 
         <!-- Unused Majora's Wrath Whip Texture -->
         <Texture Name="gGyorgUnusedMajorasWrathWhipTex" OutName="unused_majoras_wrath_whip" Format="rgba16" Width="8" Height="16" Offset="0xA0" />
@@ -69,12 +69,12 @@
 
         <!-- Gyorg Animations -->
         <Animation Name="gGyorgFloppingAnim" Offset="0x9554" /> <!-- Original name is "bus_dead" -->
-        <Animation Name="gGyorgJumpingAnim" Offset="0x98F0" /> <!-- Original name is "bus_jump". Maybe unused? -->
+        <Animation Name="gGyorgJumpingAnim" Offset="0x98F0" /> <!-- Unused. Original name is "bus_jump" -->
         <Animation Name="gGyorgStunnedAnim" Offset="0x99D0" /> <!-- Original name is "bus_sibire" ("paralyzed") -->
         <Animation Name="gGyorgBackingUpAnim" Offset="0x9C14" /> <!-- Original name is "bus_stop" -->
         <Animation Name="gGyorgFastSwimmingAnim" Offset="0x9CF8" /> <!-- Original name is "bus_swim" -->
-        <Animation Name="gGyorgGentleSwimmingAnim" Offset="0xA020" /> <!-- Maybe unused? -->
-        <Animation Name="gGyorgTailSweepAnim" Offset="0xA134" /> <!-- Maybe unused? -->
+        <Animation Name="gGyorgGentleSwimmingAnim" Offset="0xA020" /> <!-- Unused -->
+        <Animation Name="gGyorgTailSweepAnim" Offset="0xA134" /> <!-- Unused -->
         <Animation Name="gGyorgCrawlingAnim" Offset="0xA6C8" />
 
         <!-- Seaweed DisplayLists -->

--- a/assets/xml/objects/object_boss07.xml
+++ b/assets/xml/objects/object_boss07.xml
@@ -10,7 +10,7 @@
         <Animation Name="gMajorasIncarnationPumpingUpAnim" Offset="0x31E4" /> <!-- Original name is "last2_hensin3" -->
         <Animation Name="gMajorasIncarnationFinalHitAnim" Offset="0x3854" /> <!-- Original name is "last2_hensin4" -->
         <Animation Name="gMajorasIncarnationSquattingDanceAnim" Offset="0x3A64" /> <!-- Original name is "last2_kd" (probably short for "kosakku (Cossack) dance") -->
-        <Animation Name="gMajorasIncarnationStationaryAnim" Offset="0x3B3C" /> <!-- Original name is "last2_kihon" ("basic"). Unused -->
+        <Animation Name="gMajorasIncarnationStationaryAnim" Offset="0x3B3C" /> <!-- Unused. Original name is "last2_kihon" ("basic") -->
 
         <!-- Majora's Incarnation Limb DisplayLists -->
         <DList Name="gMajorasIncarnationEyestalkDL" Offset="0x7930" />
@@ -68,7 +68,7 @@
 
         <!-- Majora's Mask Animations -->
         <Animation Name="gMajorasMaskJerkingAnim" Offset="0xAE40" /> <!-- Original name is "last3_dam" -->
-        <Animation Name="gMajorasMaskStationaryAnim" Offset="0xAEDC" /> <!-- Original name is "last3_kihon" ("basic"). Unused -->
+        <Animation Name="gMajorasMaskStationaryAnim" Offset="0xAEDC" /> <!-- Unused. Original name is "last3_kihon" ("basic") -->
 
         <!-- Majora's Mask Tentacle Texture and DisplayLists -->
         <Texture Name="gMajorasMaskTentacleTex" OutName="majoras_mask_tentacle" Format="rgba16" Width="8" Height="8" Offset="0xAEF0" />
@@ -150,13 +150,13 @@
         <Animation Name="gMajorasMaskFloatingAnim" Offset="0x19E48" /> <!-- Original name is "last3_stop" -->
 
         <!-- Majora's Wrath Animations. For unused animations, we don't know what the whips are supposed to do, since their physics are controlled by the Boss07 actor.  -->
-        <Animation Name="gMajorasWrathFlipLeftAndSpin" Offset="0x1AE1C" /> <!-- Original name is "last_ac01". Unused -->
-        <Animation Name="gMajorasWrathDoubleKickAndJumpBackAnim" Offset="0x1C430" /> <!-- Original name is "last_ac02". Unused -->
-        <Animation Name="gMajorasWrathBackflipUppercutAttackAnim" Offset="0x1CFF0" /> <!-- Original name is "last_ac03". Unused -->
-        <Animation Name="gMajorasWrathHighKickAnim" Offset="0x1D974" /> <!-- Original name is "last_ac04". Unused and almost identical to gMajorasWrathKickAnim -->
+        <Animation Name="gMajorasWrathFlipLeftAndSpin" Offset="0x1AE1C" /> <!-- Unused. Original name is "last_ac01" -->
+        <Animation Name="gMajorasWrathDoubleKickAndJumpBackAnim" Offset="0x1C430" /> <!-- Unused. Original name is "last_ac02" -->
+        <Animation Name="gMajorasWrathBackflipUppercutAttackAnim" Offset="0x1CFF0" /> <!-- Unused. Original name is "last_ac03" -->
+        <Animation Name="gMajorasWrathHighKickAnim" Offset="0x1D974" /> <!-- Unused and almost identical to gMajorasWrathKickAnim. Original name is "last_ac04" -->
         <Animation Name="gMajorasWrathDamageAnim" Offset="0x1DEB4" /> <!-- Original name is "last_dam" -->
         <Animation Name="gMajorasWrathDeathAnim" Offset="0x22BB4" /> <!-- Original name is "last_dead" -->
-        <Animation Name="gMajorasWrathTiptoeWhipAttackAnim" Offset="0x23A44" /> <!-- Original name is "last_def". Unused -->
+        <Animation Name="gMajorasWrathTiptoeWhipAttackAnim" Offset="0x23A44" /> <!-- Unused. Original name is "last_def" -->
         <Animation Name="gMajorasWrathHeavyBreathingAnim" Offset="0x23DAC" /> <!-- Original name is "last_hen" (short for "metamorphosis/transformation") -->
         <Animation Name="gMajorasWrathIntroAnim" Offset="0x25018" /> <!-- Original name is "last_hen2" -->
         <Animation Name="gMajorasWrathBackflipAnim" Offset="0x25878" /> <!-- Original name is "last_jump" -->

--- a/assets/xml/objects/object_dblue_object.xml
+++ b/assets/xml/objects/object_dblue_object.xml
@@ -14,7 +14,7 @@
         <!-- DisplayLists and Collision for the ice stalactites that can be thawed with Fire Arrows.  -->
         <DList Name="gGreatBayTempleObjectIceStalactiteRimDL" Offset="0x3250" />
         <DList Name="gGreatBayTempleObjectIceStalactiteDL" Offset="0x3358" /> <!-- Original name is "m2_KON_ICE_model" -->
-        <Collision Name="gGreatBayTempleObjectIceStalactiteCol" Offset="0x3540" /> <!-- Original name is "m2_KON_ICE_bgdatainfo". Unused -->
+        <Collision Name="gGreatBayTempleObjectIceStalactiteCol" Offset="0x3540" /> <!-- Unused. Original name is "m2_KON_ICE_bgdatainfo" -->
 
         <!-- DisplayLists for the frozen version of the waterfall that briefly appears when you hit it with an Ice Arrow. -->
         <DList Name="gGreatBayTempleObjectFrozenWaterfallDL" Offset="0x3770" />

--- a/assets/xml/objects/object_dog.xml
+++ b/assets/xml/objects/object_dog.xml
@@ -3,13 +3,13 @@
     <File Name="object_dog" Segment="6">
         <!-- Unused Selection Arrow with a Texture Animation -->
         <DList Name="gDogSelectionArrowAnimatedDL" Offset="0x170" /> <!-- Original name is "cursor_00_anim_model" -->
-        <DList Name="gDogSelectionArrowAnimatedEmptyDL" Offset="0x250" /> <!-- Original name is "cursor_00_anim_modelT". Probably meant "transparent" at one point -->
+        <DList Name="gDogSelectionArrowAnimatedEmptyDL" Offset="0x250" /> <!-- Original name is "cursor_00_anim_modelT" -->
         <Texture Name="gDogSelectionArrowAnimatedTex" OutName="dog_selection_arrow_animated" Format="i8" Width="8" Height="32" Offset="0x258" />
         <TextureAnimation Name="gDogSelectionArrowTexAnim" Offset="0x3C4" />
 
         <!-- Selection Arrow DisplayLists and Texture -->
         <DList Name="gDogSelectionArrowDL" Offset="0x550" /> <!-- Original name is "cursor_00_none_model" -->
-        <DList Name="gDogSelectionArrowEmptyDL" Offset="0x618" /> <!-- Original name is "cursor_00_none_modelT". Probably meant "transparent" at one point-->
+        <DList Name="gDogSelectionArrowEmptyDL" Offset="0x618" /> <!-- Original name is "cursor_00_none_modelT" -->
         <Texture Name="gDogSelectionArrowTex" OutName="dog_selection_arrow" Format="i4" Width="16" Height="32" Offset="0x620" />
 
         <!-- Dog Animations -->

--- a/assets/xml/objects/object_f52_obj.xml
+++ b/assets/xml/objects/object_f52_obj.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_f52_obj" Segment="6">
-        <DList Name="object_f52_obj_DL_000570" Offset="0x570" /> <!-- Original name is "bw_01_model". Bell post -->
-        <DList Name="object_f52_obj_DL_000698" Offset="0x698" /> <!-- Original name is "bk_model". Bell -->
+        <DList Name="object_f52_obj_DL_000570" Offset="0x570" /> <!-- Bell post. Original name is "bw_01_model" -->
+        <DList Name="object_f52_obj_DL_000698" Offset="0x698" /> <!-- Bell. Original name is "bk_model" -->
         <DList Name="object_f52_obj_DL_0007A8" Offset="0x7A8" /> <!-- Bell Base -->
-        <DList Name="object_f52_obj_DL_000840" Offset="0x840" /> <!-- Original name is "bqT_model". Bell Shadow -->
-        <DList Name="object_f52_obj_DL_0008D0" Offset="0x8D0" /> <!-- Original name is "bhT_model". Bell Hook -->
+        <DList Name="object_f52_obj_DL_000840" Offset="0x840" /> <!-- Bell Shadow. Original name is "bqT_model" -->
+        <DList Name="object_f52_obj_DL_0008D0" Offset="0x8D0" /> <!-- Bell Hook. Original name is "bhT_model" -->
         <DList Name="object_f52_obj_DL_000960" Offset="0x960" /> <!-- Bell Designs -->
         <Texture Name="object_f52_obj_Tex_000A10" OutName="tex_000A10" Format="rgba16" Width="32" Height="16" Offset="0xA10" />
         <Texture Name="object_f52_obj_Tex_000E10" OutName="tex_000E10" Format="ia16" Width="16" Height="16" Offset="0xE10" />

--- a/assets/xml/objects/object_ka.xml
+++ b/assets/xml/objects/object_ka.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <!-- Assets for Pierre, the scarecrow -->
     <File Name="object_ka" Segment="6">
         <Animation Name="object_ka_Anim_000214" Offset="0x214" /> <!-- Original name is "dance" -->
         <DList Name="object_ka_DL_001550" Offset="0x1550" />

--- a/assets/xml/objects/object_ka.xml
+++ b/assets/xml/objects/object_ka.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_ka" Segment="6">
-        <Animation Name="object_ka_Anim_000214" Offset="0x214" />
+        <Animation Name="object_ka_Anim_000214" Offset="0x214" /> <!-- Original name is "dance" -->
         <DList Name="object_ka_DL_001550" Offset="0x1550" />
         <DList Name="object_ka_DL_001600" Offset="0x1600" />
         <DList Name="object_ka_DL_0017D8" Offset="0x17D8" />
@@ -59,11 +59,11 @@
         <Limb Name="object_ka_Standardlimb_00652C" Type="Standard" EnumName="OBJECT_KA_LIMB_1A" Offset="0x652C" />
         <Limb Name="object_ka_Standardlimb_006538" Type="Standard" EnumName="OBJECT_KA_LIMB_1B" Offset="0x6538" />
         <Skeleton Name="object_ka_Skel_0065B0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_KA_LIMB_NONE" LimbMax="OBJECT_KA_LIMB_MAX" EnumName="ObjectKaLimb" Offset="0x65B0" />
-        <Animation Name="object_ka_Anim_00686C" Offset="0x686C" />
-        <Animation Name="object_ka_Anim_006A6C" Offset="0x6A6C" />
-        <Animation Name="object_ka_Anim_0071EC" Offset="0x71EC" />
-        <Animation Name="object_ka_Anim_007444" Offset="0x7444" />
-        <Animation Name="object_ka_Anim_007B90" Offset="0x7B90" />
-        <Animation Name="object_ka_Anim_0081A4" Offset="0x81A4" />
+        <Animation Name="object_ka_Anim_00686C" Offset="0x686C" /> <!-- Original name is "ka_basicdance" -->
+        <Animation Name="object_ka_Anim_006A6C" Offset="0x6A6C" /> <!-- Original name is "ka_dance" (this animation was removed in MM3D, but it's present in OoT3D) -->
+        <Animation Name="object_ka_Anim_0071EC" Offset="0x71EC" /> <!-- Original name is "ka_hello" -->
+        <Animation Name="object_ka_Anim_007444" Offset="0x7444" /> <!-- Original name is "ka_newwait" -->
+        <Animation Name="object_ka_Anim_007B90" Offset="0x7B90" /> <!-- Original name is "ka_onegai" -->
+        <Animation Name="object_ka_Anim_0081A4" Offset="0x81A4" /> <!-- Original name is "ka_turndance" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kaizoku_obj.xml
+++ b/assets/xml/objects/object_kaizoku_obj.xml
@@ -1,22 +1,22 @@
 ﻿<Root>
     <File Name="object_kaizoku_obj" Segment="6">
-        <DList Name="object_kaizoku_obj_DL_0001A0" Offset="0x1A0" />
+        <DList Name="object_kaizoku_obj_DL_0001A0" Offset="0x1A0" /> <!-- Original name is "Y2_KaizokuShutter_model" -->
         <Texture Name="object_kaizoku_obj_Tex_000300" OutName="tex_000300" Format="rgba16" Width="32" Height="64" Offset="0x300" />
         <DList Name="gPirateLiftPlatformDL" Offset="0x1680" />
         <Collision Name="gPirateLiftPlatformCol" Offset="0x19B0" />
         <Texture Name="object_kaizoku_obj_Tex_0019E0" OutName="tex_0019E0" Format="rgba16" Width="64" Height="32" Offset="0x19E0" />
         <Texture Name="object_kaizoku_obj_Tex_0029E0" OutName="tex_0029E0" Format="rgba16" Width="16" Height="32" Offset="0x29E0" />
         <Texture Name="object_kaizoku_obj_Tex_002DE0" OutName="tex_002DE0" Format="rgba16" Width="16" Height="16" Offset="0x2DE0" />
-        <DList Name="gPirateBarredShutterDL" Offset="0x32A0" />
-        <Collision Name="gPirateBarredShutterCol" Offset="0x35B0" />
+        <DList Name="gPirateBarredShutterDL" Offset="0x32A0" /> <!-- Original name is "Y2_AMIdoor_model" -->
+        <Collision Name="gPirateBarredShutterCol" Offset="0x35B0" /> <!-- Original name is "Y2_AMIdoor_bgdatainfo" -->
         <Texture Name="object_kaizoku_obj_Tex_0035E0" OutName="tex_0035E0" Format="rgba16" Width="32" Height="64" Offset="0x35E0" />
         <Texture Name="object_kaizoku_obj_Tex_0045E0" OutName="tex_0045E0" Format="rgba16" Width="32" Height="32" Offset="0x45E0" />
         <Texture Name="object_kaizoku_obj_Tex_004DE0" OutName="tex_004DE0" Format="rgba16" Width="32" Height="16" Offset="0x4DE0" />
-        <DList Name="gPirateGratedShutterDL" Offset="0x5720" />
-        <Collision Name="gPirateGratedShutterCol" Offset="0x5EC8" />
+        <DList Name="gPirateGratedShutterDL" Offset="0x5720" /> <!-- Original name is "Y2_AMIshutter_model" -->
+        <Collision Name="gPirateGratedShutterCol" Offset="0x5EC8" /> <!-- Original name is "Y2_AMIshutter_bgdatainfo" -->
         <Texture Name="object_kaizoku_obj_TLUT_005F00" OutName="tlut_005F00" Format="rgba16" Width="4" Height="4" Offset="0x5F00" />
         <Texture Name="object_kaizoku_obj_Tex_005F20" OutName="tex_005F20" Format="ci4" Width="64" Height="64" Offset="0x5F20" />
-        <DList Name="object_kaizoku_obj_DL_007630" Offset="0x7630" />
+        <DList Name="object_kaizoku_obj_DL_007630" Offset="0x7630" /> <!-- Original name is "Y2_boat_model" -->
         <Texture Name="object_kaizoku_obj_TLUT_0083C8" OutName="tlut_0083C8" Format="rgba16" Width="16" Height="16" Offset="0x83C8" />
         <Texture Name="object_kaizoku_obj_TLUT_0085C8" OutName="tlut_0085C8" Format="rgba16" Width="4" Height="4" Offset="0x85C8" />
         <Texture Name="object_kaizoku_obj_TLUT_0085E8" OutName="tlut_0085E8" Format="rgba16" Width="4" Height="4" Offset="0x85E8" />
@@ -27,15 +27,15 @@
         <Texture Name="object_kaizoku_obj_Tex_008D08" OutName="tex_008D08" Format="ci8" Width="32" Height="32" Offset="0x8D08" />
         <Texture Name="object_kaizoku_obj_Tex_009108" OutName="tex_009108" Format="ci8" Width="32" Height="32" Offset="0x9108" />
         <Texture Name="object_kaizoku_obj_Tex_009508" OutName="tex_009508" Format="ci4" Width="4" Height="4" Offset="0x9508" />
-        <Collision Name="object_kaizoku_obj_Colheader_009A88" Offset="0x9A88" />
-        <DList Name="gPiratesFortressDoorDL" Offset="0x9F20" />
+        <Collision Name="object_kaizoku_obj_Colheader_009A88" Offset="0x9A88" /> <!-- Original name is "Y2_boat_bgdatainfo" -->
+        <DList Name="gPiratesFortressDoorDL" Offset="0x9F20" /> <!-- Original name is "Y2_KaizokuDoor_model" -->
         <Texture Name="gPiratesFortressDoorTexDL" OutName="door_tex" Format="rgba16" Width="16" Height="64" Offset="0xA210" />
         <Texture Name="object_kaizoku_obj_Tex_00AA10" OutName="tex_00AA10" Format="i4" Width="32" Height="32" Offset="0xAA10" />
-        <DList Name="object_kaizoku_obj_DL_00AD50" Offset="0xAD50" />
+        <DList Name="object_kaizoku_obj_DL_00AD50" Offset="0xAD50" /> <!-- Original name is "Y2_kibako_model" -->
         <Texture Name="object_kaizoku_obj_TLUT_00AF38" OutName="tlut_00AF38" Format="rgba16" Width="4" Height="4" Offset="0xAF38" />
         <Texture Name="object_kaizoku_obj_TLUT_00AF58" OutName="tlut_00AF58" Format="rgba16" Width="4" Height="4" Offset="0xAF58" />
         <Texture Name="object_kaizoku_obj_Tex_00AF78" OutName="tex_00AF78" Format="ci4" Width="32" Height="64" Offset="0xAF78" />
         <Texture Name="object_kaizoku_obj_Tex_00B378" OutName="tex_00B378" Format="ci4" Width="32" Height="64" Offset="0xB378" />
-        <Collision Name="object_kaizoku_obj_Colheader_00B868" Offset="0xB868" />
+        <Collision Name="object_kaizoku_obj_Colheader_00B868" Offset="0xB868" /> <!-- Original name is "Y2_kibako_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kamejima.xml
+++ b/assets/xml/objects/object_kamejima.xml
@@ -5,29 +5,29 @@
         <Array Name="gTurtleWaveVtx" Count="20" Offset="0x0">
             <Vtx/>
         </Array>
-        <DList Name="gTurtleWaveDL" Offset="0x140" />
+        <DList Name="gTurtleWaveDL" Offset="0x140" /> <!-- Original name is "efc_wave_model" -->
         <Texture Name="gTurtleWaveUnusedTex" OutName="turtle_wave_unused" Format="i8" Width="32" Height="64" Offset="0x2D8" />
         <Texture Name="gTurtleWaveTex" OutName="turtle_wave" Format="i8" Width="64" Height="64" Offset="0xAD8" />
         <TextureAnimation Name="gTurtleWaveTexAnim" Offset="0x1AF0" />
 
 
         <!-- Turtle -->
-        <Collision Name="gTurtleZoraCapeAsleepCol" Offset="0x2328" />
+        <Collision Name="gTurtleZoraCapeAsleepCol" Offset="0x2328" /> <!-- Original name is "kam_all_bgdatainfo" -->
         <TextureAnimation Name="gTurtleEmptyTexAnim" Offset="0x2360"/>
-        <Collision Name="gTurtleZoraCapeAwakeCol" Offset="0x2470" />
-        <Collision Name="gTurtleUnusedCol" Offset="0x2E04" />
+        <Collision Name="gTurtleZoraCapeAwakeCol" Offset="0x2470" /> <!-- Original name is "kam_kamebgbox_bgdatainfo" -->
+        <Collision Name="gTurtleUnusedCol" Offset="0x2E04" /> <!-- Original name might be "kam_kamebg_bgdatainfo"? MM3D has this, but the collision vertices do not match at all. -->
         
-        <Animation Name="gTurtleGlitchy1Anim" Offset="0x3980" />
-        <Animation Name="gTurtleCoughAnim" Offset="0x47B8" />
-        <Animation Name="gTurtleIdleAnim" Offset="0x48B0" />
+        <Animation Name="gTurtleGlitchy1Anim" Offset="0x3980" /> <!-- Original name is "kam_laugh" -->
+        <Animation Name="gTurtleCoughAnim" Offset="0x47B8" /> <!-- Original name is "kam_laughlong" -->
+        <Animation Name="gTurtleIdleAnim" Offset="0x48B0" /> <!-- Original name is "kam_mezame" -->
 
-        <DList Name="gTurtleAsleepDL" Offset="0x4E70" /> <!-- When asleep, the turtle looks like a giant rock -->
+        <DList Name="gTurtleAsleepDL" Offset="0x4E70" /> <!-- Original name is "kam_sima_3_model". When asleep, the turtle looks like a giant rock -->
 
         <Texture Name="gTurtleAsleepTLUT" OutName="turtle_asleep_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5248" />
         <Texture Name="gTurtleAsleepGrassTex" OutName="turtle_asleep_grass" Format="ci8" Width="32" Height="32" Offset="0x5448" />
         <Texture Name="gTurtleAsleepGrassDirtTex" OutName="turtle_asleep_grass_dirt" Format="ci8" Width="64" Height="32" Offset="0x5848" />
 
-        <Animation Name="gTurtleSwimAnim" Offset="0x6980" />
+        <Animation Name="gTurtleSwimAnim" Offset="0x6980" /> <!-- Original name is "kam_swim" -->
 
         <DList Name="gTurtleShellDL" Offset="0x8760" />
         <DList Name="gTurtleFrontLeftUpperFlipperDL" Offset="0x8E18" />
@@ -88,12 +88,12 @@
         <Limb Name="gTurtleFrontRightEndFlipperLimb" Type="Standard" EnumName="TURTLE_LIMB_FRONT_RIGHT_END_FLIPPER" Offset="0xE6E0" />
         <Skeleton Name="gTurtleSkel" Type="Flex" LimbType="Standard" LimbNone="TURTLE_LIMB_NONE" LimbMax="TURTLE_LIMB_MAX" EnumName="TurtleLimb" Offset="0xE748" />
 
-        <Animation Name="gTurtleGlitchy2Anim" Offset="0xEF98" />
-        <Animation Name="gTurtleSpeak1Anim" Offset="0x100CC" />
-        <Animation Name="gTurtleGlitchyRaiseHeadAnim" Offset="0x10918" />
-        <Animation Name="gTurtleSpeak2Anim" Offset="0x119D4" />
-        <Animation Name="gTurtleFloatAnim" Offset="0x12260" />
-        <Animation Name="gTurtleGlitchyLookAroundAnim" Offset="0x13264" />
-        <Animation Name="gTurtleYawnAnim" Offset="0x14E8C" />
+        <Animation Name="gTurtleGlitchy2Anim" Offset="0xEF98" /> <!-- Original name is "kam_talk" -->
+        <Animation Name="gTurtleSpeak1Anim" Offset="0x100CC" /> <!-- Original name is "kam_talklong" -->
+        <Animation Name="gTurtleGlitchyRaiseHeadAnim" Offset="0x10918" /> <!-- Original name is "kam_unazuku" -->
+        <Animation Name="gTurtleSpeak2Anim" Offset="0x119D4" /> <!-- Original name is "kam_unazukulong" -->
+        <Animation Name="gTurtleFloatAnim" Offset="0x12260" /> <!-- Original name is "kam_wait" -->
+        <Animation Name="gTurtleGlitchyLookAroundAnim" Offset="0x13264" /> <!-- Original name is "kam_yawn" -->
+        <Animation Name="gTurtleYawnAnim" Offset="0x14E8C" /> <!-- Original name is "kam_yawnlong" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kamejima.xml
+++ b/assets/xml/objects/object_kamejima.xml
@@ -21,7 +21,7 @@
         <Animation Name="gTurtleCoughAnim" Offset="0x47B8" /> <!-- Original name is "kam_laughlong" -->
         <Animation Name="gTurtleIdleAnim" Offset="0x48B0" /> <!-- Original name is "kam_mezame" -->
 
-        <DList Name="gTurtleAsleepDL" Offset="0x4E70" /> <!-- Original name is "kam_sima_3_model". When asleep, the turtle looks like a giant rock -->
+        <DList Name="gTurtleAsleepDL" Offset="0x4E70" /> <!-- When asleep, the turtle looks like a giant rock. Original name is "kam_sima_3_model" -->
 
         <Texture Name="gTurtleAsleepTLUT" OutName="turtle_asleep_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5248" />
         <Texture Name="gTurtleAsleepGrassTex" OutName="turtle_asleep_grass" Format="ci8" Width="32" Height="32" Offset="0x5448" />

--- a/assets/xml/objects/object_kanban.xml
+++ b/assets/xml/objects/object_kanban.xml
@@ -1,18 +1,18 @@
 ﻿<Root>
     <File Name="object_kanban" Segment="6">
         <DList Name="object_kanban_DL_000C30" Offset="0xC30" />
-        <DList Name="object_kanban_DL_000CB0" Offset="0xCB0" />
-        <DList Name="object_kanban_DL_000DB8" Offset="0xDB8" />
-        <DList Name="object_kanban_DL_000E78" Offset="0xE78" />
-        <DList Name="object_kanban_DL_000F38" Offset="0xF38" />
-        <DList Name="object_kanban_DL_000FF8" Offset="0xFF8" />
-        <DList Name="object_kanban_DL_0010B8" Offset="0x10B8" />
-        <DList Name="object_kanban_DL_0011C0" Offset="0x11C0" />
-        <DList Name="object_kanban_DL_0012C8" Offset="0x12C8" />
-        <DList Name="object_kanban_DL_0013D0" Offset="0x13D0" />
-        <DList Name="object_kanban_DL_001488" Offset="0x1488" />
-        <DList Name="object_kanban_DL_001540" Offset="0x1540" />
-        <DList Name="object_kanban_DL_001630" Offset="0x1630" />
+        <DList Name="object_kanban_DL_000CB0" Offset="0xCB0" /> <!-- Original name is "kanban_L_top_R_model" -->
+        <DList Name="object_kanban_DL_000DB8" Offset="0xDB8" /> <!-- Original name is "kanban_L_top_L_model" -->
+        <DList Name="object_kanban_DL_000E78" Offset="0xE78" /> <!-- Original name is "kanban_L_bottom_L_model" -->
+        <DList Name="object_kanban_DL_000F38" Offset="0xF38" /> <!-- Original name is "kanban_R_top_R_model" -->
+        <DList Name="object_kanban_DL_000FF8" Offset="0xFF8" /> <!-- Original name is "kanban_R_bottom_R_model" -->
+        <DList Name="object_kanban_DL_0010B8" Offset="0x10B8" /> <!-- Original name is "kanban_L_bottom_R_model" -->
+        <DList Name="object_kanban_DL_0011C0" Offset="0x11C0" /> <!-- Original name is "kanban_R_top_L_model" -->
+        <DList Name="object_kanban_DL_0012C8" Offset="0x12C8" /> <!-- Original name is "kanban_R_bottom_L_model" -->
+        <DList Name="object_kanban_DL_0013D0" Offset="0x13D0" /> <!-- Original name is "kanban_bo_top_model" -->
+        <DList Name="object_kanban_DL_001488" Offset="0x1488" /> <!-- Original name is "kanban_bo_center_model" -->
+        <DList Name="object_kanban_DL_001540" Offset="0x1540" /> <!-- Original name is "kanban_bo_bottom_model" -->
+        <DList Name="object_kanban_DL_001630" Offset="0x1630" /> <!-- Original name is "kanban_eff_modelT" -->
         <Texture Name="object_kanban_Tex_0016B0" OutName="tex_0016B0" Format="i8" Width="16" Height="16" Offset="0x16B0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_kbt.xml
+++ b/assets/xml/objects/object_kbt.xml
@@ -1,16 +1,16 @@
 ﻿<Root>
     <File Name="object_kbt" Segment="6">
-        <Animation Name="object_kbt_Anim_000670" Offset="0x670" />
-        <Animation Name="object_kbt_Anim_000FE8" Offset="0xFE8" />
-        <Animation Name="object_kbt_Anim_001674" Offset="0x1674" />
-        <Animation Name="object_kbt_Anim_001940" Offset="0x1940" />
-        <Animation Name="object_kbt_Anim_001BF4" Offset="0x1BF4" />
-        <Animation Name="object_kbt_Anim_002084" Offset="0x2084" />
-        <Animation Name="object_kbt_Anim_002710" Offset="0x2710" />
-        <Animation Name="object_kbt_Anim_002DE0" Offset="0x2DE0" />
-        <Animation Name="object_kbt_Anim_003414" Offset="0x3414" />
-        <Animation Name="object_kbt_Anim_003D24" Offset="0x3D24" />
-        <Animation Name="object_kbt_Anim_004274" Offset="0x4274" />
+        <Animation Name="object_kbt_Anim_000670" Offset="0x670" /> <!-- Original name is "kbt_neru" -->
+        <Animation Name="object_kbt_Anim_000FE8" Offset="0xFE8" /> <!-- Original name is "kbt_nerutalk" -->
+        <Animation Name="object_kbt_Anim_001674" Offset="0x1674" /> <!-- Original name is "kbt_niramitalk" -->
+        <Animation Name="object_kbt_Anim_001940" Offset="0x1940" /> <!-- Original name is "kbt_niramu" -->
+        <Animation Name="object_kbt_Anim_001BF4" Offset="0x1BF4" /> <!-- Original name is "kbt_niramu02" -->
+        <Animation Name="object_kbt_Anim_002084" Offset="0x2084" /> <!-- Original name is "kbt_okiru" -->
+        <Animation Name="object_kbt_Anim_002710" Offset="0x2710" /> <!-- Original name is "kbt_talk01" -->
+        <Animation Name="object_kbt_Anim_002DE0" Offset="0x2DE0" /> <!-- Original name is "kbt_talk02" -->
+        <Animation Name="object_kbt_Anim_003414" Offset="0x3414" /> <!-- Original name is "kbt_talk03" -->
+        <Animation Name="object_kbt_Anim_003D24" Offset="0x3D24" /> <!-- Original name is "kbt_talk04" -->
+        <Animation Name="object_kbt_Anim_004274" Offset="0x4274" /> <!-- Original name is "kbt_testwait" -->
         <DList Name="object_kbt_DL_007550" Offset="0x7550" />
         <DList Name="object_kbt_DL_0076F8" Offset="0x76F8" />
         <DList Name="object_kbt_DL_0077E0" Offset="0x77E0" />
@@ -69,7 +69,7 @@
         <Limb Name="object_kbt_Standardlimb_00DE84" Type="Standard" EnumName="OBJECT_KBT_LIMB_12" Offset="0xDE84" />
         <Limb Name="object_kbt_Standardlimb_00DE90" Type="Standard" EnumName="OBJECT_KBT_LIMB_13" Offset="0xDE90" />
         <Skeleton Name="object_kbt_Skel_00DEE8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_KBT_LIMB_NONE" LimbMax="OBJECT_KBT_LIMB_MAX" EnumName="ObjectKbtLimb" Offset="0xDEE8" />
-        <Animation Name="object_kbt_Anim_00E7BC" Offset="0xE7BC" />
-        <Animation Name="object_kbt_Anim_00F0C8" Offset="0xF0C8" />
+        <Animation Name="object_kbt_Anim_00E7BC" Offset="0xE7BC" /> <!-- Original name is "kbt_wait01" -->
+        <Animation Name="object_kbt_Anim_00F0C8" Offset="0xF0C8" /> <!-- Original name is "kbt_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_keikoku_demo.xml
+++ b/assets/xml/objects/object_keikoku_demo.xml
@@ -7,21 +7,21 @@
 
         <!-- DmOpstage draws both an empty XLU and non-empty OPA at the same time, each version has its own empty DL instead of reusing. -->
         <DList Name="gKeikokuDemoFloorEmptyDL" Offset="0x970" />
-        <DList Name="gKeikokuDemoFloorDL" Offset="0x978" />
+        <DList Name="gKeikokuDemoFloorDL" Offset="0x978" /> <!-- Original name is "daichi_model" -->
 
         <!-- DmOpstage type DMOPSTAGE_TYPE_GROUND textures -->
         <Texture Name="gKeikokuDemoYellowFlowersOnGrassTex" OutName="yellow_flowers_on_grass" Format="rgba16" Width="32" Height="32" Offset="0xC50" />
         <Texture Name="gKeikokuDemoFallLeavesOnGrassTex" OutName="fall_leaves_on_grass" Format="rgba16" Width="32" Height="32" Offset="0x1450" />
 
         <!-- DmOpstage type DMOPSTAGE_TYPE_GROUND Dyna Collider -->
-        <Collision Name="gKeikokuDemoFloorColliderHeader" Offset="0x1C98" />
+        <Collision Name="gKeikokuDemoFloorCol" Offset="0x1C98" /> <!-- Original name is "daichi_bgdatainfo" -->
 
         <DList Name="gKeikokuDemoTallTreeWithRootBaseEmptyDL" Offset="0x2870" />
-        <DList Name="gKeikokuDemoTallTreeWithRootBaseDL" Offset="0x2878" />
+        <DList Name="gKeikokuDemoTallTreeWithRootBaseDL" Offset="0x2878" /> <!-- Original name is "lost_woods_wood1_model" -->
         <DList Name="gKeikokuDemoTallTreeCutEmptyDL" Offset="0x3060" />
-        <DList Name="gKeikokuDemoTallTreeCutDL" Offset="0x3068" />
+        <DList Name="gKeikokuDemoTallTreeCutDL" Offset="0x3068" /> <!-- Original name is "lost_woods_wood2_model" -->
         <DList Name="gKeikokuDemoTallTreeStraightEmptyDL" Offset="0x3720" />
-        <DList Name="gKeikokuDemoTallTreeStraightDL" Offset="0x3728" />
+        <DList Name="gKeikokuDemoTallTreeStraightDL" Offset="0x3728" /> <!-- Original name is "lost_woods_wood3_model" -->
         <Texture Name="gKeikokuDemoTreeLeavesTex" OutName="tree_leaves" Format="ia16" Width="32" Height="32" Offset="0x3930" />
         <Texture Name="gKeikokuDemoTreeCutEndGrainTex" OutName="cut_end_grain" Format="rgba16" Width="32" Height="32" Offset="0x4130" />
 

--- a/assets/xml/objects/object_keikoku_obj.xml
+++ b/assets/xml/objects/object_keikoku_obj.xml
@@ -8,19 +8,19 @@
         <TextureAnimation Name="object_keikoku_obj_Matanimheader_0005F8" Offset="0x5F8" />
         <Texture Name="object_keikoku_obj_Tex_000600" OutName="tex_000600" Format="i4" Width="64" Height="64" Offset="0x600" />
         <Texture Name="object_keikoku_obj_Tex_000E00" OutName="tex_000E00" Format="i4" Width="64" Height="64" Offset="0xE00" />
-        <DList Name="object_keikoku_obj_DL_001640" Offset="0x1640" />
+        <DList Name="object_keikoku_obj_DL_001640" Offset="0x1640" /> <!-- Original name is "g2T_model" -->
         <Texture Name="object_keikoku_obj_Tex_001780" OutName="tex_001780" Format="ia4" Width="32" Height="128" Offset="0x1780" />
         <Texture Name="object_keikoku_obj_Tex_001F80" OutName="tex_001F80" Format="ia4" Width="16" Height="64" Offset="0x1F80" />
         <Texture Name="object_keikoku_obj_Tex_002180" OutName="tex_002180" Format="ia8" Width="8" Height="32" Offset="0x2180" />
-        <Collision Name="object_keikoku_obj_Colheader_002300" Offset="0x2300" />
+        <Collision Name="object_keikoku_obj_Colheader_002300" Offset="0x2300" /> <!-- Original name is "z2_00_saku01_bgdatainfo" -->
         <DList Name="object_keikoku_obj_DL_0027D0" Offset="0x27D0" />
-        <DList Name="object_keikoku_obj_DL_0027D8" Offset="0x27D8" />
+        <DList Name="object_keikoku_obj_DL_0027D8" Offset="0x27D8" /> <!-- Original name is "z2_00_yama01_model" -->
         <Texture Name="object_keikoku_obj_Tex_002A78" OutName="tex_002A78" Format="rgba16" Width="16" Height="64" Offset="0x2A78" />
         <Texture Name="object_keikoku_obj_Tex_003278" OutName="tex_003278" Format="rgba16" Width="32" Height="32" Offset="0x3278" />
         <Texture Name="object_keikoku_obj_Tex_003A78" OutName="tex_003A78" Format="i4" Width="64" Height="64" Offset="0x3A78" />
         <TextureAnimation Name="object_keikoku_obj_Matanimheader_004290" Offset="0x4290" />
         <DList Name="object_keikoku_obj_DL_0044A0" Offset="0x44A0" />
-        <DList Name="object_keikoku_obj_DL_0044A8" Offset="0x44A8" />
+        <DList Name="object_keikoku_obj_DL_0044A8" Offset="0x44A8" /> <!-- Original name is "z2_00_yama02_model" -->
         <Texture Name="object_keikoku_obj_Tex_004618" OutName="tex_004618" Format="rgba16" Width="16" Height="32" Offset="0x4618" />
         <Texture Name="object_keikoku_obj_Tex_004A18" OutName="tex_004A18" Format="rgba16" Width="32" Height="32" Offset="0x4A18" />
     </File>

--- a/assets/xml/objects/object_kepn_koya.xml
+++ b/assets/xml/objects/object_kepn_koya.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_kepn_koya" Segment="6">
-        <DList Name="object_kepn_koya_DL_003470" Offset="0x3470" />
-        <DList Name="object_kepn_koya_DL_003478" Offset="0x3478" />
+        <DList Name="object_kepn_koya_DL_003470" Offset="0x3470" /> <!-- Original name is "w2_kepn_koya_modelT" -->
+        <DList Name="object_kepn_koya_DL_003478" Offset="0x3478" /> <!-- Original name is "w2_kepn_koya_model" -->
         <Texture Name="object_kepn_koya_TLUT_005118" OutName="tlut_005118" Format="rgba16" Width="16" Height="16" Offset="0x5118" />
         <Texture Name="object_kepn_koya_Tex_005318" OutName="tex_005318" Format="ci8" Width="16" Height="16" Offset="0x5318" />
         <Texture Name="object_kepn_koya_Tex_005418" OutName="tex_005418" Format="ci8" Width="64" Height="32" Offset="0x5418" />
@@ -13,6 +13,6 @@
         <Texture Name="object_kepn_koya_Tex_006E18" OutName="tex_006E18" Format="ci8" Width="32" Height="32" Offset="0x6E18" />
         <Texture Name="object_kepn_koya_Tex_007218" OutName="tex_007218" Format="rgba16" Width="8" Height="8" Offset="0x7218" />
         <Texture Name="object_kepn_koya_Tex_007298" OutName="tex_007298" Format="ci8" Width="8" Height="8" Offset="0x7298" />
-        <Collision Name="object_kepn_koya_Colheader_00805C" Offset="0x805C" />
+        <Collision Name="object_kepn_koya_Colheader_00805C" Offset="0x805C" /> <!-- Original name is "w2_kepn_koya_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kgy.xml
+++ b/assets/xml/objects/object_kgy.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_kgy" Segment="6">
-        <Animation Name="object_kgy_Anim_0008FC" Offset="0x8FC" />
-        <Animation Name="object_kgy_Anim_001764" Offset="0x1764" />
-        <Animation Name="object_kgy_Anim_001EA4" Offset="0x1EA4" />
-        <Animation Name="object_kgy_Anim_00292C" Offset="0x292C" />
-        <Animation Name="object_kgy_Anim_003334" Offset="0x3334" />
-        <Animation Name="object_kgy_Anim_003D88" Offset="0x3D88" />
-        <Animation Name="object_kgy_Anim_0042E4" Offset="0x42E4" />
-        <Animation Name="object_kgy_Anim_004B98" Offset="0x4B98" />
+        <Animation Name="object_kgy_Anim_0008FC" Offset="0x8FC" /> <!-- Original name is "kgy_abareru" -->
+        <Animation Name="object_kgy_Anim_001764" Offset="0x1764" /> <!-- Original name is "kgy_katsugu" -->
+        <Animation Name="object_kgy_Anim_001EA4" Offset="0x1EA4" /> <!-- Original name is "kgy_muki" -->
+        <Animation Name="object_kgy_Anim_00292C" Offset="0x292C" /> <!-- Original name is "kgy_mukiwait" -->
+        <Animation Name="object_kgy_Anim_003334" Offset="0x3334" /> <!-- Original name is "kgy_tataku" -->
+        <Animation Name="object_kgy_Anim_003D88" Offset="0x3D88" /> <!-- Original name is "kgy_tataku02" -->
+        <Animation Name="object_kgy_Anim_0042E4" Offset="0x42E4" /> <!-- Original name is "kgy_utsumuki" -->
+        <Animation Name="object_kgy_Anim_004B98" Offset="0x4B98" /> <!-- Original name is "kgy_wait01" -->
         <DList Name="object_kgy_DL_009C80" Offset="0x9C80" />
         <DList Name="object_kgy_DL_009DA0" Offset="0x9DA0" />
         <DList Name="object_kgy_DL_009F28" Offset="0x9F28" />
@@ -39,10 +39,10 @@
         <Texture Name="object_kgy_Tex_00E228" OutName="tex_00E228" Format="i8" Width="32" Height="32" Offset="0xE228" />
         <Texture Name="object_kgy_Tex_00E628" OutName="tex_00E628" Format="ci8" Width="16" Height="16" Offset="0xE628" />
         <DList Name="object_kgy_DL_00E8E8" Offset="0xE8E8" />
-        <DList Name="object_kgy_DL_00E8F0" Offset="0xE8F0" />
+        <DList Name="object_kgy_DL_00E8F0" Offset="0xE8F0" /> <!-- Original name is "swordA_model" -->
         <TextureAnimation Name="object_kgy_Matanimheader_00EE58" Offset="0xEE58" />
         <DList Name="object_kgy_DL_00F178" Offset="0xF178" />
-        <DList Name="object_kgy_DL_00F180" Offset="0xF180" />
+        <DList Name="object_kgy_DL_00F180" Offset="0xF180" /> <!-- Original name is "swordB_model" -->
         <TextureAnimation Name="object_kgy_Matanimheader_00F6A0" Offset="0xF6A0" />
         <Texture Name="object_kgy_Tex_00F6B0" OutName="tex_00F6B0" Format="i8" Width="16" Height="16" Offset="0xF6B0" />
         <Limb Name="object_kgy_Standardlimb_00F7B0" Type="Standard" EnumName="OBJECT_KGY_LIMB_01" Offset="0xF7B0" />
@@ -68,7 +68,7 @@
         <Limb Name="object_kgy_Standardlimb_00F8A0" Type="Standard" EnumName="OBJECT_KGY_LIMB_15" Offset="0xF8A0" />
         <Limb Name="object_kgy_Standardlimb_00F8AC" Type="Standard" EnumName="OBJECT_KGY_LIMB_16" Offset="0xF8AC" />
         <Skeleton Name="object_kgy_Skel_00F910" Type="Flex" LimbType="Standard" LimbNone="OBJECT_KGY_LIMB_NONE" LimbMax="OBJECT_KGY_LIMB_MAX" EnumName="ObjectKgyLimb" Offset="0xF910" />
-        <Animation Name="object_kgy_Anim_0101F0" Offset="0x101F0" />
-        <Animation Name="object_kgy_Anim_010B84" Offset="0x10B84" />
+        <Animation Name="object_kgy_Anim_0101F0" Offset="0x101F0" /> <!-- Original name is "kgy_wait02" -->
+        <Animation Name="object_kgy_Anim_010B84" Offset="0x10B84" /> <!-- Original name is "kgy_yorokobu" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kibako.xml
+++ b/assets/xml/objects/object_kibako.xml
@@ -2,8 +2,8 @@
     <!-- Object for small wooden crate -->
     <File Name="object_kibako" Segment="6">
         <Texture Name="gSmallCrateTex" OutName="small_crate" Format="rgba16" Width="32" Height="64" Offset="0x0" />
-        <DList Name="gSmallCrateDL" Offset="0x1180" />
+        <DList Name="gSmallCrateDL" Offset="0x1180" /> <!-- Original name is "field_kibako_model" -->
         <Texture Name="gSmallCrateFragmentTex" OutName="small_crate_fragment" Format="rgba16" Width="64" Height="16" Offset="0x1240" />
-        <DList Name="gSmallCrateFragmentDL" Offset="0x1A70" />
+        <DList Name="gSmallCrateFragmentDL" Offset="0x1A70" /> <!-- Original name is "field_kibako_hahen_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kibako2.xml
+++ b/assets/xml/objects/object_kibako2.xml
@@ -4,11 +4,11 @@
         <Texture Name="gLargeCrateTLUT" OutName="large_crate_tlut" Format="rgba16" Width="4" Height="4" Offset="0x0" />
         <Texture Name="gLargeCrateTopTex" OutName="large_crate_top" Format="ci4" Width="32" Height="64" Offset="0x20" />
         <Texture Name="gLargeCrateSidesTex" OutName="large_crate_sides" Format="ci4" Width="32" Height="64" Offset="0x420" />
-        <DList Name="gLargeCrateDL" Offset="0x960" />
-        <Collision Name="gLargeCrateCol" Offset="0xB70" />
+        <DList Name="gLargeCrateDL" Offset="0x960" /> <!-- Original name is "CIkibako_model" -->
+        <Collision Name="gLargeCrateCol" Offset="0xB70" /> <!-- Original name is "CIkibako_bgdatainfo" -->
         <Texture Name="gLargeCrateFragmentTLUT" OutName="large_crate_fragment_tlut" Format="rgba16" Width="4" Height="4" Offset="0xBA0" />
         <Texture Name="gLargeCrateFragmentTex" OutName="large_crate_fragment" Format="ci4" Width="32" Height="64" Offset="0xBC0" />
-        <DList Name="gLargeCrateFragment1DL" Offset="0x1040" />
-        <DList Name="gLargeCrateFragment2DL" Offset="0x1100" />
+        <DList Name="gLargeCrateFragment1DL" Offset="0x1040" /> <!-- Original name is "CIkibako_hahen_model" -->
+        <DList Name="gLargeCrateFragment2DL" Offset="0x1100" /> <!-- Original name is "CIkibako_hahen2_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kin2_obj.xml
+++ b/assets/xml/objects/object_kin2_obj.xml
@@ -4,32 +4,28 @@
         Piece, bookshelves and chests of drawers.
     -->
     <File Name="object_kin2_obj" Segment="6">
-        <DList Name="gOceanSpiderHouseEmpty1DL" Offset="0x120" />
+        <DList Name="gOceanSpiderHouseEmpty1DL" Offset="0x120" /> <!-- Not present in MM3D, but it was probably named "m2_KIN_BOMBhahen_modelT" based on the rest of this object. -->
+        <DList Name="gOceanSpiderHouseBombableWallDebrisDL" Offset="0x128" /> <!-- Original name is "m2_KIN_BOMBhahen_model" -->
 
-        <DList Name="gOceanSpiderHouseBombableWallDebrisDL" Offset="0x128" />
-        <DList Name="gOceanSpiderHouseBombableWallCrackDL" Offset="0x2C0" />
-        <DList Name="gOceanSpiderHouseBombableWallDL" Offset="0x360" />
-        <Collision Name="gOceanSpiderHouseBombableWallCol" Offset="0x490" />
+        <DList Name="gOceanSpiderHouseBombableWallCrackDL" Offset="0x2C0" /> <!-- Not present in MM3D, but it was probably named "m2_KIN_BOMBwall_modelT" based on the rest of this object. -->
+        <DList Name="gOceanSpiderHouseBombableWallDL" Offset="0x360" /> <!-- Original name is "m2_KIN_BOMBwall_model" -->
+        <Collision Name="gOceanSpiderHouseBombableWallCol" Offset="0x490" /> <!-- Original name is "m2_KIN_BOMBwall_bgdatainfo" -->
 
-        <DList Name="gOceanSpiderHouseEmpty2DL" Offset="0x650" />
+        <DList Name="gOceanSpiderHouseEmpty2DL" Offset="0x650" /> <!-- Original name is "m2_KIN_GAKU_modelT" -->
+        <DList Name="gOceanSpiderHouseSkullkidPaintingDL" Offset="0x658" /> <!-- Original name is "m2_KIN_GAKU_model" -->
+        <Collision Name="gOceanSpiderHouseSkullkidPaintingCol" Offset="0x798" /> <!-- Original name is "m2_KIN_GAKU_bgdatainfo" -->
 
-        <DList Name="gOceanSpiderHouseSkullkidPaintingDL" Offset="0x658" />
-        <Collision Name="gOceanSpiderHouseSkullkidPaintingCol" Offset="0x798" />
-
-        <DList Name="gOceanSpiderHouseEmpty3DL" Offset="0x820" />
+        <DList Name="gOceanSpiderHouseEmpty3DL" Offset="0x820" /> <!-- Original name is "m2_KIN_SAKU_modelT" -->
+        <DList Name="gOceanSpiderHouseFireplaceGrateDL" Offset="0x828" /> <!-- Original name is "m2_KIN_SAKU_model" -->
+        <Collision Name="gOceanSpiderHouseFireplaceGrateCol" Offset="0x908" /> <!-- Original name is "m2_KIN_SAKU_bgdatainfo" -->
         
-        <DList Name="gOceanSpiderHouseFireplaceGrateDL" Offset="0x828" />
-        <Collision Name="gOceanSpiderHouseFireplaceGrateCol" Offset="0x908" />
+        <DList Name="gOceanSpiderHouseEmpty4DL" Offset="0xCA0" /> <!-- Original name is "m2_KIN_TANAbig_modelT" -->
+        <DList Name="gOceanSpiderHouseBookshelfDL" Offset="0xCA8" /> <!-- Original name is "m2_KIN_TANAbig_model"-->
+        <Collision Name="gOceanSpiderHouseBookshelfCol" Offset="0xF80" /> <!-- Original name is "m2_KIN_TANAbig_bgdatainfo" -->
         
-        <DList Name="gOceanSpiderHouseEmpty4DL" Offset="0xCA0" />
-        
-        <DList Name="gOceanSpiderHouseBookshelfDL" Offset="0xCA8" />
-        <Collision Name="gOceanSpiderHouseBookshelfCol" Offset="0xF80" />
-        
-        <DList Name="gOceanSpiderHouseEmpty5DL" Offset="0x10F0" />
-        
-        <DList Name="gOceanSpiderHouseChestOfDrawersDL" Offset="0x10F8" />
-        <Collision Name="gOceanSpiderHouseChestOfDrawersCol" Offset="0x1328" />
+        <DList Name="gOceanSpiderHouseEmpty5DL" Offset="0x10F0" /> <!-- Original name is "m2_KIN_TANAsmall_modelT" -->
+        <DList Name="gOceanSpiderHouseChestOfDrawersDL" Offset="0x10F8" /> <!-- Original name is "m2_KIN_TANAsmall_model" -->
+        <Collision Name="gOceanSpiderHouseChestOfDrawersCol" Offset="0x1328" /> <!-- Original name is "m2_KIN_TANAsmall_bgdatainfo" -->
         
         <Texture Name="gOceanSpiderHouseUnused1TLUT" OutName="ocean_spider_house_unused_tlut_1" Format="rgba16" Width="4" Height="4" Offset="0x1360" />
         <Texture Name="gOceanSpiderHouseTLUT" OutName="ocean_spider_house_tlut" Format="rgba16" Width="4" Height="4" Offset="0x1380" />

--- a/assets/xml/objects/object_kinsta1_obj.xml
+++ b/assets/xml/objects/object_kinsta1_obj.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_kinsta1_obj" Segment="6">
-        <DList Name="object_kinsta1_obj_DL_000190" Offset="0x190" />
-        <DList Name="object_kinsta1_obj_DL_000198" Offset="0x198" />
+        <DList Name="object_kinsta1_obj_DL_000190" Offset="0x190" /> <!-- Original name is "m2_KIN1_shutter_modelT" -->
+        <DList Name="object_kinsta1_obj_DL_000198" Offset="0x198" /> <!-- Original name is "m2_KIN1_shutter_model" -->
         <Texture Name="object_kinsta1_obj_Tex_0002F0" OutName="tex_0002F0" Format="rgba16" Width="32" Height="64" Offset="0x2F0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_kinsta2_obj.xml
+++ b/assets/xml/objects/object_kinsta2_obj.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <!-- Object for Oceanside Spider House Door -->
     <File Name="object_kinsta2_obj" Segment="6">
-        <DList Name="gOceansideSpiderHouseDoorDL" Offset="0x310" />
+        <DList Name="gOceansideSpiderHouseDoorDL" Offset="0x310" /> <!-- Original name is "m2_Kin2DOOR_model" -->
         <Texture Name="gOceansideSpiderHouseDoorTex" OutName="oceanside_spider_house_door" Format="rgba16" Width="32" Height="64" Offset="0x4E8" />
     </File>
 </Root>

--- a/assets/xml/objects/object_kitan.xml
+++ b/assets/xml/objects/object_kitan.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_kitan" Segment="6">
-        <Animation Name="object_kitan_Anim_000CE8" Offset="0xCE8" />
-        <Animation Name="object_kitan_Anim_00190C" Offset="0x190C" />
-        <Animation Name="object_kitan_Anim_002770" Offset="0x2770" />
+        <Animation Name="object_kitan_Anim_000CE8" Offset="0xCE8" /> <!-- Original name is "kt_hohoho" -->
+        <Animation Name="object_kitan_Anim_00190C" Offset="0x190C" /> <!-- Original name is "kt_laugh" -->
+        <Animation Name="object_kitan_Anim_002770" Offset="0x2770" /> <!-- Original name is "kt_wait" -->
         <DList Name="object_kitan_DL_004C40" Offset="0x4C40" />
         <DList Name="object_kitan_DL_004DF0" Offset="0x4DF0" />
         <DList Name="object_kitan_DL_005160" Offset="0x5160" />

--- a/assets/xml/objects/object_knight.xml
+++ b/assets/xml/objects/object_knight.xml
@@ -1,49 +1,57 @@
 ﻿<Root>
+    <!--
+        Assets for Igos du Ikana and his aides.
+        A note about the original animation names; in MM3D, they split them up into two into two nearly-identical but
+        incompatible sets of animations. For example, there is an animation named "nsk_king_front_damage" for the king,
+        and an animation named "nsk_zako_front_damage" for the aides. In the original game, the animations are used
+        for *both* the king and his aides, so for the animation names, I just removed "king" or "zako" from the name
+        under the assumption that Grezzo were probably the ones who added the qualifier to the names.
+    -->
     <File Name="object_knight" Segment="6">
-        <Animation Name="object_knight_Anim_0005A8" Offset="0x5A8" />
-        <Animation Name="object_knight_Anim_0009E0" Offset="0x9E0" />
-        <Animation Name="object_knight_Anim_000D9C" Offset="0xD9C" />
-        <Animation Name="object_knight_Anim_001CDC" Offset="0x1CDC" />
-        <Animation Name="object_knight_Anim_002174" Offset="0x2174" />
-        <Animation Name="object_knight_Anim_003008" Offset="0x3008" />
-        <Animation Name="object_knight_Anim_0031F0" Offset="0x31F0" />
-        <Animation Name="object_knight_Anim_003650" Offset="0x3650" />
-        <Animation Name="object_knight_Anim_0040E0" Offset="0x40E0" />
-        <Animation Name="object_knight_Anim_004620" Offset="0x4620" />
-        <Animation Name="object_knight_Anim_004974" Offset="0x4974" />
-        <Animation Name="object_knight_Anim_005D30" Offset="0x5D30" />
-        <Animation Name="object_knight_Anim_005E78" Offset="0x5E78" />
-        <Animation Name="object_knight_Anim_006754" Offset="0x6754" />
-        <Animation Name="object_knight_Anim_006EF8" Offset="0x6EF8" />
-        <Animation Name="object_knight_Anim_0079D4" Offset="0x79D4" />
-        <Animation Name="object_knight_Anim_008390" Offset="0x8390" />
-        <Animation Name="object_knight_Anim_008524" Offset="0x8524" />
-        <Animation Name="object_knight_Anim_0089E4" Offset="0x89E4" />
-        <Animation Name="object_knight_Anim_008D80" Offset="0x8D80" />
-        <Animation Name="object_knight_Anim_009538" Offset="0x9538" />
-        <Animation Name="object_knight_Anim_009D8C" Offset="0x9D8C" />
-        <Animation Name="object_knight_Anim_00A530" Offset="0xA530" />
-        <Animation Name="object_knight_Anim_00A88C" Offset="0xA88C" />
-        <Animation Name="object_knight_Anim_00AB68" Offset="0xAB68" />
-        <Animation Name="object_knight_Anim_00AFAC" Offset="0xAFAC" />
-        <Animation Name="object_knight_Anim_00B5D4" Offset="0xB5D4" />
-        <Animation Name="object_knight_Anim_00BCF4" Offset="0xBCF4" />
-        <Animation Name="object_knight_Anim_00C384" Offset="0xC384" />
-        <Animation Name="object_knight_Anim_00C7F0" Offset="0xC7F0" />
-        <Animation Name="object_knight_Anim_00CDE0" Offset="0xCDE0" />
-        <Animation Name="object_knight_Anim_00D870" Offset="0xD870" />
-        <Animation Name="object_knight_Anim_00DDCC" Offset="0xDDCC" />
-        <Animation Name="object_knight_Anim_00E15C" Offset="0xE15C" />
-        <Animation Name="object_knight_Anim_00E45C" Offset="0xE45C" />
-        <Animation Name="object_knight_Anim_00E7F4" Offset="0xE7F4" />
-        <Animation Name="object_knight_Anim_00EA90" Offset="0xEA90" />
-        <Animation Name="object_knight_Anim_00EF44" Offset="0xEF44" />
-        <Animation Name="object_knight_Anim_00F90C" Offset="0xF90C" />
-        <Animation Name="object_knight_Anim_00FC78" Offset="0xFC78" />
-        <Animation Name="object_knight_Anim_01024C" Offset="0x1024C" />
-        <Animation Name="object_knight_Anim_010E98" Offset="0x10E98" />
-        <Animation Name="object_knight_Anim_011298" Offset="0x11298" />
-        <Animation Name="object_knight_Anim_011AAC" Offset="0x11AAC" />
+        <Animation Name="object_knight_Anim_0005A8" Offset="0x5A8" /> <!-- Original name is probably "nsk_aramaD" -->
+        <Animation Name="object_knight_Anim_0009E0" Offset="0x9E0" /> <!-- Original name is probably "nsk_araraD" -->
+        <Animation Name="object_knight_Anim_000D9C" Offset="0xD9C" /> <!-- Original name is probably "nsk_back_damage" -->
+        <Animation Name="object_knight_Anim_001CDC" Offset="0x1CDC" /> <!-- Original name is probably "nsk_back_down" -->
+        <Animation Name="object_knight_Anim_002174" Offset="0x2174" /> <!-- Original name is probably "nsk_back_jump" -->
+        <Animation Name="object_knight_Anim_003008" Offset="0x3008" /> <!-- Original name is probably "nsk_bunri" -->
+        <Animation Name="object_knight_Anim_0031F0" Offset="0x31F0" /> <!-- Original name is probably "nsk_defend" -->
+        <Animation Name="object_knight_Anim_003650" Offset="0x3650" /> <!-- Original name is probably "nsk_fighting_run" -->
+        <Animation Name="object_knight_Anim_0040E0" Offset="0x40E0" /> <!-- Original name is probably "nsk_fighting_wait" -->
+        <Animation Name="object_knight_Anim_004620" Offset="0x4620" /> <!-- Original name is probably "nsk_fighting_walk" -->
+        <Animation Name="object_knight_Anim_004974" Offset="0x4974" /> <!-- Original name is probably "nsk_front_damage" -->
+        <Animation Name="object_knight_Anim_005D30" Offset="0x5D30" /> <!-- Original name is probably "nsk_front_down" -->
+        <Animation Name="object_knight_Anim_005E78" Offset="0x5E78" /> <!-- Original name is probably "nsk_furufuruD" -->
+        <Animation Name="object_knight_Anim_006754" Offset="0x6754" /> <!-- Original name is probably "nsk_gabaBD" -->
+        <Animation Name="object_knight_Anim_006EF8" Offset="0x6EF8" /> <!-- Original name is probably "nsk_gabaD" -->
+        <Animation Name="object_knight_Anim_0079D4" Offset="0x79D4" /> <!-- Original name is probably "nsk_gattai" -->
+        <Animation Name="object_knight_Anim_008390" Offset="0x8390" /> <!-- Original name is probably "nsk_goD" -->
+        <Animation Name="object_knight_Anim_008524" Offset="0x8524" /> <!-- Original name is probably "nsk_guardA" -->
+        <Animation Name="object_knight_Anim_0089E4" Offset="0x89E4" /> <!-- Original name is probably "nsk_guardB" -->
+        <Animation Name="object_knight_Anim_008D80" Offset="0x8D80" /> <!-- Original name is probably "nsk_haiteru" -->
+        <Animation Name="object_knight_Anim_009538" Offset="0x9538" /> <!-- Original name is probably "nsk_haku" -->
+        <Animation Name="object_knight_Anim_009D8C" Offset="0x9D8C" /> <!-- Original name is probably "nsk_jakinD" -->
+        <Animation Name="object_knight_Anim_00A530" Offset="0xA530" /> <!-- Original name is probably "nsk_jakinTOsekiD" -->
+        <Animation Name="object_knight_Anim_00A88C" Offset="0xA88C" /> <!-- Original name is probably "nsk_jidandaD" -->
+        <Animation Name="object_knight_Anim_00AB68" Offset="0xAB68" /> <!-- Original name is probably "nsk_jump" -->
+        <Animation Name="object_knight_Anim_00AFAC" Offset="0xAFAC" /> <!-- Original name is probably "nsk_jump_kiru" -->
+        <Animation Name="object_knight_Anim_00B5D4" Offset="0xB5D4" /> <!-- Original name is probably "nsk_jump_kiru_end" -->
+        <Animation Name="object_knight_Anim_00BCF4" Offset="0xBCF4" /> <!-- Original name is probably "nsk_koteL" -->
+        <Animation Name="object_knight_Anim_00C384" Offset="0xC384" /> <!-- Original name is probably "nsk_koteR" -->
+        <Animation Name="object_knight_Anim_00C7F0" Offset="0xC7F0" /> <!-- Original name is probably "nsk_kunekuneaD" -->
+        <Animation Name="object_knight_Anim_00CDE0" Offset="0xCDE0" /> <!-- Original name is probably "nsk_laugh" -->
+        <Animation Name="object_knight_Anim_00D870" Offset="0xD870" /> <!-- Original name is probably "nsk_laughD" -->
+        <Animation Name="object_knight_Anim_00DDCC" Offset="0xDDCC" /> <!-- Original name is probably "nsk_march" -->
+        <Animation Name="object_knight_Anim_00E15C" Offset="0xE15C" /> <!-- Original name is probably "nsk_modoru" -->
+        <Animation Name="object_knight_Anim_00E45C" Offset="0xE45C" /> <!-- Original name is probably "nsk_muzumuzuwalk" -->
+        <Animation Name="object_knight_Anim_00E7F4" Offset="0xE7F4" /> <!-- Original name is probably "nsk_nunuBD" -->
+        <Animation Name="object_knight_Anim_00EA90" Offset="0xEA90" /> <!-- Original name is probably "nsk_nunuD" -->
+        <Animation Name="object_knight_Anim_00EF44" Offset="0xEF44" /> <!-- Original name is probably "nsk_side_walk" -->
+        <Animation Name="object_knight_Anim_00F90C" Offset="0xF90C" /> <!-- Original name is probably "nsk_sonicgiri" -->
+        <Animation Name="object_knight_Anim_00FC78" Offset="0xFC78" /> <!-- Original name is probably "nsk_suwariwaitD" -->
+        <Animation Name="object_knight_Anim_01024C" Offset="0x1024C" /> <!-- Original name is probably "nsk_suwaru02D" -->
+        <Animation Name="object_knight_Anim_010E98" Offset="0x10E98" /> <!-- Original name is probably "nsk_suwaruD" -->
+        <Animation Name="object_knight_Anim_011298" Offset="0x11298" /> <!-- Original name is probably "nsk_tategiri" -->
+        <Animation Name="object_knight_Anim_011AAC" Offset="0x11AAC" /> <!-- Original name is probably "nsk_tategiri_kaburu" -->
         <DList Name="object_knight_DL_012400" Offset="0x12400" />
         <Texture Name="object_knight_Tex_012760" OutName="tex_012760" Format="rgba16" Width="16" Height="16" Offset="0x12760" />
         <Texture Name="object_knight_Tex_012960" OutName="tex_012960" Format="rgba16" Width="16" Height="16" Offset="0x12960" />
@@ -101,14 +109,14 @@
         <Array Name="object_knight_Vtx_018BD0" Count="18" Offset="0x18BD0">
             <Vtx/>
         </Array>
-        <DList Name="object_knight_DL_018CF0" Offset="0x18CF0" />
-        <DList Name="object_knight_DL_018DE0" Offset="0x18DE0" />
+        <DList Name="object_knight_DL_018CF0" Offset="0x18CF0" /> <!-- Original name is "w2_hikari_naname_modelT" -->
+        <DList Name="object_knight_DL_018DE0" Offset="0x18DE0" /> <!-- Original name is "w2_hikari_naname2_modelT" -->
         <DList Name="object_knight_DL_018E50" Offset="0x18E50" />
         <Texture Name="object_knight_Tex_018E58" OutName="tex_018E58" Format="ia8" Width="16" Height="16" Offset="0x18E58" />
         <Texture Name="object_knight_Tex_018F58" OutName="tex_018F58" Format="ia16" Width="16" Height="32" Offset="0x18F58" />
         <TextureAnimation Name="object_knight_Matanimheader_019360" Offset="0x19360" />
         <DList Name="object_knight_DL_0193A8" Offset="0x193A8" />
-        <DList Name="object_knight_DL_0193B0" Offset="0x193B0" />
+        <DList Name="object_knight_DL_0193B0" Offset="0x193B0" /> <!-- Original name is "w2_ikn_katen_model" -->
         <Texture Name="object_knight_Tex_019470" OutName="tex_019470" Format="rgba16" Width="4" Height="4" Offset="0x19470" />
         <Texture Name="object_knight_Tex_019490" OutName="tex_019490" Format="i8" Width="32" Height="64" Offset="0x19490" />
         <DList Name="object_knight_DL_01D380" Offset="0x1D380" />
@@ -201,11 +209,11 @@
         <Limb Name="object_knight_Standardlimb_0202EC" Type="Standard" EnumName="OBJECT_KNIGHT_2_LIMB_1B" Offset="0x202EC" />
         <Limb Name="object_knight_Standardlimb_0202F8" Type="Standard" EnumName="OBJECT_KNIGHT_2_LIMB_1C" Offset="0x202F8" />
         <Skeleton Name="object_knight_Skel_020374" Type="Flex" LimbType="Standard" LimbNone="OBJECT_KNIGHT_2_LIMB_NONE" LimbMax="OBJECT_KNIGHT_2_LIMB_MAX" EnumName="ObjectKnight2Limb" Offset="0x20374" />
-        <Animation Name="object_knight_Anim_020950" Offset="0x20950" />
-        <Animation Name="object_knight_Anim_02105C" Offset="0x2105C" />
-        <Animation Name="object_knight_Anim_021B10" Offset="0x21B10" />
-        <Animation Name="object_knight_Anim_021E34" Offset="0x21E34" />
-        <Animation Name="object_knight_Anim_022728" Offset="0x22728" />
-        <Animation Name="object_knight_Anim_022CAC" Offset="0x22CAC" />
+        <Animation Name="object_knight_Anim_020950" Offset="0x20950" /> <!-- Original name is probably "nsk_tategiri_tame" -->
+        <Animation Name="object_knight_Anim_02105C" Offset="0x2105C" /> <!-- Original name is probably "nsk_towaitBD" -->
+        <Animation Name="object_knight_Anim_021B10" Offset="0x21B10" /> <!-- Original name is probably "nsk_walkD" -->
+        <Animation Name="object_knight_Anim_021E34" Offset="0x21E34" /> <!-- Original name is probably "nsk_whyD" -->
+        <Animation Name="object_knight_Anim_022728" Offset="0x22728" /> <!-- Original name is probably "nsk_yokogiri" -->
+        <Animation Name="object_knight_Anim_022CAC" Offset="0x22CAC" /> <!-- Original name is probably "nsk_yokogiri_kime" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kumo30.xml
+++ b/assets/xml/objects/object_kumo30.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_kumo30" Segment="6">
-        <DList Name="object_kumo30_DL_000A50" Offset="0xA50" />
-        <DList Name="object_kumo30_DL_000C98" Offset="0xC98" />
+        <DList Name="object_kumo30_DL_000A50" Offset="0xA50" /> <!-- Original name is "konpeki_mist1_FT_model" -->
+        <DList Name="object_kumo30_DL_000C98" Offset="0xC98" /> <!-- Original name is "konpeki_mist3_FT_model" -->
         <Texture Name="object_kumo30_Tex_000E80" OutName="tex_000E80" Format="i8" Width="64" Height="64" Offset="0xE80" />
         <Texture Name="object_kumo30_Tex_001E80" OutName="tex_001E80" Format="i4" Width="32" Height="32" Offset="0x1E80" />
         <Texture Name="object_kumo30_Tex_002080" OutName="tex_002080" Format="i4" Width="64" Height="64" Offset="0x2080" />
         <TextureAnimation Name="object_kumo30_Matanimheader_002890" Offset="0x2890" />
-        <DList Name="object_kumo30_DL_002A40" Offset="0x2A40" />
+        <DList Name="object_kumo30_DL_002A40" Offset="0x2A40" /> <!-- Original name is "z2_30_kumo_model" -->
         <Texture Name="object_kumo30_Tex_002B58" OutName="tex_002B58" Format="i8" Width="32" Height="32" Offset="0x2B58" />
         <Texture Name="object_kumo30_Tex_002F58" OutName="tex_002F58" Format="i8" Width="32" Height="32" Offset="0x2F58" />
         <TextureAnimation Name="object_kumo30_Matanimheader_003368" Offset="0x3368" />

--- a/assets/xml/objects/object_kusa.xml
+++ b/assets/xml/objects/object_kusa.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_kusa" Segment="6">
-        <DList Name="gKusaSprout" Offset="0x140" />
-        <DList Name="gKusaStump" Offset="0x2E0" />
+        <DList Name="gKusaSprout" Offset="0x140" /> <!-- Original name is "obj_kusa01_model" -->
+        <DList Name="gKusaStump" Offset="0x2E0" /> <!-- Original name is "obj_kusa03_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kz.xml
+++ b/assets/xml/objects/object_kz.xml
@@ -1,17 +1,17 @@
 ﻿<Root>
     <File Name="object_kz" Segment="6">
-        <Animation Name="object_kz_Anim_0003CC" Offset="0x3CC" />
-        <Animation Name="object_kz_Anim_000F5C" Offset="0xF5C" />
-        <Animation Name="object_kz_Anim_001390" Offset="0x1390" />
-        <Animation Name="object_kz_Anim_001578" Offset="0x1578" />
-        <Animation Name="object_kz_Anim_001E9C" Offset="0x1E9C" />
-        <Animation Name="object_kz_Anim_002730" Offset="0x2730" />
-        <Animation Name="object_kz_Anim_002BA0" Offset="0x2BA0" />
-        <Animation Name="object_kz_Anim_003A3C" Offset="0x3A3C" />
-        <Animation Name="object_kz_Anim_0043E4" Offset="0x43E4" />
-        <Animation Name="object_kz_Anim_004860" Offset="0x4860" />
-        <Animation Name="object_kz_Anim_005644" Offset="0x5644" />
-        <Animation Name="object_kz_Anim_0058B8" Offset="0x58B8" />
+        <Animation Name="object_kz_Anim_0003CC" Offset="0x3CC" /> <!-- Original name is "kz_attackA" -->
+        <Animation Name="object_kz_Anim_000F5C" Offset="0xF5C" /> <!-- Original name is "kz_attackB" -->
+        <Animation Name="object_kz_Anim_001390" Offset="0x1390" /> <!-- Original name is "kz_back_ten" -->
+        <Animation Name="object_kz_Anim_001578" Offset="0x1578" /> <!-- Original name is "kz_defense" -->
+        <Animation Name="object_kz_Anim_001E9C" Offset="0x1E9C" /> <!-- Original name is "kz_doron" -->
+        <Animation Name="object_kz_Anim_002730" Offset="0x2730" /> <!-- Original name is "kz_down" -->
+        <Animation Name="object_kz_Anim_002BA0" Offset="0x2BA0" /> <!-- Original name is "kz_downwait" -->
+        <Animation Name="object_kz_Anim_003A3C" Offset="0x3A3C" /> <!-- Original name is "kz_downwake" -->
+        <Animation Name="object_kz_Anim_0043E4" Offset="0x43E4" /> <!-- Original name is "kz_getout" -->
+        <Animation Name="object_kz_Anim_004860" Offset="0x4860" /> <!-- Original name is "kz_hit" -->
+        <Animation Name="object_kz_Anim_005644" Offset="0x5644" /> <!-- Original name is "kz_kime" -->
+        <Animation Name="object_kz_Anim_0058B8" Offset="0x58B8" /> <!-- Original name is "kz_run" -->
 
         <Texture Name="object_kz_TLUT_0058D0" OutName="tlut_0058D0" Format="rgba16" Width="16" Height="16" Offset="0x58D0" />
         <Texture Name="object_kz_Tex_005AD0" OutName="tex_005AD0" Format="ci8" Width="8" Height="8" Offset="0x5AD0" />
@@ -82,12 +82,12 @@
         <Limb Name="object_kz_Standardlimb_00D7C0" Type="Standard" EnumName="KAIZOKU_LIMB_17" Offset="0xD7C0" />
         <Skeleton Name="gKaizokuSkel" Type="Flex" LimbType="Standard" LimbNone="KAIZOKU_LIMB_NONE" LimbMax="KAIZOKU_LIMB_MAX" EnumName="KaizokuLimb" Offset="0xD828" />
 
-        <Animation Name="object_kz_Anim_00DBE4" Offset="0xDBE4" />
-        <Animation Name="object_kz_Anim_00E1C8" Offset="0xE1C8" />
-        <Animation Name="object_kz_Anim_00E8BC" Offset="0xE8BC" />
-        <Animation Name="object_kz_Anim_00ED1C" Offset="0xED1C" />
-        <Animation Name="object_kz_Anim_00EF9C" Offset="0xEF9C" />
-        <Animation Name="object_kz_Anim_00F288" Offset="0xF288" />
-        <Animation Name="object_kz_Anim_00F8E4" Offset="0xF8E4" />
+        <Animation Name="object_kz_Anim_00DBE4" Offset="0xDBE4" /> <!-- Original name is "kz_side_walk" -->
+        <Animation Name="object_kz_Anim_00E1C8" Offset="0xE1C8" /> <!-- Original name is "kz_start" -->
+        <Animation Name="object_kz_Anim_00E8BC" Offset="0xE8BC" /> <!-- Original name is "kz_syuta" -->
+        <Animation Name="object_kz_Anim_00ED1C" Offset="0xED1C" /> <!-- Original name is "kz_syutawait" -->
+        <Animation Name="object_kz_Anim_00EF9C" Offset="0xEF9C" /> <!-- Original name is "kz_talk" -->
+        <Animation Name="object_kz_Anim_00F288" Offset="0xF288" /> <!-- Original name is "kz_togetout" -->
+        <Animation Name="object_kz_Anim_00F8E4" Offset="0xF8E4" /> <!-- Original name is "kz_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_kzsaku.xml
+++ b/assets/xml/objects/object_kzsaku.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_kzsaku" Segment="6">
-        <DList Name="object_kzsaku_DL_000040" Offset="0x40" />
+        <DList Name="object_kzsaku_DL_000040" Offset="0x40" /> <!-- Original name is "kz_saku_model" -->
         <Texture Name="object_kzsaku_Tex_0000D0" OutName="tex_0000D0" Format="ia8" Width="32" Height="128" Offset="0xD0" />
-        <Collision Name="object_kzsaku_Colheader_001118" Offset="0x1118" />
+        <Collision Name="object_kzsaku_Colheader_001118" Offset="0x1118" /> <!-- Original name is "z2_30_saku_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_shn.xml
+++ b/assets/xml/objects/object_shn.xml
@@ -80,7 +80,7 @@
 
         <!-- Burly Guy Animations -->
         <Animation Name="gBurlyGuyHeadScratchEndAnim" Offset="0xD2F8" /> <!-- Original name is "shn_w02TOw01" ("wait02 to wait01"?) -->
-        <Animation Name="gBurlyGuyEmptyAnim" Offset="0xD3AC" /> <!-- Original name is "shn_wait". Unused and one frame long -->
+        <Animation Name="gBurlyGuyEmptyAnim" Offset="0xD3AC" /> <!-- Unused and one frame long. Original name is "shn_wait" -->
         <Animation Name="gBurlyGuyHandsOnTableAnim" Offset="0xD9D0" /> <!-- Original name is "shn_wait01" -->
         <Animation Name="gBurlyGuyHeadScratchLoopAnim" Offset="0xDFEC" /> <!-- Original name is "shn_wait02" -->
         <Animation Name="gBurlyGuyChinScratchAnim" Offset="0xE6C4" /><!-- Original name is "shn_wait03" -->

--- a/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.c
+++ b/src/overlays/actors/ovl_Dm_Opstage/z_dm_opstage.c
@@ -47,7 +47,7 @@ void DmOpstage_Init(Actor* thisx, PlayState* play) {
 
     if (DMOPSTAGE_GET_TYPE(&this->dyna.actor) == DMOPSTAGE_TYPE_GROUND) {
         DynaPolyActor_Init(&this->dyna, 0);
-        DynaPolyActor_LoadMesh(play, &this->dyna, &gKeikokuDemoFloorColliderHeader);
+        DynaPolyActor_LoadMesh(play, &this->dyna, &gKeikokuDemoFloorCol);
     }
 
     if (DMOPSTAGE_GET_TYPE(&this->dyna.actor) > DMOPSTAGE_TYPE_GROUND) {


### PR DESCRIPTION
Some notes:
- In `object_kamejima`, there's a third, unused piece of collision. MM3D *also* has three collision files, and while two of them map to the two used files exactly as expected, this third one doesn't really line up. However, I put in there that it may *possibly* be named after that third file in MM3D, but it's definitely shaky; I'm fine with removing this.
- While I was in `object_keikoku_demo`, I changed one instance of `ColliderHeader` to `Col`.
- In `object_kin2_obj`, I changed some whitespace to make some empty DLs more closely match the non-empty DL they are associated with.
- In `object_knight`, the animation names in MM3D are a bit weird; see the comment at the top of the file for more information.
- I didn't put any names for `object_kujiya`, because that object is done in a completely different way in MM3D. In MM, each part of the lottery shop is a single DL, and then the actor is responsible for drawing them at once. In MM3D, the entire lottery shop is one single model named `Lottery_shop`.

This is also going to conflict with #1364 if it's merged; I'm totally fine handling the conflict if that one gets merged first.