### PR TITLE
Name player's generic `actionVar`s

### DIFF
--- a/include/z64player.h
+++ b/include/z64player.h
@@ -1221,8 +1221,8 @@ typedef struct Player {
     /* 0xADE */ u8 unk_ADE;
     /* 0xADF */ s8 unk_ADF[4]; // Circular buffer used for testing for triggering a quickspin
     /* 0xAE3 */ s8 unk_AE3[4]; // Circular buffer used for ?
-    /* 0xAE7 */ s8 unk_AE7; // a timer, used as an index for multiple kinds of animations too, room index?, etc
-    /* 0xAE8 */ s16 unk_AE8; // multipurpose timer
+    /* 0xAE7 */ s8 actionVar1; // context dependent variable that has different meanings depending on what action is currently running
+    /* 0xAE8 */ s16 actionVar2; // context dependent variable that has different meanings depending on what action is currently running
     /* 0xAEC */ f32 unk_AEC;
     /* 0xAF0 */ union {
                     Vec3f unk_AF0[2];

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -369,13 +369,13 @@ void func_80122F28(Player* player) {
 s32 func_80122F9C(PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    return (player->stateFlags2 & PLAYER_STATE2_80000) && (player->unk_AE7 == 2);
+    return (player->stateFlags2 & PLAYER_STATE2_80000) && (player->actionVar1 == 2);
 }
 
 s32 func_80122FCC(PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    return (player->stateFlags2 & PLAYER_STATE2_80000) && ((player->unk_AE7 == 1) || (player->unk_AE7 == 3));
+    return (player->stateFlags2 & PLAYER_STATE2_80000) && ((player->actionVar1 == 1) || (player->actionVar1 == 3));
 }
 
 void func_8012300C(PlayState* play, s32 arg1) {
@@ -389,15 +389,15 @@ void func_8012301C(Actor* thisx, PlayState* play2) {
     PlayState* play = play2;
     Player* this = (Player*)thisx;
 
-    this->unk_AE7++;
+    this->actionVar1++;
 
-    if (this->unk_AE7 == 2) {
+    if (this->actionVar1 == 2) {
         s16 objectId = gPlayerFormObjectIndices[GET_PLAYER_FORM];
 
         gActorOverlayTable[ACTOR_PLAYER].initInfo->objectId = objectId;
         func_8012F73C(&play->objectCtx, this->actor.objBankIndex, objectId);
         this->actor.objBankIndex = Object_GetIndex(&play->objectCtx, GAMEPLAY_KEEP);
-    } else if (this->unk_AE7 >= 3) {
+    } else if (this->actionVar1 >= 3) {
         s32 objBankIndex = Object_GetIndex(&play->objectCtx, gActorOverlayTable[ACTOR_PLAYER].initInfo->objectId);
 
         if (Object_IsLoaded(&play->objectCtx, objBankIndex)) {
@@ -3744,7 +3744,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList1, G
             }
         }
 
-        if ((player->stateFlags1 & (PLAYER_STATE1_2 | PLAYER_STATE1_100)) && (player->unk_AE8 != 0)) {
+        if ((player->stateFlags1 & (PLAYER_STATE1_2 | PLAYER_STATE1_100)) && (player->actionVar2 != 0)) {
             static Vec3f D_801C0E40[PLAYER_FORM_MAX] = {
                 { 0.0f, 0.0f, 0.0f },        // PLAYER_FORM_FIERCE_DEITY
                 { -578.3f, -1100.9f, 0.0f }, // PLAYER_FORM_GORON
@@ -3764,7 +3764,7 @@ void Player_PostLimbDrawGameplay(PlayState* play, s32 limbIndex, Gfx** dList1, G
             }
 
             gSPMatrix(POLY_XLU_DISP++, Matrix_NewMtx(play->state.gfxCtx), G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
-            gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 255, (u8)player->unk_AE8);
+            gDPSetEnvColor(POLY_XLU_DISP++, 0, 0, 255, (u8)player->actionVar2);
             gSPDisplayList(POLY_XLU_DISP++, gameplay_keep_DL_054C90);
 
             Matrix_Pop();

--- a/src/overlays/actors/ovl_Boss_03/z_boss_03.c
+++ b/src/overlays/actors/ovl_Boss_03/z_boss_03.c
@@ -685,7 +685,7 @@ void Boss03_ChasePlayer(Boss03* this, PlayState* play) {
          (player->actor.shape.feetPos[0].y >= WATER_HEIGHT + 8.0f)) ||
         (this->workTimer[WORK_TIMER_CURRENT_ACTION] == 0)) {
         if (&this->actor == player->actor.parent) {
-            player->unk_AE8 = 101;
+            player->actionVar2 = 101;
             player->actor.parent = NULL;
             player->csMode = PLAYER_CSMODE_NONE;
         }
@@ -781,7 +781,7 @@ void Boss03_CatchPlayer(Boss03* this, PlayState* play) {
          (player->actor.shape.feetPos[FOOT_LEFT].y >= WATER_HEIGHT + 8.0f)) ||
         (this->workTimer[WORK_TIMER_CURRENT_ACTION] == 0)) {
         if (&this->actor == player->actor.parent) {
-            player->unk_AE8 = 101;
+            player->actionVar2 = 101;
             player->actor.parent = NULL;
             player->csMode = PLAYER_CSMODE_NONE;
             Play_DisableMotionBlur();
@@ -909,7 +909,7 @@ void Boss03_ChewPlayer(Boss03* this, PlayState* play) {
     // Stop chewing when the timer runs out
     if (this->workTimer[WORK_TIMER_CURRENT_ACTION] == 0) {
         if (&this->actor == player->actor.parent) {
-            player->unk_AE8 = 101;
+            player->actionVar2 = 101;
             player->actor.parent = NULL;
             player->csMode = PLAYER_CSMODE_NONE;
             Play_DisableMotionBlur();
@@ -1751,7 +1751,7 @@ void Boss03_SetupStunned(Boss03* this, PlayState* play) {
     }
 
     if (&this->actor == player->actor.parent) {
-        player->unk_AE8 = 101;
+        player->actionVar2 = 101;
         player->actor.parent = NULL;
         player->csMode = PLAYER_CSMODE_NONE;
         Play_DisableMotionBlur();
@@ -1903,7 +1903,7 @@ void Boss03_UpdateCollision(Boss03* this, PlayState* play) {
                     Boss03_PlayUnderwaterSfx(&this->actor.projectedPos, NA_SE_EN_KONB_DAMAGE_OLD);
 
                     if (&this->actor == player->actor.parent) {
-                        player->unk_AE8 = 101;
+                        player->actionVar2 = 101;
                         player->actor.parent = NULL;
                         player->csMode = PLAYER_CSMODE_NONE;
                         Play_DisableMotionBlur();

--- a/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
+++ b/src/overlays/actors/ovl_Door_Ana/z_door_ana.c
@@ -132,7 +132,7 @@ void DoorAna_WaitOpen(DoorAna* this, PlayState* play) {
     if (Math_StepToF(&this->actor.scale.x, 0.01f, 0.001f)) {
         if ((this->actor.targetMode != TARGET_MODE_0) && (play->transitionTrigger == TRANS_TRIGGER_OFF) &&
             (play->transitionMode == TRANS_MODE_OFF) && (player->stateFlags1 & PLAYER_STATE1_80000000) &&
-            (player->unk_AE7 == 0)) {
+            (player->actionVar1 == 0)) {
 
             if (grottoType == DOORANA_TYPE_VISIBLE_SCENE_EXIT) {
                 s32 exitIndex = DOORANA_GET_EXIT_INDEX(&this->actor);

--- a/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
+++ b/src/overlays/actors/ovl_En_Bigokuta/z_en_bigokuta.c
@@ -168,7 +168,7 @@ void EnBigokuta_ShootPlayer(EnBigokuta* this, PlayState* play) {
 
     if (&this->picto.actor == player->actor.parent) {
         player->actor.parent = NULL;
-        player->unk_AE8 = 100;
+        player->actionVar2 = 100;
         player->actor.velocity.y = 0.0f;
         player->actor.world.pos.x += 20.0f * Math_SinS(this->picto.actor.home.rot.y);
         player->actor.world.pos.z += 20.0f * Math_CosS(this->picto.actor.home.rot.y);
@@ -309,7 +309,7 @@ void EnBigokuta_SuckInPlayer(EnBigokuta* this, PlayState* play) {
         this->timer++;
     }
 
-    player->unk_AE8 = 0;
+    player->actionVar2 = 0;
     Math_Vec3f_Copy(&player->actor.world.pos, &this->playerPos);
     if (Math_Vec3f_StepTo(&player->actor.world.pos, &this->playerHoldPos, sqrtf(this->timer) * 5.0f) < 0.1f) {
         s16 rotY = this->picto.actor.shape.rot.y;

--- a/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
+++ b/src/overlays/actors/ovl_En_Bigslime/z_en_bigslime.c
@@ -729,7 +729,7 @@ void EnBigslime_SetPlayerParams(EnBigslime* this, PlayState* play) {
 
     if (player->stateFlags2 & PLAYER_STATE2_80) {
         player->actor.parent = NULL;
-        player->unk_AE8 = 100;
+        player->actionVar2 = 100;
         func_800B8D98(play, &this->actor, 10.0f, this->actor.world.rot.y, 10.0f);
     }
 }
@@ -1528,7 +1528,7 @@ void EnBigslime_CutsceneGrabPlayer(EnBigslime* this, PlayState* play) {
     s32 i;
     s32 j;
 
-    player->unk_AE8 = 0;
+    player->actionVar2 = 0;
     Math_ScaledStepToS(&this->gekkoRot.x, 0, 0x400);
     EnBigslime_UpdateCameraGrabPlayer(this, play);
     if (this->grabPlayerTimer > 0) {
@@ -1577,7 +1577,7 @@ void EnBigslime_AttackPlayerInBigslime(EnBigslime* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 pitch = this->scaleFactor * 0x3333; // polar (zenith) angle
 
-    player->unk_AE8 = 0;
+    player->actionVar2 = 0;
     Math_ScaledStepToS(&this->gekkoRot.x, 0, 0x400);
     EnBigslime_UpdateCameraGrabPlayer(this, play);
     EnBigslime_UpdateWavySurface(this);
@@ -1710,7 +1710,7 @@ void EnBigslime_WindupThrowPlayer(EnBigslime* this, PlayState* play) {
         if (this->windupPunchTimer == -5) {
             if (player->stateFlags2 & PLAYER_STATE2_80) {
                 player->actor.parent = NULL;
-                player->unk_AE8 = 100;
+                player->actionVar2 = 100;
             }
 
             player->actor.velocity.y = 0.0f;

--- a/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
+++ b/src/overlays/actors/ovl_En_Dinofos/z_en_dinofos.c
@@ -450,7 +450,7 @@ s32 func_8089AE00(EnDinofos* this, PlayState* play) {
         return true;
     }
 
-    if ((GET_PLAYER_FORM == PLAYER_FORM_GORON) && (player->actor.velocity.y < -5.0f) && (player->unk_AE7 == 1) &&
+    if ((GET_PLAYER_FORM == PLAYER_FORM_GORON) && (player->actor.velocity.y < -5.0f) && (player->actionVar1 == 1) &&
         (this->unk_28B == 0)) {
         this->unk_28B = 1;
         for (i = 0; i < ARRAY_COUNT(this->colliderJntSphElement) - 3; i++) {

--- a/src/overlays/actors/ovl_En_Dragon/z_en_dragon.c
+++ b/src/overlays/actors/ovl_En_Dragon/z_en_dragon.c
@@ -548,7 +548,7 @@ void EnDragon_Grab(EnDragon* this, PlayState* play) {
 
         play->unk_18770(play, player);
         player->actor.parent = &this->actor;
-        player->unk_AE8 = 50;
+        player->actionVar2 = 50;
         this->action = DEEP_PYTHON_ACTION_GRAB;
         Actor_PlaySfx(&this->actor, NA_SE_EN_UTSUBO_EAT);
         EnDragon_SetupAttack(this);
@@ -626,7 +626,7 @@ void EnDragon_Attack(EnDragon* this, PlayState* play) {
         this->grabWaitTimer = 30;
         CutsceneManager_Stop(this->grabCsId);
         if (player->stateFlags2 & PLAYER_STATE2_80) {
-            player->unk_AE8 = 100;
+            player->actionVar2 = 100;
         }
 
         this->actor.flags &= ~ACTOR_FLAG_100000;

--- a/src/overlays/actors/ovl_En_Raf/z_en_raf.c
+++ b/src/overlays/actors/ovl_En_Raf/z_en_raf.c
@@ -319,7 +319,7 @@ void EnRaf_Idle(EnRaf* this, PlayState* play) {
             if (player->transformation == PLAYER_FORM_GORON) {
                 this->grabTarget = EN_RAF_GRAB_TARGET_GORON_PLAYER;
             } else {
-                player->unk_AE8 = 50;
+                player->actionVar2 = 50;
             }
 
             this->playerRotYWhenGrabbed = player->actor.world.rot.y;
@@ -455,7 +455,7 @@ void EnRaf_Chew(EnRaf* this, PlayState* play) {
             case EN_RAF_GRAB_TARGET_GORON_PLAYER:
                 if (this->chewCount > (BREG(54) + 4)) {
                     player->actor.parent = NULL;
-                    player->unk_AE8 = 1000;
+                    player->actionVar2 = 1000;
                     EnRaf_Explode(this, play);
                 }
                 break;

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -463,7 +463,7 @@ void EnRailgibud_Grab(EnRailgibud* this, PlayState* play) {
             if (!(player->stateFlags2 & PLAYER_STATE2_80) || (player->unk_B62 != 0)) {
                 if ((player->unk_B62 != 0) && (player->stateFlags2 & PLAYER_STATE2_80)) {
                     player->stateFlags2 &= ~PLAYER_STATE2_80;
-                    player->unk_AE8 = 100;
+                    player->actionVar2 = 100;
                 }
 
                 Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, EN_RAILGIBUD_ANIM_GRAB_END);

--- a/src/overlays/actors/ovl_En_Rd/z_en_rd.c
+++ b/src/overlays/actors/ovl_En_Rd/z_en_rd.c
@@ -842,7 +842,7 @@ void EnRd_Grab(EnRd* this, PlayState* play) {
             if (!(player->stateFlags2 & PLAYER_STATE2_80) || (player->unk_B62 != 0)) {
                 if ((player->unk_B62 != 0) && (player->stateFlags2 & PLAYER_STATE2_80)) {
                     player->stateFlags2 &= ~PLAYER_STATE2_80;
-                    player->unk_AE8 = 100;
+                    player->actionVar2 = 100;
                 }
                 Animation_Change(&this->skelAnime, &gGibdoRedeadGrabEndAnim, 0.5f, 0.0f,
                                  Animation_GetLastFrame(&gGibdoRedeadGrabEndAnim), ANIMMODE_ONCE_INTERP, 0.0f);

--- a/src/overlays/actors/ovl_En_Rr/z_en_rr.c
+++ b/src/overlays/actors/ovl_En_Rr/z_en_rr.c
@@ -299,7 +299,7 @@ void func_808FA4F4(EnRr* this, PlayState* play) {
 
     if (player->stateFlags2 & PLAYER_STATE2_80) {
         player->actor.parent = NULL;
-        player->unk_AE8 = 100;
+        player->actionVar2 = 100;
         this->actor.flags |= ACTOR_FLAG_TARGETABLE;
         this->unk_1F0 = 110;
         this->unk_1F6 = 2500;
@@ -636,7 +636,7 @@ void func_808FB1C0(EnRr* this, PlayState* play) {
         Actor_PlaySfx(&this->actor, NA_SE_EN_EYEGOLE_DEMO_EYE);
     }
 
-    player->unk_AE8 = 0;
+    player->actionVar2 = 0;
     this->unk_1F0 = 8;
     this->unk_1EA--;
 
@@ -654,7 +654,7 @@ void func_808FB2C0(EnRr* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     this->unk_1E6--;
-    player->unk_AE8 = 0;
+    player->actionVar2 = 0;
     Math_StepToF(&player->actor.world.pos.x, this->unk_228.x, 30.0f);
     Math_StepToF(&player->actor.world.pos.y, this->unk_228.y + this->unk_218, 30.0f);
     Math_StepToF(&player->actor.world.pos.z, this->unk_228.z, 30.0f);

--- a/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
+++ b/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
@@ -421,7 +421,7 @@ void EnTalkGibud_Grab(EnTalkGibud* this, PlayState* play) {
             if (!(player->stateFlags2 & PLAYER_STATE2_80) || (player->unk_B62 != 0)) {
                 if ((player->unk_B62 != 0) && (player->stateFlags2 & PLAYER_STATE2_80)) {
                     player->stateFlags2 &= ~PLAYER_STATE2_80;
-                    player->unk_AE8 = 100;
+                    player->actionVar2 = 100;
                 }
 
                 Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, EN_TALK_GIBUD_ANIM_GRAB_END);

--- a/src/overlays/actors/ovl_En_Toto/z_en_toto.c
+++ b/src/overlays/actors/ovl_En_Toto/z_en_toto.c
@@ -332,7 +332,7 @@ void func_80BA3DBC(EnToto* this, PlayState* play) {
         }
     } else {
         player = GET_PLAYER(play);
-        if ((player->stateFlags1 & PLAYER_STATE1_400) && player->actionVar1 != 0) {
+        if ((player->stateFlags1 & PLAYER_STATE1_400) && (player->actionVar1 != 0)) {
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_RECEIVED_CIRCUS_LEADERS_MASK);
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_MET_TOTO);
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_MET_GORMAN);

--- a/src/overlays/actors/ovl_En_Toto/z_en_toto.c
+++ b/src/overlays/actors/ovl_En_Toto/z_en_toto.c
@@ -332,7 +332,7 @@ void func_80BA3DBC(EnToto* this, PlayState* play) {
         }
     } else {
         player = GET_PLAYER(play);
-        if ((player->stateFlags1 & PLAYER_STATE1_400) && player->unk_AE7 != 0) {
+        if ((player->stateFlags1 & PLAYER_STATE1_400) && player->actionVar1 != 0) {
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_RECEIVED_CIRCUS_LEADERS_MASK);
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_MET_TOTO);
             Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_MET_GORMAN);

--- a/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.c
+++ b/src/overlays/actors/ovl_En_Wiz_Fire/z_en_wiz_fire.c
@@ -638,8 +638,8 @@ void EnWizFire_Update(Actor* thisx, PlayState* play2) {
         }
     }
 
-    if ((player->stateFlags2 & PLAYER_STATE2_4000) && (player->unk_AE8 < 90)) {
-        player->unk_AE8 = 90;
+    if ((player->stateFlags2 & PLAYER_STATE2_4000) && (player->actionVar2 < 90)) {
+        player->actionVar2 = 90;
     }
 
     if (!this->hitByIceArrow && !sPoolHitByIceArrow &&

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -647,14 +647,14 @@ void func_8082DE50(PlayState* play, Player* this) {
 s32 func_8082DE88(Player* this, s32 arg1, s32 arg2) {
     s16 controlStickAngleDiff = this->prevControlStickAngle - sPlayerControlStickAngle;
 
-    this->unk_AE8 +=
+    this->actionVar2 +=
         arg1 + TRUNCF_BINANG(ABS_ALT(controlStickAngleDiff) * fabsf(sPlayerControlStickMagnitude) * (1.0f / 0x600F0));
 
     if (CHECK_BTN_ANY(sPlayerControlInput->press.button, BTN_B | BTN_A)) {
-        this->unk_AE8 += 5;
+        this->actionVar2 += 5;
     }
 
-    return this->unk_AE8 >= arg2;
+    return this->actionVar2 >= arg2;
 }
 
 void func_8082DF2C(PlayState* play) {
@@ -4191,8 +4191,8 @@ s32 Player_SetAction(PlayState* play, Player* this, PlayerActionFunc actionFunc,
           PLAYER_STATE3_8000 | PLAYER_STATE3_10000 | PLAYER_STATE3_20000 | PLAYER_STATE3_40000 | PLAYER_STATE3_80000 |
           PLAYER_STATE3_200000 | PLAYER_STATE3_1000000 | PLAYER_STATE3_20000000);
 
-    this->unk_AE7 = 0;
-    this->unk_AE8 = 0;
+    this->actionVar1 = 0;
+    this->actionVar2 = 0;
     this->unk_AA4 = 0;
     this->unk_B86[0] = 0;
     this->unk_B86[1] = 0;
@@ -4416,7 +4416,7 @@ void func_80831F34(PlayState* play, Player* this, PlayerAnimationHeader* anim) {
 
         if (Inventory_ConsumeFairy(play)) {
             play->gameOverCtx.state = GAMEOVER_REVIVE_START;
-            this->unk_AE7 = 1;
+            this->actionVar1 = 1;
         } else {
             play->gameOverCtx.state = GAMEOVER_DEATH_START;
             func_801A41F8(0);
@@ -5098,7 +5098,7 @@ void func_8083375C(Player* this, PlayerMeleeWeaponAnimation meleeWeaponAnim) {
 void func_80833864(PlayState* play, Player* this, PlayerMeleeWeaponAnimation meleeWeaponAnim) {
     func_8083375C(this, meleeWeaponAnim);
     Player_SetAction(play, this, Player_Action_84, 0);
-    this->unk_AE8 = 0;
+    this->actionVar2 = 0;
 
     if ((meleeWeaponAnim < PLAYER_MWA_FLIPSLASH_FINISH) || (meleeWeaponAnim > PLAYER_MWA_ZORA_JUMPKICK_FINISH)) {
         func_8082DC38(this);
@@ -5165,7 +5165,7 @@ void func_80833A64(Player* this) {
 void func_80833AA0(Player* this, PlayState* play) {
     if (Player_SetAction(play, this, Player_Action_25, 0)) {
         Player_AnimationPlayLoop(play, this, &gPlayerAnim_link_normal_landing_wait);
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
     if (this->unk_AA5 != PLAYER_UNKAA5_4) {
         this->unk_AA5 = PLAYER_UNKAA5_0;
@@ -5228,7 +5228,7 @@ void func_80833B18(PlayState* play, Player* this, s32 arg2, f32 speed, f32 veloc
         func_8082DB60(play, this, &gPlayerAnim_link_normal_electric_shock);
         func_8082DAD4(this);
 
-        this->unk_AE8 = 20;
+        this->actionVar2 = 20;
         this->actor.velocity.y = 0.0f;
 
         Player_RequestRumble(play, this, 255, 80, 150, SQ(0));
@@ -5260,7 +5260,7 @@ void func_80833B18(PlayState* play, Player* this, s32 arg2, f32 speed, f32 veloc
             func_8082DAD4(this);
 
             if (arg2 == 2) {
-                this->unk_AE8 = 4;
+                this->actionVar2 = 4;
 
                 this->actor.speed = 3.0f;
                 this->linearVelocity = 3.0f;
@@ -5355,11 +5355,11 @@ void func_80834140(PlayState* play, Player* this, PlayerAnimationHeader* anim) {
     if (!(this->stateFlags1 & PLAYER_STATE1_80)) {
         func_80834104(play, this);
         if (func_8082DA90(play)) {
-            this->unk_AE8 = -30;
+            this->actionVar2 = -30;
         }
         this->stateFlags1 |= PLAYER_STATE1_80;
         PlayerAnimation_Change(play, &this->skelAnime, anim, 1.0f, 0.0f, 84.0f, ANIMMODE_ONCE, -6.0f);
-        this->unk_AE7 = 1;
+        this->actionVar1 = 1;
         this->linearVelocity = 0.0f;
     }
 }
@@ -5519,7 +5519,7 @@ s32 func_80834600(Player* this, PlayState* play) {
                 Player_SetAction(play, this, Player_Action_19, 0);
             }
 
-            this->unk_AE7 = sp64;
+            this->actionVar1 = sp64;
             if ((s8)sp64 == 0) {
                 Player_SetUpperAction(play, this, Player_UpperAction_4);
                 var_a2 = (this->unk_B40 < 0.5f) ? D_8085CFD4[Player_IsHoldingTwoHandedWeapon(this)]
@@ -5748,8 +5748,8 @@ void func_80835324(PlayState* play, Player* this, f32 arg2, s16 arg3) {
     func_8082DD2C(play, this);
 
     this->csId = CS_ID_NONE;
-    this->unk_AE7 = 1;
-    this->unk_AE8 = 1;
+    this->actionVar1 = 1;
+    this->actionVar2 = 1;
 
     this->unk_3A0.x = Math_SinS(arg3) * arg2 + this->actor.world.pos.x;
     this->unk_3A0.z = Math_CosS(arg3) * arg2 + this->actor.world.pos.z;
@@ -5828,7 +5828,7 @@ void func_808354A4(PlayState* play, s32 exitIndex, s32 arg2) {
 
 void func_808355D8(PlayState* play, Player* this, PlayerAnimationHeader* anim) {
     func_80833AA0(this, play);
-    this->unk_AE8 = -2;
+    this->actionVar2 = -2;
     func_8082E5EC(play, this, anim);
     func_8082E1F0(this, NA_SE_IT_DEKUNUTS_FLOWER_CLOSE);
 }
@@ -5949,11 +5949,11 @@ s32 Player_HandleExitsAndVoids(PlayState* play, Player* this, CollisionPoly* pol
                         this->stateFlags1 |= PLAYER_STATE1_20000000;
                     } else {
                         func_80834104(play, this);
-                        this->unk_AE8 = 9999;
+                        this->actionVar2 = 9999;
                         if (this->floorProperty == FLOOR_PROPERTY_5) {
-                            this->unk_AE7 = -1;
+                            this->actionVar1 = -1;
                         } else {
-                            this->unk_AE7 = 1;
+                            this->actionVar1 = 1;
                         }
                     }
                 }
@@ -6052,7 +6052,7 @@ void Player_Door_Staircase(PlayState* play, Player* this, Actor* door) {
     func_80835324(play, this, 50.0f, this->actor.shape.rot.y);
 
     this->unk_397 = this->doorType;
-    this->unk_AE7 = 0;
+    this->actionVar1 = 0;
     this->stateFlags1 |= PLAYER_STATE1_20000000;
     func_80835BF8(&doorStaircase->actor.world.pos, doorStaircase->actor.shape.rot.y, -140.0f, &this->unk_3A0);
 
@@ -6065,7 +6065,7 @@ void Player_Door_Staircase(PlayState* play, Player* this, Actor* door) {
     func_8082DAD4(this);
 
     if (this->doorTimer != 0) {
-        this->unk_AE8 = 0;
+        this->actionVar2 = 0;
         func_8082E438(play, this, func_8082ED20(this));
         this->skelAnime.endFrame = 0.0f;
     } else {
@@ -6096,7 +6096,7 @@ void Player_Door_Sliding(PlayState* play, Player* this, Actor* door) {
     }
 
     func_80835324(play, this, 50.0f, this->actor.shape.rot.y);
-    this->unk_AE7 = 0;
+    this->actionVar1 = 0;
     this->unk_397 = this->doorType;
     this->stateFlags1 |= PLAYER_STATE1_20000000;
     Actor_OffsetOfPointInActorCoords(&doorSliding->dyna.actor, &sp38, &this->actor.world.pos);
@@ -6112,7 +6112,7 @@ void Player_Door_Sliding(PlayState* play, Player* this, Actor* door) {
     func_8082DAD4(this);
 
     if (this->doorTimer != 0) {
-        this->unk_AE8 = 0;
+        this->actionVar2 = 0;
         func_8082E438(play, this, func_8082ED20(this));
         this->skelAnime.endFrame = 0.0f;
     } else {
@@ -6215,14 +6215,14 @@ void Player_Door_Knob(PlayState* play, Player* this, Actor* door) {
             } else if (enDoorType != ENDOOR_TYPE_7) {
                 Camera* mainCam;
 
-                this->unk_AE7 = 38.0f * D_8085C3E8;
+                this->actionVar1 = 38.0f * D_8085C3E8;
                 mainCam = Play_GetCamera(play, CAM_ID_MAIN);
 
                 Camera_ChangeDoorCam(mainCam, &knobDoor->dyna.actor,
                                      play->doorCtx.transitionActorList[DOOR_GET_TRANSITION_ID(&knobDoor->dyna.actor)]
                                          .sides[(this->doorDirection > 0) ? 0 : 1]
                                          .bgCamIndex,
-                                     0.0f, this->unk_AE7, 26.0f * D_8085C3E8, 10.0f * D_8085C3E8);
+                                     0.0f, this->actionVar1, 26.0f * D_8085C3E8, 10.0f * D_8085C3E8);
             }
         }
     }
@@ -6337,7 +6337,7 @@ void func_808369F4(Player* this, PlayState* play) {
 void func_80836A5C(Player* this, PlayState* play) {
     func_808369F4(this, play);
     if (func_80123420(this)) {
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
 }
 
@@ -6533,9 +6533,9 @@ void func_80837134(PlayState* play, Player* this) {
         }
     } else if (this->stateFlags2 & PLAYER_STATE2_80000) {
         if (func_80123420(this)) {
-            anim = D_8085C2A4[this->unk_AE7].unk_8;
+            anim = D_8085C2A4[this->actionVar1].unk_8;
         } else {
-            anim = D_8085C2A4[this->unk_AE7].unk_4;
+            anim = D_8085C2A4[this->actionVar1].unk_4;
         }
     } else if (this->skelAnime.animation == &gPlayerAnim_link_normal_run_jump) {
         anim = &gPlayerAnim_link_normal_run_jump_end;
@@ -6554,9 +6554,9 @@ void func_80837134(PlayState* play, Player* this) {
         this->skelAnime.endFrame = 8.0f;
 
         if (temp_v0_2 == 1) {
-            this->unk_AE8 = 0xA;
+            this->actionVar2 = 0xA;
         } else {
-            this->unk_AE8 = 0x14;
+            this->actionVar2 = 0x14;
         }
     } else if (temp_v0_2 == 0) {
         func_80836A98(this, anim, play);
@@ -6601,9 +6601,9 @@ s32 func_808373F8(PlayState* play, Player* this, u16 sfxId) {
             }
 
             func_80834D50(play, this, D_8085C2A4[var_v1].unk_0, speed, ((var_v1 == 4) ? NA_SE_VO_LI_SWORD_N : sfxId));
-            this->unk_AE8 = -1;
+            this->actionVar2 = -1;
             this->stateFlags2 |= PLAYER_STATE2_80000;
-            this->unk_AE7 = var_v1;
+            this->actionVar1 = var_v1;
             return true;
         }
         anim = &gPlayerAnim_link_normal_run_jump;
@@ -6619,7 +6619,7 @@ s32 func_808373F8(PlayState* play, Player* this, u16 sfxId) {
         if ((this->actor.depthInWater > 0.0f) && (this->remainingHopsCounter != 0)) {
             this->actor.world.pos.y += this->actor.depthInWater;
             func_80834D50(play, this, anim, speed, NA_SE_NONE);
-            this->unk_AE8 = 1;
+            this->actionVar2 = 1;
             this->stateFlags3 |= PLAYER_STATE3_200000;
             Player_PlaySfx(this, (NA_SE_PL_DEKUNUTS_JUMP5 + 1 - this->remainingHopsCounter));
             Player_AnimSfx_PlayVoice(this, sfxId);
@@ -6638,7 +6638,7 @@ s32 func_808373F8(PlayState* play, Player* this, u16 sfxId) {
     }
 
     func_80834D50(play, this, anim, speed, sfxId);
-    this->unk_AE8 = 1;
+    this->actionVar2 = 1;
 
     return true;
 }
@@ -6749,14 +6749,14 @@ void func_80837BF8(PlayState* play, Player* this) {
 }
 
 void func_80837C20(PlayState* play, Player* this) {
-    s32 sp1C = this->unk_AE8;
-    s32 sp18 = this->unk_AE7;
+    s32 sp1C = this->actionVar2;
+    s32 sp18 = this->actionVar1;
 
     Player_SetAction_PreserveMoveFlags(play, this, Player_Action_50, 0);
     this->actor.velocity.y = 0.0f;
 
-    this->unk_AE8 = sp1C;
-    this->unk_AE7 = sp18;
+    this->actionVar2 = sp1C;
+    this->actionVar1 = sp18;
 }
 
 void func_80837C78(PlayState* play, Player* this) {
@@ -6764,9 +6764,9 @@ void func_80837C78(PlayState* play, Player* this) {
     this->stateFlags1 |= (PLAYER_STATE1_400 | PLAYER_STATE1_20000000);
 
     if (this->getItemId == GI_HEART_CONTAINER) {
-        this->unk_AE8 = 20;
+        this->actionVar2 = 20;
     } else if (this->getItemId >= GI_NONE) {
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     } else {
         this->getItemId = -this->getItemId;
     }
@@ -6862,8 +6862,8 @@ s32 func_80837DEC(Player* this, PlayState* play) {
                             func_8082E920(play, this,
                                           ANIM_FLAG_1 | ANIM_FLAG_UPDATE_Y | ANIM_FLAG_4 | ANIM_FLAG_8 |
                                               ANIM_FLAG_NOMOVE | ANIM_FLAG_80);
-                            this->unk_AE8 = -1;
-                            this->unk_AE7 = var_v1_2;
+                            this->actionVar2 = -1;
+                            this->actionVar1 = var_v1_2;
                         } else {
                             this->stateFlags1 |= PLAYER_STATE1_2000;
                             this->stateFlags1 &= ~PLAYER_STATE1_20000;
@@ -7284,8 +7284,8 @@ s32 func_80838A90(Player* this, PlayState* play) {
                                 func_8082E438(play, this, D_8085BE84[31][this->modelAnimType]);
                             }
                             this->stateFlags1 |= PLAYER_STATE1_20000000;
-                            this->unk_AE8 = 80;
-                            this->unk_AE7 = -1;
+                            this->actionVar2 = 80;
+                            this->actionVar1 = -1;
                             this->lockOnActor = this->talkActor;
                         } else {
                             this->csId = CS_ID_GLOBAL_TALK;
@@ -7297,13 +7297,13 @@ s32 func_80838A90(Player* this, PlayState* play) {
                     } else {
                         this->stateFlags1 |= (PLAYER_STATE1_20000000 | PLAYER_STATE1_10000000 | PLAYER_STATE1_40);
                         this->csId = play->playerCsIds[PLAYER_CS_ID_ITEM_SHOW];
-                        this->unk_AE7 = 1;
+                        this->actionVar1 = 1;
                         this->actor.textId = 0xFE;
                     }
                     this->actor.flags |= ACTOR_FLAG_TALK_REQUESTED;
                     this->exchangeItemAction = this->itemAction;
-                    if (this->unk_AE7 >= 0) {
-                        Player_AnimationPlayOnce(play, this, D_8085D1F8[this->unk_AE7]);
+                    if (this->actionVar1 >= 0) {
+                        Player_AnimationPlayOnce(play, this, D_8085D1F8[this->actionVar1]);
                     }
                     func_8082DAD4(this);
                     return true;
@@ -7359,7 +7359,7 @@ s32 func_80838A90(Player* this, PlayState* play) {
                     Player_StopCutscene(this);
                     if (!(this->stateFlags1 & PLAYER_STATE1_800000)) {
                         Player_SetAction(play, this, Player_Action_43, 1);
-                        this->unk_AE8 = 13;
+                        this->actionVar2 = 13;
                         func_80836D8C(this);
                         if (this->unk_AA5 == PLAYER_UNKAA5_2) {
                             play->actorCtx.flags |= ACTORCTX_FLAG_PICTO_BOX_ON;
@@ -7551,8 +7551,8 @@ void func_80839860(Player* this, PlayState* play, s32 arg2) {
 
     func_80834D50(play, this, D_8085C2A4[arg2].unk_0, speed, NA_SE_VO_LI_SWORD_N);
 
-    this->unk_AE8 = 1;
-    this->unk_AE7 = arg2;
+    this->actionVar2 = 1;
+    this->actionVar1 = arg2;
 
     this->currentYaw = this->actor.shape.rot.y + (arg2 << 0xE);
     this->linearVelocity = !(arg2 & 1) ? 6.0f : 8.5f;
@@ -7710,7 +7710,7 @@ void func_8083A04C(Player* this) {
             this->currentBoots = PLAYER_BOOTS_ZORA_LAND;
         }
         if (Player_Action_54 == this->actionFunc) {
-            this->unk_AE8 = 20;
+            this->actionVar2 = 20;
         }
     } else {
         if (CHECK_BTN_ALL(sPlayerControlInput->press.button, BTN_B)) {
@@ -7861,9 +7861,9 @@ s32 func_8083A6C0(PlayState* play, Player* this) {
         if (Player_GetBottleHeld(this) > PLAYER_BOTTLE_NONE) {
             Player_SetAction(play, this, Player_Action_68, 0);
             if (this->actor.depthInWater > 12.0f) {
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             }
-            func_8082DB90(play, this, D_8085D200[this->unk_AE8].unk_0);
+            func_8082DB90(play, this, D_8085D200[this->actionVar2].unk_0);
             Player_PlaySfx(this, NA_SE_IT_SWORD_SWING);
             Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_AUTO_JUMP);
             return true;
@@ -7901,7 +7901,7 @@ s32 func_8083A878(PlayState* play, Player* this, f32 arg2) {
             Player_SetAction(play, this, Player_Action_55, 0);
             func_8082E634(play, this, &gPlayerAnim_link_swimer_swim);
             this->stateFlags1 |= (PLAYER_STATE1_8000000 | PLAYER_STATE1_20000000);
-            this->unk_AE8 = 20;
+            this->actionVar2 = 20;
             this->linearVelocity = 2.0f;
             func_80123140(play, this);
             return false;
@@ -7930,11 +7930,11 @@ void func_8083A98C(Actor* thisx, PlayState* play2) {
         return;
     }
 
-    if (DECR(this->unk_AE8) != 0) {
+    if (DECR(this->actionVar2) != 0) {
         camMode = (play->sceneId != SCENE_AYASHIISHOP) ? CAM_MODE_FIRSTPERSON : CAM_MODE_DEKUHIDE;
 
         // Show controls overlay. SCENE_AYASHIISHOP does not have Zoom, so has a different one.
-        if (this->unk_AE8 == 1) {
+        if (this->actionVar2 == 1) {
             Message_StartTextbox(play, (play->sceneId == SCENE_AYASHIISHOP) ? 0x2A00 : 0x5E6, NULL);
         }
     } else {
@@ -8014,15 +8014,15 @@ void Player_InitMode_Telescope(PlayState* play, Player* this) {
     if (play->sceneId == SCENE_00KEIKOKU) {
         this->actor.focus.rot.x = 0xBD8;
         this->actor.focus.rot.y = -0x4D74;
-        this->unk_AE8 = 20;
+        this->actionVar2 = 20;
     } else if (play->sceneId == SCENE_AYASHIISHOP) {
         this->actor.focus.rot.x = 0x9A6;
         this->actor.focus.rot.y = 0x2102;
-        this->unk_AE8 = 2;
+        this->actionVar2 = 2;
     } else {
         this->actor.focus.rot.x = 0x9A6;
         this->actor.focus.rot.y = 0x2102;
-        this->unk_AE8 = 20;
+        this->actionVar2 = 20;
     }
     play->actorCtx.flags |= ACTORCTX_FLAG_1;
 }
@@ -8033,7 +8033,7 @@ void Player_InitMode_B(PlayState* play, Player* this) {
 
 void Player_InitMode_D(PlayState* play, Player* this) {
     if (func_8083A878(play, this, 180.0f)) {
-        this->unk_AE8 = -20;
+        this->actionVar2 = -20;
     }
 }
 
@@ -8043,7 +8043,7 @@ void func_8083ADF0(PlayState* play, Player* this) {
     gSaveContext.entranceSpeed = 2.0f;
 
     if (func_8083A878(play, this, 120.0f)) {
-        this->unk_AE8 = -15;
+        this->actionVar2 = -15;
     }
 }
 
@@ -8054,9 +8054,9 @@ void Player_InitMode_F(PlayState* play, Player* this) {
 
     this->linearVelocity = gSaveContext.entranceSpeed;
     if (func_8083A878(play, this, 800.0f)) {
-        this->unk_AE8 = -80.0f / this->linearVelocity;
-        if (this->unk_AE8 < -20) {
-            this->unk_AE8 = -20;
+        this->actionVar2 = -80.0f / this->linearVelocity;
+        if (this->actionVar2 < -20) {
+            this->actionVar2 = -20;
         }
     }
 }
@@ -8118,7 +8118,7 @@ void func_8083B1A0(Player* this, PlayState* play) {
 void func_8083B23C(Player* this, PlayState* play) {
     Player_SetAction(play, this, Player_Action_2, 1);
     func_8082E438(play, this, D_8085BE84[PLAYER_ANIMGROUP_6][this->modelAnimType]);
-    this->unk_AE8 = 1;
+    this->actionVar2 = 1;
 }
 
 void func_8083B29C(Player* this, PlayState* play) {
@@ -8211,7 +8211,7 @@ s32 func_8083B3B4(PlayState* play, Player* this, Input* input) {
             if (this->stateFlags1 & PLAYER_STATE1_400) {
                 this->stateFlags1 |= (PLAYER_STATE1_400 | PLAYER_STATE1_800 | PLAYER_STATE1_20000000);
             }
-            this->unk_AE8 = 2;
+            this->actionVar2 = 2;
         }
 
         func_8082E438(play, this,
@@ -8238,7 +8238,7 @@ void func_8083B798(PlayState* play, Player* this) {
         this->unk_B48 = 2.0f;
     } else {
         Player_AnimationPlayLoop(play, this, &gPlayerAnim_link_swimer_swim);
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
 
     this->unk_AAA = 0x3E80;
@@ -8280,7 +8280,7 @@ void func_8083B930(PlayState* play, Player* this) {
         } else if ((this->currentBoots < PLAYER_BOOTS_ZORA_UNDERWATER) && (this->stateFlags2 & PLAYER_STATE2_400)) {
             this->stateFlags2 &= ~PLAYER_STATE2_400;
             func_8083B3B4(play, this, NULL);
-            this->unk_AE7 = 1;
+            this->actionVar1 = 1;
         } else if (Player_Action_27 == this->actionFunc) {
             Player_SetAction(play, this, Player_Action_59, 0);
             func_8083B798(play, this);
@@ -8764,11 +8764,11 @@ s32 Player_HandleSlopes(PlayState* play, Player* this) {
             } else {
                 Player_SetAction(play, this, Player_Action_73, 0);
                 func_8082DE50(play, this);
-                func_8082E514(play, this, sPlayerSlopeSlipAnims[this->unk_AE7]);
+                func_8082E514(play, this, sPlayerSlopeSlipAnims[this->actionVar1]);
                 this->linearVelocity = sqrtf(SQXZ(this->actor.velocity));
                 this->currentYaw = downwardSlopeYaw;
                 if (sPlayerFloorPitchShape >= 0) {
-                    this->unk_AE7 = 1;
+                    this->actionVar1 = 1;
                     Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_HANG);
                 }
 
@@ -9016,7 +9016,7 @@ s32 func_8083D860(Player* this, PlayState* play) {
                 this->stateFlags1 &= ~PLAYER_STATE1_8000000;
 
                 if ((var_t0 != 0) || temp_t2) {
-                    if ((this->unk_AE7 = var_t0) != 0) {
+                    if ((this->actionVar1 = var_t0) != 0) {
                         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                             anim = &gPlayerAnim_link_normal_Fclimb_startA;
 
@@ -9029,14 +9029,14 @@ s32 func_8083D860(Player* this, PlayState* play) {
                         distToInteractWall = 20.5f;
                     }
 
-                    this->unk_AE8 = -2;
+                    this->actionVar2 = -2;
                     this->actor.world.pos.y += yOut;
 
                     this->actor.shape.rot.y = this->currentYaw = this->actor.wallYaw + 0x8000;
                 } else {
                     anim = this->ageProperties->unk_B0;
                     distToInteractWall = (this->ageProperties->wallCheckRadius - this->ageProperties->unk_3C) + 17.0f;
-                    this->unk_AE8 = -4;
+                    this->actionVar2 = -4;
 
                     this->actor.shape.rot.y = this->currentYaw = i = this->actor.wallYaw; //! FAKE
                 }
@@ -9720,7 +9720,7 @@ s32 func_8083FD80(Player* this, PlayState* play) {
         //! Calling this function sets the meleeWeaponQuads' damage properties correctly, patching "Power Crouch Stab".
         func_8083375C(this, PLAYER_MWA_STAB_1H);
         Player_AnimationPlayOnce(play, this, &gPlayerAnim_link_normal_defense_kiru);
-        this->unk_AE7 = 1;
+        this->actionVar1 = 1;
         this->meleeWeaponAnimation = PLAYER_MWA_STAB_1H;
         this->currentYaw = this->actor.shape.rot.y + this->upperLimbRot.y;
         this->unk_ADD = 0;
@@ -9952,10 +9952,10 @@ s32 func_808401F4(PlayState* play, Player* this) {
 Vec3f D_8085D2A4 = { 0.0f, 0.0f, 5.0f };
 
 void func_80840770(PlayState* play, Player* this) {
-    if (this->unk_AE8 != 0) {
-        if (this->unk_AE8 > 0) {
-            this->unk_AE8--;
-            if (this->unk_AE8 == 0) {
+    if (this->actionVar2 != 0) {
+        if (this->actionVar2 > 0) {
+            this->actionVar2--;
+            if (this->actionVar2 == 0) {
                 if (this->stateFlags1 & PLAYER_STATE1_8000000) {
                     PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_swimer_swim_wait, 1.0f, 0.0f,
                                            Animation_GetLastFrame(&gPlayerAnim_link_swimer_swim_wait), ANIMMODE_ONCE,
@@ -9966,7 +9966,7 @@ void func_80840770(PlayState* play, Player* this) {
                                            0.0f);
                 }
                 gSaveContext.healthAccumulator = 0xA0;
-                this->unk_AE8 = -1;
+                this->actionVar2 = -1;
             }
         } else if (gSaveContext.healthAccumulator == 0) {
             Player_StopCutscene(this);
@@ -9982,10 +9982,10 @@ void func_80840770(PlayState* play, Player* this) {
             func_808339B4(this, -20);
             Audio_SetBgmVolumeOn();
         }
-    } else if (this->unk_AE7 != 0) {
+    } else if (this->actionVar1 != 0) {
         Player_StopCutscene(this);
         this->csId = play->playerCsIds[PLAYER_CS_ID_REVIVE];
-        this->unk_AE8 = 60;
+        this->actionVar2 = 60;
         Player_SpawnFairy(play, this, &this->actor.world.pos, &D_8085D2A4, FAIRY_PARAMS(FAIRY_TYPE_5, false, 0));
         Player_PlaySfx(this, NA_SE_EV_FIATY_HEAL - SFX_FLAG);
     } else if (play->gameOverCtx.state == GAMEOVER_DEATH_WAIT_GROUND) {
@@ -10056,7 +10056,7 @@ s32 func_80840A30(PlayState* play, Player* this, f32* arg2, f32 arg3) {
                     } else {
                         Player_SetAction(play, this, Player_Action_26, 0);
                         Player_AnimationPlayOnce(play, this, D_8085BE84[PLAYER_ANIMGROUP_16][this->modelAnimType]);
-                        this->unk_AE8 = 1;
+                        this->actionVar2 = 1;
                     }
                 }
 
@@ -10115,7 +10115,7 @@ void func_80840E5C(Player* this, PlayState* play) {
 void func_80840EC0(Player* this, PlayState* play) {
     Player_SetAction(play, this, Player_Action_30, 1);
     Player_AnimationPlayLoop(play, this, D_8085CF60[Player_IsHoldingTwoHandedWeapon(this)]);
-    this->unk_AE8 = 1;
+    this->actionVar2 = 1;
     this->unk_B38 = 0.0f;
 }
 
@@ -10234,7 +10234,7 @@ void Player_InitMode_1(PlayState* play, Player* this) {
     if (this->transformation == PLAYER_FORM_FIERCE_DEITY) {
         func_80841358(play, this, false);
     }
-    this->unk_AE8 = 20;
+    this->actionVar2 = 20;
 }
 
 void Player_InitMode_3(PlayState* play, Player* this) {
@@ -10264,7 +10264,7 @@ void Player_InitMode_6(PlayState* play, Player* this) {
         Player_SetAction(play, this, Player_Action_0, 0);
         func_8082E514(play, this, D_8085BE84[PLAYER_ANIMGROUP_43][this->modelAnimType]);
         this->stateFlags1 |= PLAYER_STATE1_20000000;
-        this->unk_AE8 = 0x28;
+        this->actionVar2 = 0x28;
         gSaveContext.save.isOwlSave = false;
     } else {
         Player_SetAction(play, this, Player_Action_4, 0);
@@ -10288,7 +10288,7 @@ void func_80841744(PlayState* play, Player* this) {
     }
     this->stateFlags1 |= PLAYER_STATE1_20000000;
     this->unk_ABC = -10000.0f;
-    this->unk_AE8 = 0x2710;
+    this->actionVar2 = 0x2710;
     this->unk_B10[5] = 8.0f;
 }
 
@@ -11296,7 +11296,7 @@ void Player_UpdateCamAndSeqModes(PlayState* play, Player* this) {
                         (this->meleeWeaponAnimation >= PLAYER_MWA_FORWARD_SLASH_1H) &&
                         (this->meleeWeaponAnimation <= PLAYER_MWA_ZORA_PUNCH_KICK)) ||
                        (this->stateFlags3 & PLAYER_STATE3_8) ||
-                       ((Player_Action_52 == this->actionFunc) && (this->unk_AE8 == 0)) ||
+                       ((Player_Action_52 == this->actionFunc) && (this->actionVar2 == 0)) ||
                        (Player_Action_53 == this->actionFunc)) {
                 camMode = CAM_MODE_STILL;
             } else {
@@ -11580,7 +11580,7 @@ void func_80844784(PlayState* play, Player* this) {
                     Audio_SetSfxTimerLerpInterval(4, 2);
                 }
 
-                this->unk_AE8 = 0x270F;
+                this->actionVar2 = 0x270F;
                 Math_Vec3f_Copy(this->unk_AF0, &this->actor.world.pos);
             }
 
@@ -11770,7 +11770,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
                 func_8083B930(play, this);
                 this->stateFlags2 &= ~PLAYER_STATE2_400;
                 if (Player_Action_54 == this->actionFunc) {
-                    this->unk_AE8 = 20;
+                    this->actionVar2 = 20;
                 }
             }
             this->prevBoots = this->currentBoots;
@@ -11778,7 +11778,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         if ((this->actor.parent == NULL) && (this->stateFlags1 & PLAYER_STATE1_800000)) {
             this->actor.parent = this->rideActor;
             func_80837BD0(play, this);
-            this->unk_AE8 = -1;
+            this->actionVar2 = -1;
             Player_AnimationPlayOnce(play, this, &gPlayerAnim_link_uma_wait_1);
             func_8082E920(play, this, ANIM_FLAG_1 | ANIM_FLAG_UPDATE_Y | ANIM_FLAG_8 | ANIM_FLAG_NOMOVE | ANIM_FLAG_80);
         }
@@ -12076,7 +12076,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
             }
             if (!(this->stateFlags1 & (PLAYER_STATE1_80 | PLAYER_STATE1_4000000)) && (this->invincibilityTimer <= 0)) {
                 if ((Player_Action_93 != this->actionFunc) &&
-                    ((Player_Action_96 != this->actionFunc) || (this->unk_AE7 != 1))) {
+                    ((Player_Action_96 != this->actionFunc) || (this->actionVar1 != 1))) {
                     if (this->cylinder.base.atFlags != AT_NONE) {
                         CollisionCheck_SetAT(play, &play->colChkCtx, &this->cylinder.base);
                     }
@@ -12305,7 +12305,7 @@ void Player_Draw(Actor* thisx, PlayState* play) {
             spE0 = 0.0f;
         } else {
             Matrix_Translate(0.0f, -this->unk_ABC, 0.0f, MTXMODE_APPLY);
-            spE0 = this->unk_AE8 - 6;
+            spE0 = this->actionVar2 - 6;
             if (spE0 < 0.0f) {
                 spE8 = D_8085D55C;
                 spE0 = this->unk_B86[0];
@@ -12386,11 +12386,11 @@ void Player_Draw(Actor* thisx, PlayState* play) {
             func_80122BA4(play, &this->unk_3D0, 2, 255);
 
             if (this->unk_B86[1] < 3) {
-                if (this->unk_AE7 >= 5) {
+                if (this->actionVar1 >= 5) {
                     f32 var_fa1;
                     u8 sp9B;
 
-                    var_fa1 = (this->unk_AE7 - 4) * 0.02f;
+                    var_fa1 = (this->actionVar1 - 4) * 0.02f;
 
                     if (this->unk_B86[1] != 0) {
                         sp9B = (-this->unk_B86[1] * 0x55) + 0xFF;
@@ -12679,7 +12679,7 @@ void func_808479F4(PlayState* play, Player* this, f32 arg2) {
 }
 
 void func_80847A50(Player* this) {
-    Player_PlaySfx(this, ((this->unk_AE7 != 0) ? NA_SE_PL_WALK_METAL1 : NA_SE_PL_WALK_LADDER) +
+    Player_PlaySfx(this, ((this->actionVar1 != 0) ? NA_SE_PL_WALK_METAL1 : NA_SE_PL_WALK_LADDER) +
                              this->ageProperties->surfaceSfxIdOffset);
 }
 
@@ -12731,8 +12731,8 @@ s32 func_80847BF0(Player* this, PlayState* play) {
     s32 var_a2;
     f32 sp34;
 
-    if (this->unk_AE8 < 0) {
-        this->unk_AE8 = 0x63;
+    if (this->actionVar2 < 0) {
+        this->actionVar2 = 0x63;
     } else {
         var_a2 = (this->mountSide < 0) ? 0 : 1;
 
@@ -12896,10 +12896,10 @@ s32 func_808482E0(PlayState* play, Player* this) {
         return true;
     }
 
-    if (this->unk_AE7 == 0) {
+    if (this->actionVar1 == 0) {
         GetItemEntry* giEntry = &sGetItemTable[this->getItemId - 1];
 
-        this->unk_AE7 = 1;
+        this->actionVar1 = 1;
         Message_StartTextbox(play, giEntry->textId, &this->actor);
         Item_Give(play, giEntry->itemId);
 
@@ -13393,15 +13393,15 @@ void Player_Action_0(Player* this, PlayState* play) {
     PlayerAnimation_Update(play, &this->skelAnime);
     func_808323C0(this, play->playerCsIds[PLAYER_CS_ID_ITEM_BOTTLE]);
 
-    if (DECR(this->unk_AE8) == 0) {
+    if (DECR(this->actionVar2) == 0) {
         if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
             Player_StopCutscene(this);
             Player_SetAction(play, this, Player_Action_4, 0);
             this->stateFlags1 &= ~PLAYER_STATE1_20000000;
         }
-    } else if (this->unk_AE8 == 30) {
+    } else if (this->actionVar2 == 30) {
         if (Message_GetState(&play->msgCtx) != TEXT_STATE_NONE) {
-            this->unk_AE8++;
+            this->actionVar2++;
         } else {
             Message_StartTextbox(play, 0xC03, NULL);
         }
@@ -13447,7 +13447,7 @@ void Player_Action_1(Player* this, PlayState* play) {
                 Player_AnimationPlayOnce(play, this, func_8082ED20(this));
 
                 if ((play->roomCtx.curRoom.num == this->unk_3CE) && (play->roomCtx.prevRoom.num < 0)) {
-                    this->unk_AE8 = 5;
+                    this->actionVar2 = 5;
                 } else {
                     play->roomCtx.curRoom.num = -1;
                     play->roomCtx.prevRoom.num = -1;
@@ -13455,19 +13455,19 @@ void Player_Action_1(Player* this, PlayState* play) {
                     play->roomCtx.prevRoom.segment = NULL;
 
                     func_8012EBF8(play, &play->roomCtx);
-                    this->unk_AE8 = -1;
-                    this->unk_AE7 = this->unk_3CE;
+                    this->actionVar2 = -1;
+                    this->actionVar1 = this->unk_3CE;
                 }
             }
         }
-    } else if (this->unk_AE8 < 0) {
-        if (Room_StartRoomTransition(play, &play->roomCtx, this->unk_AE7)) {
+    } else if (this->actionVar2 < 0) {
+        if (Room_StartRoomTransition(play, &play->roomCtx, this->actionVar1)) {
             Map_InitRoomData(play, play->roomCtx.curRoom.num);
             Minimap_SavePlayerRoomInitInfo(play);
-            this->unk_AE8 = 5;
+            this->actionVar2 = 5;
         }
-    } else if (this->unk_AE8 > 0) {
-        this->unk_AE8--;
+    } else if (this->actionVar2 > 0) {
+        this->actionVar2--;
     } else {
         R_PLAY_FILL_SCREEN_ALPHA += R_PLAY_FILL_SCREEN_ON;
         if (R_PLAY_FILL_SCREEN_ALPHA < 0) {
@@ -13485,11 +13485,11 @@ void Player_Action_2(Player* this, PlayState* play) {
     s16 yawTarget;
     s32 temp_v0;
 
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
             func_8082E794(this);
             Player_AnimationPlayLoop(play, this, func_8082EF54(this));
-            this->unk_AE8 = 0;
+            this->actionVar2 = 0;
             this->stateFlags3 &= ~PLAYER_STATE3_8;
         }
         func_8082FC60(this);
@@ -13607,13 +13607,13 @@ void Player_Action_4(Player* this, PlayState* play) {
     if (animFinished ||
         ((this->currentMask == PLAYER_MASK_SCENTS) && (this->skelAnime.animation != &gPlayerAnim_cl_msbowait)) ||
         ((this->currentMask != PLAYER_MASK_SCENTS) && (this->skelAnime.animation == &gPlayerAnim_cl_msbowait))) {
-        if (this->unk_AE8 != 0) {
-            if (DECR(this->unk_AE8) == 0) {
+        if (this->actionVar2 != 0) {
+            if (DECR(this->actionVar2) == 0) {
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
 
             this->skelAnime.jointTable[PLAYER_LIMB_ROOT - 1].y =
-                (this->skelAnime.jointTable[PLAYER_LIMB_ROOT - 1].y + ((this->unk_AE8 & 1) * 0x50)) - 0x28;
+                (this->skelAnime.jointTable[PLAYER_LIMB_ROOT - 1].y + ((this->actionVar2 & 1) * 0x50)) - 0x28;
         } else {
             func_8082E794(this);
             Player_ChooseIdleAnim(play, this);
@@ -13622,7 +13622,7 @@ void Player_Action_4(Player* this, PlayState* play) {
     }
 
     func_80832F24(this);
-    if ((this->unk_AE8 == 0) && !func_80847880(play, this) && !func_80833058(play, this, D_8085D01C, 1)) {
+    if ((this->actionVar2 == 0) && !func_80847880(play, this) && !func_80833058(play, this, D_8085D01C, 1)) {
         if (func_8082FB68(this)) {
             func_8083B23C(this, play);
             return;
@@ -14079,7 +14079,7 @@ void Player_Action_17(Player* this, PlayState* play) {
         func_8082E67C(play, this, D_8085BE84[PLAYER_ANIMGROUP_32][this->modelAnimType]);
     }
 
-    if (DECR(this->unk_AE8) == 0) {
+    if (DECR(this->actionVar2) == 0) {
         if (!func_80838A90(this, play)) {
             func_80836A98(this, D_8085BE84[PLAYER_ANIMGROUP_33][this->modelAnimType], play);
         }
@@ -14118,8 +14118,8 @@ void Player_Action_18(Player* this, PlayState* play) {
             Player_AnimationPlayLoop(play, this, D_8085BE84[PLAYER_ANIMGROUP_20][this->modelAnimType]);
         }
 
-        this->unk_AE8 = 1;
-        this->unk_AE7 = 0;
+        this->actionVar2 = 1;
+        this->actionVar1 = 0;
     }
 
     if (!Player_IsGoronOrDeku(this)) {
@@ -14131,7 +14131,7 @@ void Player_Action_18(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         f32 yStick = sPlayerControlInput->rel.stick_y * 180;
         f32 xStick = sPlayerControlInput->rel.stick_x * -120;
         s16 temp_a0 = this->actor.shape.rot.y - Camera_GetInputDirYaw(play->cameraPtrs[play->activeCamId]);
@@ -14154,14 +14154,14 @@ void Player_Action_18(Player* this, PlayState* play) {
         this->upperLimbRot.x = this->actor.focus.rot.x;
         Math_ScaledStepToS(&this->upperLimbRot.y, temp_ft5, var_a3);
 
-        if (this->unk_AE7 != 0) {
+        if (this->actionVar1 != 0) {
             if (!func_808401F4(play, this)) {
                 if (this->skelAnime.curFrame < 2.0f) {
                     func_8082FA5C(play, this, PLAYER_MELEE_WEAPON_STATE_1);
                 }
             } else {
-                this->unk_AE8 = 1;
-                this->unk_AE7 = 0;
+                this->actionVar2 = 1;
+                this->actionVar1 = 0;
             }
         } else if (!func_8083FE38(this, play)) {
             if (func_8083A274(this, play)) {
@@ -14197,7 +14197,7 @@ void Player_Action_18(Player* this, PlayState* play) {
 
 void Player_Action_19(Player* this, PlayState* play) {
     func_80832F24(this);
-    if (this->unk_AE7 == 0) {
+    if (this->actionVar1 == 0) {
         D_80862B04 = func_8083216C(this, play);
         if ((Player_UpperAction_3 == this->upperActionFunc) || (func_808331FC(play, this, &this->unk_284, 4.0f) > 0)) {
             Player_SetAction(play, this, Player_Action_2, 1);
@@ -14236,7 +14236,7 @@ void Player_Action_21(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_20 | PLAYER_STATE2_40;
     func_808345A8(this);
 
-    if (!(this->stateFlags1 & PLAYER_STATE1_20000000) && (this->unk_AE8 == 0) && (this->unk_B75 != 0)) {
+    if (!(this->stateFlags1 & PLAYER_STATE1_20000000) && (this->actionVar2 == 0) && (this->unk_B75 != 0)) {
         s16 temp_v0 = this->unk_B76;
         s16 temp_v1 = this->actor.shape.rot.y - temp_v0;
 
@@ -14255,15 +14255,15 @@ void Player_Action_21(Player* this, PlayState* play) {
     }
 
     if (PlayerAnimation_Update(play, &this->skelAnime) && (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
-        if (this->unk_AE8 != 0) {
-            this->unk_AE8--;
-            if (this->unk_AE8 == 0) {
+        if (this->actionVar2 != 0) {
+            this->actionVar2--;
+            if (this->actionVar2 == 0) {
                 func_8085B384(this, play);
             }
         } else if ((this->stateFlags1 & PLAYER_STATE1_20000000) ||
                    (!(this->cylinder.base.acFlags & AC_HIT) && (this->unk_B75 == 0))) {
             if (this->stateFlags1 & PLAYER_STATE1_20000000) {
-                this->unk_AE8++;
+                this->actionVar2++;
             } else {
                 Player_SetAction(play, this, Player_Action_22, 0);
                 this->stateFlags1 |= PLAYER_STATE1_4000000;
@@ -14288,7 +14288,7 @@ void Player_Action_22(Player* this, PlayState* play) {
     func_80832F24(this);
     if (PlayerAnimation_Update(play, &this->skelAnime) && (this->linearVelocity == 0.0f)) {
         if (this->stateFlags1 & PLAYER_STATE1_20000000) {
-            this->unk_AE8++;
+            this->actionVar2++;
         } else {
             Player_SetAction(play, this, Player_Action_23, 0);
             this->stateFlags1 |= PLAYER_STATE1_4000000;
@@ -14406,22 +14406,23 @@ void Player_Action_25(Player* this, PlayState* play) {
         }
 
         func_8083216C(this, play);
-        if ((((this->stateFlags2 & PLAYER_STATE2_80000) && ((this->unk_AE7 == 2) || (this->unk_AE7 >= 4))) ||
+        if ((((this->stateFlags2 & PLAYER_STATE2_80000) && ((this->actionVar1 == 2) || (this->actionVar1 >= 4))) ||
              !func_80839770(this, play)) &&
             (this->actor.velocity.y < 0.0f)) {
-            if (this->unk_AE8 >= 0) {
-                if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->unk_AE8 == 0) || (this->fallDistance > 0)) {
+            if (this->actionVar2 >= 0) {
+                if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) || (this->actionVar2 == 0) ||
+                    (this->fallDistance > 0)) {
                     if ((sPlayerYDistToFloor > 800.0f) || (this->stateFlags3 & PLAYER_STATE3_10000)) {
                         func_80840980(this, NA_SE_VO_LI_FALL_S);
                         this->stateFlags3 &= ~PLAYER_STATE3_10000;
                     }
                     PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_link_normal_landing, 1.0f, 0.0f, 0.0f,
                                            ANIMMODE_ONCE, 8.0f);
-                    this->unk_AE8 = -1;
+                    this->actionVar2 = -1;
                 }
             } else {
-                if ((this->unk_AE8 == -1) && (this->fallDistance > 120) && (sPlayerYDistToFloor > 280.0f)) {
-                    this->unk_AE8 = -2;
+                if ((this->actionVar2 == -1) && (this->fallDistance > 120) && (sPlayerYDistToFloor > 280.0f)) {
+                    this->actionVar2 = -2;
                     func_80840980(this, NA_SE_VO_LI_FALL_L);
                 }
 
@@ -14498,7 +14499,7 @@ void Player_Action_26(Player* this, PlayState* play) {
         return;
     }
 
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         s32 temp_v0;
 
         Math_StepToF(&this->linearVelocity, 0.0f, 2.0f);
@@ -14620,16 +14621,16 @@ void Player_Action_30(Player* this, PlayState* play) {
         func_8083133C(this);
         this->stateFlags1 &= ~PLAYER_STATE1_20000;
         Player_AnimationPlayLoop(play, this, D_8085CF60[Player_IsHoldingTwoHandedWeapon(this)]);
-        this->unk_AE8 = -1;
+        this->actionVar2 = -1;
     }
 
     func_80832F24(this);
-    if (!func_8083FE38(this, play) && (this->unk_AE8 != 0)) {
+    if (!func_8083FE38(this, play) && (this->actionVar2 != 0)) {
         func_80840F34(this);
-        if (this->unk_AE8 < 0) {
+        if (this->actionVar2 < 0) {
             if (this->unk_B08 >= 0.1f) {
                 this->unk_ADD = 0;
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             } else if (!CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_B)) {
                 func_80840E5C(this, play);
             }
@@ -14789,7 +14790,7 @@ void Player_Action_33(Player* this, PlayState* play) {
             }
 
             func_80834D50(play, this, NULL, speed, NA_SE_VO_LI_AUTO_JUMP);
-            this->unk_AE8 = -1;
+            this->actionVar2 = -1;
         }
     } else {
         temp_v0 = func_808331FC(play, this, &this->skelAnime, 4.0f);
@@ -14822,9 +14823,9 @@ void Player_Action_33(Player* this, PlayState* play) {
         }
 
         if ((this->skelAnime.animation == &gPlayerAnim_link_normal_100step_up) || (this->skelAnime.curFrame > 5.0f)) {
-            if (this->unk_AE8 == 0) {
+            if (this->actionVar2 == 0) {
                 Player_AnimSfx_PlayFloorJump(this);
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             }
             Math_SmoothStepToF(&this->unk_ABC, 0.0f, 0.1f, 400.0f, 150.0f);
         }
@@ -14854,13 +14855,13 @@ void Player_Action_35(Player* this, PlayState* play) {
         if ((this->stateFlags3 & PLAYER_STATE3_10) && !(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
             func_80833AA0(this, play);
             this->stateFlags1 |= PLAYER_STATE1_20000000;
-        } else if (this->unk_AE8 == 0) {
+        } else if (this->actionVar2 == 0) {
             PlayerAnimation_Update(play, &this->skelAnime);
             if (DECR(this->doorTimer) == 0) {
                 this->linearVelocity = 0.1f;
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             }
-        } else if (this->unk_AE7 == 0) {
+        } else if (this->actionVar1 == 0) {
             f32 sp6C = 5.0f * D_8085C3E4;
             s32 var_t0 = func_808411D4(play, this, &sp6C, -1);
 
@@ -14887,7 +14888,7 @@ void Player_Action_35(Player* this, PlayState* play) {
             }
 
             if (var_t0 < 0x1E) {
-                this->unk_AE7 = 1;
+                this->actionVar1 = 1;
                 this->stateFlags1 |= PLAYER_STATE1_20000000;
                 this->unk_3A0.x = this->unk_3AC.x;
                 this->unk_3A0.z = this->unk_3AC.z;
@@ -14904,8 +14905,8 @@ void Player_Action_35(Player* this, PlayState* play) {
                     this->unk_3A0.z = (Math_CosS(sPlayerConveyorYaw) * 400.0f) + this->actor.world.pos.z;
                 }
             } else {
-                if (this->unk_AE8 < 0) {
-                    this->unk_AE8++;
+                if (this->actionVar2 < 0) {
+                    this->actionVar2++;
                     sp5C = gSaveContext.entranceSpeed;
                     sp58 = -1;
                 } else if (this->unk_397 == 4) {
@@ -14971,7 +14972,7 @@ void Player_Action_35(Player* this, PlayState* play) {
                                 Player_TranslateAndRotateY(this, &this->unk_3A0, &D_8085D644, &this->unk_3AC);
 
                                 this->actor.shape.rot.y += (this->doorDirection != 0) ? 0x4000 : -0x4000;
-                                this->unk_AE7 = 0;
+                                this->actionVar1 = 0;
 
                                 this->actor.world.rot.y = this->currentYaw = this->actor.shape.rot.y;
                             }
@@ -14984,8 +14985,8 @@ void Player_Action_35(Player* this, PlayState* play) {
             }
 
             temp_v0_8 = func_808411D4(play, this, &sp5C, sp58);
-            if ((this->unk_AE8 == 0) || ((temp_v0_8 == 0) && (this->linearVelocity == 0.0f) &&
-                                         (Play_GetCamera(play, CAM_ID_MAIN)->stateFlags & CAM_STATE_4))) {
+            if ((this->actionVar2 == 0) || ((temp_v0_8 == 0) && (this->linearVelocity == 0.0f) &&
+                                            (Play_GetCamera(play, CAM_ID_MAIN)->stateFlags & CAM_STATE_4))) {
                 if (this->unk_397 == 4) {
                     Map_InitRoomData(play, play->roomCtx.curRoom.num);
                     Minimap_SavePlayerRoomInitInfo(play);
@@ -15026,7 +15027,7 @@ void Player_Action_36(Player* this, PlayState* play) {
 
     this->stateFlags2 |= PLAYER_STATE2_20;
 
-    if (DECR(this->unk_AE7) == 0) {
+    if (DECR(this->actionVar1) == 0) {
         func_80835DF8(play, this, &poly, &bgId);
     }
 
@@ -15034,9 +15035,9 @@ void Player_Action_36(Player* this, PlayState* play) {
     func_8083216C(this, play);
 
     if (animFinished) {
-        if (this->unk_AE8 == 0) {
+        if (this->actionVar2 == 0) {
             if (DECR(this->doorTimer) == 0) {
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
         } else {
@@ -15095,8 +15096,8 @@ void Player_Action_38(Player* this, PlayState* play) {
 
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         Player_AnimationPlayLoop(play, this, &gPlayerAnim_link_silver_wait);
-        this->unk_AE8 = 1;
-    } else if (this->unk_AE8 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         if (PlayerAnimation_OnFrame(&this->skelAnime, 27.0f)) {
             Actor* interactRangeActor = this->interactRangeActor;
 
@@ -15131,10 +15132,10 @@ void Player_Action_39(Player* this, PlayState* play) {
 void Player_Action_40(Player* this, PlayState* play) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         Player_AnimationPlayLoop(play, this, &gPlayerAnim_link_normal_nocarry_free_wait);
-        this->unk_AE8 = 15;
-    } else if (this->unk_AE8 != 0) {
-        this->unk_AE8--;
-        if (this->unk_AE8 == 0) {
+        this->actionVar2 = 15;
+    } else if (this->actionVar2 != 0) {
+        this->actionVar2--;
+        if (this->actionVar2 == 0) {
             func_80836A98(this, &gPlayerAnim_link_normal_nocarry_free_end, play);
             this->stateFlags1 &= ~PLAYER_STATE1_800;
             Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_DAMAGE_S);
@@ -15208,7 +15209,7 @@ void Player_Action_43(Player* this, PlayState* play) {
           func_808391D8(this, play)))) {
         func_80839ED0(this, play);
         Audio_PlaySfx(NA_SE_SY_CAMERA_ZOOM_UP);
-    } else if ((DECR(this->unk_AE8) == 0) || (this->unk_AA5 != PLAYER_UNKAA5_3)) {
+    } else if ((DECR(this->actionVar2) == 0) || (this->unk_AA5 != PLAYER_UNKAA5_3)) {
         if (func_801240DC(this)) {
             this->unk_AA6 |= 0x43;
         } else {
@@ -15233,10 +15234,10 @@ void Player_Action_44(Player* this, PlayState* play) {
         func_800E0238(Play_GetCamera(play, CAM_ID_MAIN));
         CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
         if (this->stateFlags1 & PLAYER_STATE1_800000) {
-            s32 sp44 = this->unk_AE8;
+            s32 sp44 = this->actionVar2;
 
             func_80837BD0(play, this);
-            this->unk_AE8 = sp44;
+            this->actionVar2 = sp44;
         } else if (!func_80847994(play, this) && !func_80847880(play, this) && !func_808387A0(play, this) &&
                    ((this->talkActor != this->interactRangeActor) || !func_8083D23C(this, play))) {
             if (func_801242B4(this)) {
@@ -15274,11 +15275,11 @@ void Player_Action_44(Player* this, PlayState* play) {
     if (this->lockOnActor != NULL) {
         this->currentYaw = func_8083C62C(this, false);
         this->actor.shape.rot.y = this->currentYaw;
-        if (this->unk_AE7 != 0) {
+        if (this->actionVar1 != 0) {
             if (!(this->stateFlags1 & PLAYER_STATE1_800)) {
                 if (PlayerAnimation_Update(play, &this->unk_284)) {
-                    this->unk_AE7--;
-                    if (this->unk_AE7 != 0) {
+                    this->actionVar1--;
+                    if (this->actionVar1 != 0) {
                         PlayerAnimation_Change(play, &this->unk_284, &gPlayerAnim_link_normal_talk_free, 1.0f, 0.0f,
                                                Animation_GetLastFrame(&gPlayerAnim_link_normal_talk_free),
                                                ANIMMODE_ONCE, -6.0f);
@@ -15295,7 +15296,7 @@ void Player_Action_44(Player* this, PlayState* play) {
                 PlayerAnimation_Change(
                     play, &this->unk_284, D_8085BE84[PLAYER_ANIMGROUP_25][this->modelAnimType], 0.4f, 0.0f,
                     Animation_GetLastFrame(D_8085BE84[PLAYER_ANIMGROUP_25][this->modelAnimType]), ANIMMODE_ONCE, -6.0f);
-                this->unk_AE7 = 2;
+                this->actionVar1 = 2;
             }
         }
     }
@@ -15329,8 +15330,8 @@ void Player_Action_46(Player* this, PlayState* play) {
     this->stateFlags2 |= (PLAYER_STATE2_1 | PLAYER_STATE2_40 | PLAYER_STATE2_100);
 
     if (func_8082E67C(play, this, &gPlayerAnim_link_normal_pushing)) {
-        this->unk_AE8 = 1;
-    } else if ((this->unk_AE8 == 0) && PlayerAnimation_OnFrame(&this->skelAnime, 11.0f)) {
+        this->actionVar2 = 1;
+    } else if ((this->actionVar2 == 0) && PlayerAnimation_OnFrame(&this->skelAnime, 11.0f)) {
         Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_PUSH);
     }
 
@@ -15372,8 +15373,8 @@ void Player_Action_47(Player* this, PlayState* play) {
     this->stateFlags2 |= (PLAYER_STATE2_1 | PLAYER_STATE2_40 | PLAYER_STATE2_100);
 
     if (func_8082E67C(play, this, anim)) {
-        this->unk_AE8 = 1;
-    } else if (this->unk_AE8 == 0) {
+        this->actionVar2 = 1;
+    } else if (this->actionVar2 == 0) {
         if (PlayerAnimation_OnFrame(&this->skelAnime, 11.0f)) {
             Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_PUSH);
         }
@@ -15432,9 +15433,9 @@ void Player_Action_48(Player* this, PlayState* play) {
 
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         Player_AnimationPlayLoop(play, this,
-                                 (this->unk_AE7 > 0) ? &gPlayerAnim_link_normal_fall_wait
-                                                     : D_8085BE84[PLAYER_ANIMGROUP_39][this->modelAnimType]);
-    } else if (this->unk_AE7 == 0) {
+                                 (this->actionVar1 > 0) ? &gPlayerAnim_link_normal_fall_wait
+                                                        : D_8085BE84[PLAYER_ANIMGROUP_39][this->modelAnimType]);
+    } else if (this->actionVar1 == 0) {
         f32 frame;
 
         if (this->skelAnime.animation == &gPlayerAnim_link_normal_fall) {
@@ -15446,25 +15447,25 @@ void Player_Action_48(Player* this, PlayState* play) {
         if (PlayerAnimation_OnFrame(&this->skelAnime, frame)) {
             Player_AnimSfx_PlayFloor(this, NA_SE_PL_WALK_GROUND);
             if (this->skelAnime.animation == &gPlayerAnim_link_normal_fall) {
-                this->unk_AE7 = 1;
+                this->actionVar1 = 1;
             } else {
-                this->unk_AE7 = -1;
+                this->actionVar1 = -1;
             }
         }
     }
 
     Math_ScaledStepToS(&this->actor.shape.rot.y, this->currentYaw, 0x800);
-    if (this->unk_AE7 != 0) {
+    if (this->actionVar1 != 0) {
         Player_GetMovementSpeedAndYaw(this, &speedTarget, &yawTarget, SPEED_MODE_LINEAR, play);
         if (this->unk_ADF[this->unk_ADE] >= 0) {
             func_808381A0(this,
-                          (this->unk_AE7 > 0) ? D_8085BE84[PLAYER_ANIMGROUP_37][this->modelAnimType]
-                                              : D_8085BE84[PLAYER_ANIMGROUP_40][this->modelAnimType],
+                          (this->actionVar1 > 0) ? D_8085BE84[PLAYER_ANIMGROUP_37][this->modelAnimType]
+                                                 : D_8085BE84[PLAYER_ANIMGROUP_40][this->modelAnimType],
                           play);
         } else if (CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A) || (this->actor.shape.feetFloorFlags != 0)) {
             func_80833A64(this);
 
-            if (this->unk_AE7 < 0) {
+            if (this->actionVar1 < 0) {
                 this->linearVelocity = -0.8f;
             } else {
                 this->linearVelocity = 0.8f;
@@ -15512,7 +15513,7 @@ void Player_Action_50(Player* this, PlayState* play) {
 
     this->stateFlags2 |= PLAYER_STATE2_40;
 
-    if ((this->unk_AE7 != 0) && (ABS_ALT(yStick) < ABS_ALT(xStick))) {
+    if ((this->actionVar1 != 0) && (ABS_ALT(yStick) < ABS_ALT(xStick))) {
         var_fv0 = ABS_ALT(xStick) * 0.0325f;
         yStick = 0;
     } else {
@@ -15534,7 +15535,7 @@ void Player_Action_50(Player* this, PlayState* play) {
 
     this->skelAnime.playSpeed = var_fv1 * var_fv0;
 
-    if (this->unk_AE8 >= 0) {
+    if (this->actionVar2 >= 0) {
         if ((this->actor.wallPoly != NULL) && (this->actor.wallBgId != BGCHECK_SCENE)) {
             dyna = DynaPoly_GetActor(&play->colCtx, this->actor.wallBgId);
 
@@ -15551,14 +15552,14 @@ void Player_Action_50(Player* this, PlayState* play) {
 
     func_80831944(play, this);
 
-    if ((this->unk_AE8 < 0) || !func_8083E354(this, play)) {
+    if ((this->actionVar2 < 0) || !func_8083E354(this, play)) {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
-            if (this->unk_AE8 < 0) {
-                this->unk_AE8 = ABS_ALT(this->unk_AE8) & 1;
+            if (this->actionVar2 < 0) {
+                this->actionVar2 = ABS_ALT(this->actionVar2) & 1;
             } else if (yStick != 0) {
                 f32 yIntersect;
 
-                sp78 = this->unk_AE7 + this->unk_AE8;
+                sp78 = this->actionVar1 + this->actionVar2;
 
                 if (yStick > 0) {
                     sp6C.x = 0.0f;
@@ -15568,7 +15569,7 @@ void Player_Action_50(Player* this, PlayState* play) {
                     yIntersect = func_80835D2C(play, this, &sp6C, &sp60);
 
                     if (this->actor.world.pos.y < yIntersect) {
-                        if (this->unk_AE7 != 0) {
+                        if (this->actionVar1 != 0) {
                             this->actor.world.pos.y = yIntersect;
                             this->stateFlags1 &= ~PLAYER_STATE1_200000;
                             func_80837CEC(play, this, this->actor.wallPoly, this->ageProperties->unk_3C,
@@ -15578,22 +15579,22 @@ void Player_Action_50(Player* this, PlayState* play) {
                             func_808381A0(this, &gPlayerAnim_link_normal_jump_climb_up_free, play);
                             this->stateFlags1 |= PLAYER_STATE1_4000;
                         } else {
-                            func_8083DCC4(this, this->ageProperties->unk_D4[this->unk_AE8], play);
+                            func_8083DCC4(this, this->ageProperties->unk_D4[this->actionVar2], play);
                         }
                     } else {
                         this->skelAnime.prevTransl = this->ageProperties->unk_4A[sp78];
                         Player_AnimationPlayOnce(play, this, this->ageProperties->unk_B4[sp78]);
                     }
                 } else if ((this->actor.world.pos.y - this->actor.floorHeight) < 15.0f) {
-                    if (this->unk_AE7 != 0) {
+                    if (this->actionVar1 != 0) {
                         func_8083E2F4(this, play);
                     } else {
-                        if (this->unk_AE8 != 0) {
+                        if (this->actionVar2 != 0) {
                             this->skelAnime.prevTransl = this->ageProperties->unk_44;
                         }
 
-                        func_8083DCC4(this, this->ageProperties->unk_CC[this->unk_AE8], play);
-                        this->unk_AE8 = 1;
+                        func_8083DCC4(this, this->ageProperties->unk_CC[this->actionVar2], play);
+                        this->actionVar2 = 1;
                     }
                 } else {
                     sp78 ^= 1;
@@ -15603,15 +15604,15 @@ void Player_Action_50(Player* this, PlayState* play) {
                                            0.0f);
                 }
 
-                this->unk_AE8 ^= 1;
-            } else if ((this->unk_AE7 != 0) && (xStick != 0)) {
-                anim2 = this->ageProperties->unk_C4[this->unk_AE8];
+                this->actionVar2 ^= 1;
+            } else if ((this->actionVar1 != 0) && (xStick != 0)) {
+                anim2 = this->ageProperties->unk_C4[this->actionVar2];
 
                 if (xStick > 0) {
-                    this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->unk_AE8];
+                    this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->actionVar2];
                     Player_AnimationPlayOnce(play, this, anim2);
                 } else {
-                    this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->unk_AE8 + 2];
+                    this->skelAnime.prevTransl = this->ageProperties->unk_7A[this->actionVar2 + 2];
                     PlayerAnimation_Change(play, &this->skelAnime, anim2, -1.0f, Animation_GetLastFrame(anim2), 0.0f, 2,
                                            0.0f);
                 }
@@ -15623,10 +15624,10 @@ void Player_Action_50(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_AE8 < 0) {
-        if (((this->unk_AE8 == -2) &&
+    if (this->actionVar2 < 0) {
+        if (((this->actionVar2 == -2) &&
              (PlayerAnimation_OnFrame(&this->skelAnime, 14.0f) || PlayerAnimation_OnFrame(&this->skelAnime, 29.0f))) ||
-            ((this->unk_AE8 == -4) &&
+            ((this->actionVar2 == -4) &&
              (PlayerAnimation_OnFrame(&this->skelAnime, 22.0f) || PlayerAnimation_OnFrame(&this->skelAnime, 35.0f) ||
               PlayerAnimation_OnFrame(&this->skelAnime, 49.0f) || PlayerAnimation_OnFrame(&this->skelAnime, 55.0f)))) {
             func_80847A50(this);
@@ -15659,7 +15660,7 @@ void Player_Action_51(Player* this, PlayState* play) {
     } else {
         f32* var_v1 = D_8085D66C;
 
-        if (this->unk_AE8 != 0) {
+        if (this->actionVar2 != 0) {
             Player_PlayAnimSfx(this, D_8085D67C);
             var_v1 = D_8085D674;
         }
@@ -15756,10 +15757,10 @@ void Player_Action_52(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_40;
 
     func_80847E2C(this, 1.0f, 10.0f);
-    if (this->unk_AE8 == 0) {
+    if (this->actionVar2 == 0) {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
             this->skelAnime.animation = &gPlayerAnim_link_uma_wait_1;
-            this->unk_AE8 = 0x63;
+            this->actionVar2 = 0x63;
         } else {
             s32 var_v0 = (this->mountSide < 0) ? 0 : 1;
 
@@ -15779,8 +15780,8 @@ void Player_Action_52(Player* this, PlayState* play) {
 
         this->skelAnime.prevTransl = D_8085D6E0;
 
-        if ((this->unk_AE8 < 0) || ((rideActor->animIndex != (this->unk_AE8 & 0xFFFF)) &&
-                                    ((rideActor->animIndex >= ENHORSE_ANIM_STOPPING) || (this->unk_AE8 >= 2)))) {
+        if ((this->actionVar2 < 0) || ((rideActor->animIndex != (this->actionVar2 & 0xFFFF)) &&
+                                       ((rideActor->animIndex >= ENHORSE_ANIM_STOPPING) || (this->actionVar2 >= 2)))) {
             s32 animIndex = rideActor->animIndex;
 
             if (animIndex < ENHORSE_ANIM_STOPPING) {
@@ -15797,24 +15798,24 @@ void Player_Action_52(Player* this, PlayState* play) {
                 Player_AnimationPlayOnce(play, this, D_8085D6D0[index]);
             } else {
                 this->skelAnime.animation = D_8085D688[animIndex - 2];
-                if (this->unk_AE8 >= 0) {
+                if (this->actionVar2 >= 0) {
                     Animation_SetMorph(play, &this->skelAnime, 8.0f);
                 }
 
                 if (animIndex < ENHORSE_ANIM_WALK) {
                     func_808309CC(play, this);
-                    this->unk_AE7 = 0;
+                    this->actionVar1 = 0;
                 }
             }
 
-            this->unk_AE8 = animIndex;
+            this->actionVar2 = animIndex;
         }
 
-        if (this->unk_AE8 == 1) {
+        if (this->actionVar2 == 1) {
             if (D_80862B04 || func_8082DAFC(play)) {
                 Player_AnimationPlayOnce(play, this, &gPlayerAnim_link_uma_wait_3);
             } else if (PlayerAnimation_Update(play, &this->skelAnime)) {
-                this->unk_AE8 = 0x63;
+                this->actionVar2 = 0x63;
             } else if (this->skelAnime.animation == &gPlayerAnim_link_uma_wait_1) {
                 Player_PlayAnimSfx(this, D_8085D6E8);
             }
@@ -15828,11 +15829,11 @@ void Player_Action_52(Player* this, PlayState* play) {
 
         if ((play->csCtx.state != CS_STATE_IDLE) || (this->csMode != PLAYER_CSMODE_NONE)) {
             this->unk_AA5 = PLAYER_UNKAA5_0;
-            this->unk_AE7 = 0;
-        } else if ((this->unk_AE8 < 2) || (this->unk_AE8 >= 4)) {
+            this->actionVar1 = 0;
+        } else if ((this->actionVar2 < 2) || (this->actionVar2 >= 4)) {
             D_80862B04 = func_8083216C(this, play);
             if (D_80862B04) {
-                this->unk_AE7 = 0;
+                this->actionVar1 = 0;
             }
         }
 
@@ -15843,10 +15844,10 @@ void Player_Action_52(Player* this, PlayState* play) {
         this->currentYaw = this->actor.shape.rot.y = rideActor->actor.shape.rot.y;
 
         if (!D_80862B04) {
-            if (this->unk_AE7 != 0) {
+            if (this->actionVar1 != 0) {
                 if (PlayerAnimation_Update(play, &this->unk_284)) {
                     rideActor->stateFlags &= ~ENHORSE_FLAG_8;
-                    this->unk_AE7 = 0;
+                    this->actionVar1 = 0;
                 }
 
                 if (this->unk_284.animation == &gPlayerAnim_link_uma_stop_muti) {
@@ -15872,14 +15873,14 @@ void Player_Action_52(Player* this, PlayState* play) {
                 if (EN_HORSE_CHECK_3(rideActor)) {
                     anim = &gPlayerAnim_link_uma_stop_muti;
                 } else if (EN_HORSE_CHECK_2(rideActor)) {
-                    if ((this->unk_AE8 >= 2) && (this->unk_AE8 != 0x63)) {
-                        anim = D_8085D6A4[this->unk_AE8];
+                    if ((this->actionVar2 >= 2) && (this->actionVar2 != 0x63)) {
+                        anim = D_8085D6A4[this->actionVar2];
                     }
                 }
 
                 if (anim != NULL) {
                     PlayerAnimation_PlayOnce(play, &this->unk_284, anim);
-                    this->unk_AE7 = 1;
+                    this->actionVar1 = 1;
                 }
             }
         }
@@ -15968,7 +15969,7 @@ s32 func_80850734(PlayState* play, Player* this) {
         this->stateFlags2 |= PLAYER_STATE2_400;
         PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_pz_waterroll, 2.0f / 3.0f, 4.0f,
                                Animation_GetLastFrame(&gPlayerAnim_pz_waterroll), ANIMMODE_ONCE, -6.0f);
-        this->unk_AE8 = 5;
+        this->actionVar2 = 5;
         this->unk_B86[0] = 0;
         this->unk_B48 = this->linearVelocity;
         this->actor.velocity.y = 0.0f;
@@ -15996,18 +15997,18 @@ void Player_Action_54(Player* this, PlayState* play) {
     func_8082E67C(play, this, &gPlayerAnim_link_swimer_swim_wait);
     func_808475B4(this);
 
-    if (this->unk_AE8 != 0) {
-        this->unk_AE8--;
+    if (this->actionVar2 != 0) {
+        this->actionVar2--;
     }
 
     func_8082F164(this, BTN_R);
 
     if (CHECK_BTN_ALL(sPlayerControlInput->press.button, BTN_A)) {
-        this->unk_AE8 = 0;
+        this->actionVar2 = 0;
     }
 
     if (!func_8082DAFC(play) && !func_80833058(play, this, D_8085D048, 1) &&
-        !func_8083B3B4(play, this, sPlayerControlInput) && ((this->unk_AE8 != 0) || !func_80850734(play, this))) {
+        !func_8083B3B4(play, this, sPlayerControlInput) && ((this->actionVar2 != 0) || !func_80850734(play, this))) {
         speedTarget = 0.0f;
         yawTarget = this->actor.shape.rot.y;
 
@@ -16048,7 +16049,7 @@ void Player_Action_55(Player* this, PlayState* play) {
         func_808477D0(play, this, NULL, this->linearVelocity);
         func_808475B4(this);
 
-        if (DECR(this->unk_AE8) == 0) {
+        if (DECR(this->actionVar2) == 0) {
             func_808353DC(play, this);
         }
     }
@@ -16103,13 +16104,13 @@ void Player_Action_56(Player* this, PlayState* play) {
 
     speedTarget = 0.0f;
 
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         if ((!func_8082DA90(play) && !CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A)) ||
             (this->currentBoots != PLAYER_BOOTS_ZORA_LAND)) {
             this->unk_B86[0] = 1;
         }
 
-        if (PlayerAnimation_Update(play, &this->skelAnime) && (DECR(this->unk_AE8) == 0)) {
+        if (PlayerAnimation_Update(play, &this->skelAnime) && (DECR(this->actionVar2) == 0)) {
             if (this->unk_B86[0] != 0) {
                 this->stateFlags3 &= ~PLAYER_STATE3_8000;
                 func_8082DB90(play, this, &gPlayerAnim_pz_swimtowait);
@@ -16276,10 +16277,10 @@ void Player_Action_59(Player* this, PlayState* play) {
 
     if (this->currentBoots >= PLAYER_BOOTS_ZORA_UNDERWATER) {
         func_808353DC(play, this);
-    } else if (this->unk_AE7 == 0) {
+    } else if (this->actionVar1 == 0) {
         f32 temp_fv0;
 
-        if (this->unk_AE8 == 0) {
+        if (this->actionVar2 == 0) {
             if (PlayerAnimation_Update(play, &this->skelAnime) ||
                 ((this->skelAnime.curFrame >= 22.0f) && !CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A))) {
                 func_8083B798(play, this);
@@ -16295,7 +16296,7 @@ void Player_Action_59(Player* this, PlayState* play) {
                 !(this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (this->actor.depthInWater < 120.0f)) {
                 func_808481CC(play, this, -2.0f);
             } else {
-                this->unk_AE7++;
+                this->actionVar1++;
                 func_8082E634(play, this, &gPlayerAnim_link_swimer_swim_wait);
             }
         }
@@ -16304,16 +16305,16 @@ void Player_Action_59(Player* this, PlayState* play) {
         if (temp_fv0 < this->actor.velocity.y) {
             this->actor.velocity.y = temp_fv0;
         }
-    } else if (this->unk_AE7 == 1) {
+    } else if (this->actionVar1 == 1) {
         PlayerAnimation_Update(play, &this->skelAnime);
         func_808475B4(this);
         if (this->unk_AAA < 0x2710) {
-            this->unk_AE7++;
-            this->unk_AE8 = this->actor.depthInWater;
+            this->actionVar1++;
+            this->actionVar2 = this->actor.depthInWater;
             func_8082E634(play, this, &gPlayerAnim_link_swimer_swim);
         }
     } else if (!func_8083B3B4(play, this, sPlayerControlInput)) {
-        f32 var_fv1 = (this->unk_AE8 * 0.018f) + 4.0f;
+        f32 var_fv1 = (this->actionVar2 * 0.018f) + 4.0f;
 
         if (this->stateFlags1 & PLAYER_STATE1_800) {
             sPlayerControlInput = NULL;
@@ -16561,7 +16562,7 @@ void func_8085255C(PlayState* play, Player* this) {
 }
 
 void func_808525C4(PlayState* play, Player* this) {
-    if (this->unk_AE8++ >= 3) {
+    if (this->actionVar2++ >= 3) {
         if ((this->transformation == PLAYER_FORM_ZORA) || (this->transformation == PLAYER_FORM_DEKU)) {
             func_8082E5A8(play, this, D_8085D190[this->transformation]);
         } else if (this->transformation == PLAYER_FORM_GORON) {
@@ -16578,12 +16579,12 @@ void func_808525C4(PlayState* play, Player* this) {
 void Player_Action_63(Player* this, PlayState* play) {
     if ((this->unk_AA5 != PLAYER_UNKAA5_4) && ((PlayerAnimation_Update(play, &this->skelAnime) &&
                                                 (this->skelAnime.animation == D_8085D17C[this->transformation])) ||
-                                               ((this->skelAnime.mode == 0) && (this->unk_AE8 == 0)))) {
+                                               ((this->skelAnime.mode == 0) && (this->actionVar2 == 0)))) {
         func_808525C4(play, this);
         if (!(this->actor.flags & ACTOR_FLAG_20000000) || (this->unk_A90->id == ACTOR_EN_ZOT)) {
             func_80152434(play, 1);
         }
-    } else if (this->unk_AE8 != 0) {
+    } else if (this->actionVar2 != 0) {
         if (play->msgCtx.ocarinaMode == 4) {
             play->interfaceCtx.unk_222 = 0;
             CutsceneManager_Stop(play->playerCsIds[PLAYER_CS_ID_ITEM_OCARINA]);
@@ -16699,12 +16700,12 @@ void Player_Action_65(Player* this, PlayState* play) {
     func_8083249C(this);
 
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE8 != 0) {
-            if (this->unk_AE8 > 1) {
-                this->unk_AE8--;
+        if (this->actionVar2 != 0) {
+            if (this->actionVar2 > 1) {
+                this->actionVar2--;
             }
 
-            if (func_808482E0(play, this) && (this->unk_AE8 == 1)) {
+            if (func_808482E0(play, this) && (this->actionVar2 == 1)) {
                 Player_SetModels(this, Player_ActionToModelGroup(this, this->itemAction));
 
                 if ((this->getItemDrawIdPlusOne == GID_REMAINS_ODOLWA + 1) ||
@@ -16762,10 +16763,10 @@ void Player_Action_65(Player* this, PlayState* play) {
                                   ANIM_FLAG_80);
                 Player_StopCutscene(this);
                 this->csId = play->playerCsIds[PLAYER_CS_ID_ITEM_GET];
-                this->unk_AE8 = 2;
+                this->actionVar2 = 2;
             }
         }
-    } else if (this->unk_AE8 == 0) {
+    } else if (this->actionVar2 == 0) {
         if (this->transformation == PLAYER_FORM_HUMAN) {
             Player_PlayAnimSfx(this, D_8085D73C);
         } else if (this->transformation == PLAYER_FORM_DEKU) {
@@ -16794,9 +16795,9 @@ AnimSfxEntry D_8085D75C[] = {
 
 void Player_Action_66(Player* this, PlayState* play) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE7 == 0) {
-            if (DECR(this->unk_AE8) == 0) {
-                this->unk_AE7 = 1;
+        if (this->actionVar1 == 0) {
+            if (DECR(this->actionVar2) == 0) {
+                this->actionVar1 = 1;
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
             }
         } else {
@@ -16843,7 +16844,7 @@ void Player_Action_67(Player* this, PlayState* play) {
     func_808323C0(this, play->playerCsIds[PLAYER_CS_ID_ITEM_BOTTLE]);
 
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE8 == 0) {
+        if (this->actionVar2 == 0) {
             if (this->itemAction == PLAYER_IA_BOTTLE_POE) {
                 s32 health = Rand_S16Offset(-1, 3);
 
@@ -16882,31 +16883,31 @@ void Player_Action_67(Player* this, PlayState* play) {
             func_8082DB60(play, this,
                           (this->transformation == PLAYER_FORM_DEKU) ? &gPlayerAnim_pn_drink
                                                                      : &gPlayerAnim_link_bottle_drink_demo_wait);
-            this->unk_AE8 = 1;
+            this->actionVar2 = 1;
 
         //! FAKE
         dummy_label_235515:;
-        } else if (this->unk_AE8 < 0) {
-            this->unk_AE8++;
-            if (this->unk_AE8 == 0) {
-                this->unk_AE8 = 3;
+        } else if (this->actionVar2 < 0) {
+            this->actionVar2++;
+            if (this->actionVar2 == 0) {
+                this->actionVar2 = 3;
                 this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
-            } else if (this->unk_AE8 == -6) {
+            } else if (this->actionVar2 == -6) {
                 func_808530E0(play, this);
             }
         } else {
             Player_StopCutscene(this);
             func_80839E74(this, play);
         }
-    } else if (this->unk_AE8 == 1) {
+    } else if (this->actionVar2 == 1) {
         if ((gSaveContext.healthAccumulator == 0) && (gSaveContext.magicState != MAGIC_STATE_FILL)) {
             if (this->transformation == PLAYER_FORM_DEKU) {
                 PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_pn_drinkend, 2.0f / 3.0f, 0.0f, 5.0f, 2,
                                        -6.0f);
-                this->unk_AE8 = -7;
+                this->actionVar2 = -7;
             } else {
                 func_8082E4A4(play, this, &gPlayerAnim_link_bottle_drink_demo_end);
-                this->unk_AE8 = 2;
+                this->actionVar2 = 2;
             }
 
             Player_UpdateBottleHeld(play, this,
@@ -16915,7 +16916,7 @@ void Player_Action_67(Player* this, PlayState* play) {
         }
 
         Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_DRINK - SFX_FLAG);
-    } else if ((this->unk_AE8 == 2) && PlayerAnimation_OnFrame(&this->skelAnime, 29.0f)) {
+    } else if ((this->actionVar2 == 2) && PlayerAnimation_OnFrame(&this->skelAnime, 29.0f)) {
         Player_AnimSfx_PlayVoice(this, NA_SE_VO_LI_BREATH_DRINK);
     }
 }
@@ -16940,23 +16941,23 @@ struct_8085D798 D_8085D798[] = {
 };
 
 void Player_Action_68(Player* this, PlayState* play) {
-    struct_8085D200* sp24 = &D_8085D200[this->unk_AE8];
+    struct_8085D200* sp24 = &D_8085D200[this->actionVar2];
 
     func_80832F24(this);
 
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE7 != 0) {
+        if (this->actionVar1 != 0) {
             func_808323C0(this, play->playerCsIds[PLAYER_CS_ID_ITEM_SHOW]);
 
-            if (this->unk_AE8 == 0) {
-                Message_StartTextbox(play, D_8085D798[this->unk_AE7 - 1].textId, &this->actor);
+            if (this->actionVar2 == 0) {
+                Message_StartTextbox(play, D_8085D798[this->actionVar1 - 1].textId, &this->actor);
 
                 Audio_PlayFanfare(NA_BGM_GET_ITEM | 0x900);
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
                 Actor* talkActor;
 
-                this->unk_AE7 = 0;
+                this->actionVar1 = 0;
                 Player_StopCutscene(this);
                 func_800E0238(Play_GetCamera(play, CAM_ID_MAIN));
 
@@ -16969,11 +16970,11 @@ void Player_Action_68(Player* this, PlayState* play) {
             func_80839E74(this, play);
         }
     } else {
-        if (this->unk_AE7 == 0) {
+        if (this->actionVar1 == 0) {
             s32 temp_ft5 = this->skelAnime.curFrame - sp24->unk_8;
 
             if ((temp_ft5 >= 0) && (sp24->unk_9 >= temp_ft5)) {
-                if ((this->unk_AE8 != 0) && (temp_ft5 == 0)) {
+                if ((this->actionVar2 != 0) && (temp_ft5 == 0)) {
                     Player_PlaySfx(this, NA_SE_IT_SCOOP_UP_WATER);
                 }
 
@@ -16994,8 +16995,8 @@ void Player_Action_68(Player* this, PlayState* play) {
                         }
 
                         if (i < ARRAY_COUNT(D_8085D798)) {
-                            this->unk_AE7 = i + 1;
-                            this->unk_AE8 = 0;
+                            this->actionVar1 = i + 1;
+                            this->actionVar2 = 0;
                             this->stateFlags1 |= PLAYER_STATE1_10000000 | PLAYER_STATE1_20000000;
                             interactRangeActor->parent = &this->actor;
                             Player_UpdateBottleHeld(play, this, entry->itemId, entry->itemAction);
@@ -17133,12 +17134,12 @@ void Player_Action_71(Player* this, PlayState* play) {
                 this->getItemDrawIdPlusOne = ABS_ALT(giEntry->gid);
             }
 
-            if (this->unk_AE8 == 0) {
+            if (this->actionVar2 == 0) {
                 if ((this->actor.textId != 0) && (this->actor.textId != 0xFFFF)) {
                     Message_StartTextbox(play, this->actor.textId, &this->actor);
                 }
 
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
                 Player_StopCutscene(this);
                 this->getItemDrawIdPlusOne = GID_NONE + 1;
@@ -17147,7 +17148,7 @@ void Player_Action_71(Player* this, PlayState* play) {
                 this->unk_B5E = 0xA;
             }
         }
-    } else if (this->unk_AE8 >= 0) {
+    } else if (this->actionVar2 >= 0) {
         if ((Player_BottleFromIA(this, this->itemAction) > PLAYER_BOTTLE_NONE) &&
             PlayerAnimation_OnFrame(&this->skelAnime, 36.0f)) {
             Player_SetModels(this, PLAYER_MODELGROUP_BOTTLE);
@@ -17159,7 +17160,7 @@ void Player_Action_71(Player* this, PlayState* play) {
         Player_PlayAnimSfx(this, D_8085D840);
     }
 
-    if ((this->unk_AE7 == 0) && (this->lockOnActor != NULL)) {
+    if ((this->actionVar1 == 0) && (this->lockOnActor != NULL)) {
         this->currentYaw = func_8083C62C(this, 0);
         this->actor.shape.rot.y = this->currentYaw;
     }
@@ -17213,7 +17214,7 @@ void Player_Action_73(Player* this, PlayState* play) {
 
     Actor_GetSlopeDirection(floorPoly, &slopeNormal, &downwardSlopeYaw);
     var_v0 = downwardSlopeYaw;
-    if (this->unk_AE7 != 0) {
+    if (this->actionVar1 != 0) {
         var_v0 = downwardSlopeYaw + 0x8000;
     }
     if (this->linearVelocity < 0.0f) {
@@ -17233,8 +17234,8 @@ void Player_Action_73(Player* this, PlayState* play) {
 
     if (Math_AsymStepToF(&this->linearVelocity, var_fv0, temp_fv1, var_fa0) && (var_fv0 == 0.0f)) {
         func_80836A98(this,
-                      (this->unk_AE7 == 0) ? D_8085BE84[PLAYER_ANIMGROUP_41][this->modelAnimType]
-                                           : D_8085BE84[PLAYER_ANIMGROUP_42][this->modelAnimType],
+                      (this->actionVar1 == 0) ? D_8085BE84[PLAYER_ANIMGROUP_41][this->modelAnimType]
+                                              : D_8085BE84[PLAYER_ANIMGROUP_42][this->modelAnimType],
                       play);
     }
 
@@ -17245,7 +17246,7 @@ void Player_Action_73(Player* this, PlayState* play) {
 void func_80859CE0(PlayState* play, Player* this, s32 arg2);
 
 void Player_Action_74(Player* this, PlayState* play) {
-    if ((DECR(this->unk_AE8) == 0) && func_808387A0(play, this)) {
+    if ((DECR(this->actionVar2) == 0) && func_808387A0(play, this)) {
         func_80859CE0(play, this, 0);
         Player_SetAction(play, this, Player_Action_97, 0);
         Player_Action_97(this, play);
@@ -17254,7 +17255,7 @@ void Player_Action_74(Player* this, PlayState* play) {
 
 void Player_Action_75(Player* this, PlayState* play) {
     Player_SetAction(play, this, Player_Action_74, 0);
-    this->unk_AE8 = 0x28;
+    this->actionVar2 = 0x28;
     Actor_Spawn(&play->actorCtx, play, ACTOR_DEMO_KANKYO, 0.0f, 0.0f, 0.0f, 0, 0, 0, 0x10);
 }
 
@@ -17263,11 +17264,11 @@ void Player_Cutscene_SetPosAndYawToStart(Player* this, CsCmdActorCue* cue);
 void Player_Action_76(Player* this, PlayState* play) {
     if (sPlayerYDistToFloor < 150.0f) {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
-            if (this->unk_AE8 == 0) {
+            if (this->actionVar2 == 0) {
                 if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
                     this->skelAnime.endFrame = this->skelAnime.animLength - 1.0f;
                     Player_AnimSfx_PlayFloorLand(this);
-                    this->unk_AE8 = 1;
+                    this->actionVar2 = 1;
                 }
             } else {
                 func_8085B384(this, play);
@@ -17300,9 +17301,9 @@ void Player_Action_77(Player* this, PlayState* play) {
         }
     }
 
-    if ((this->unk_AE8++ >= 9) && !func_8082DA90(play)) {
-        if (this->unk_AE7 != 0) {
-            if (this->unk_AE7 < 0) {
+    if ((this->actionVar2++ >= 9) && !func_8082DA90(play)) {
+        if (this->actionVar1 != 0) {
+            if (this->actionVar1 < 0) {
                 func_80169FDC(&play->state);
             } else {
                 func_80169EFC(&play->state);
@@ -17343,12 +17344,12 @@ void Player_Action_80(Player* this, PlayState* play) {
     if (play->unk_1887C < 0) {
         play->unk_1887C = 0;
         func_80839ED0(this, play);
-    } else if (this->unk_AE7 == 0) {
+    } else if (this->actionVar1 == 0) {
         if ((play->sceneId != SCENE_20SICHITAI) && CHECK_BTN_ALL(sPlayerControlInput->press.button, BTN_B)) {
             play->unk_1887C = 10;
             func_80847880(play, this);
             Player_SetAction(play, this, Player_Action_80, 1);
-            this->unk_AE7 = 1;
+            this->actionVar1 = 1;
         } else {
             play->unk_1887C = 0;
             func_80847190(play, this, 0);
@@ -17371,7 +17372,7 @@ void Player_Action_80(Player* this, PlayState* play) {
         play->unk_1887C = -1;
         Player_Action_81(this, play);
         Player_SetAction(play, this, Player_Action_80, 0);
-        this->unk_AE7 = 0;
+        this->actionVar1 = 0;
     } else {
         play->unk_1887C = 10;
         Player_Action_81(this, play);
@@ -17395,13 +17396,13 @@ void Player_Action_81(Player* this, PlayState* play) {
 }
 
 void Player_Action_82(Player* this, PlayState* play) {
-    if (this->unk_AE7 >= 0) {
-        if (this->unk_AE7 < 6) {
-            this->unk_AE7++;
+    if (this->actionVar1 >= 0) {
+        if (this->actionVar1 < 6) {
+            this->actionVar1++;
         } else {
-            this->unk_B48 = (this->unk_AE7 >> 1) * 22.0f;
+            this->unk_B48 = (this->actionVar1 >> 1) * 22.0f;
             if (func_8082DE88(this, 1, 0x64)) {
-                this->unk_AE7 = -1;
+                this->actionVar1 = -1;
                 EffectSsIcePiece_SpawnBurst(play, &this->actor.world.pos, this->actor.scale.x);
                 Player_PlaySfx(this, NA_SE_PL_ICE_BROKEN);
             }
@@ -17409,8 +17410,8 @@ void Player_Action_82(Player* this, PlayState* play) {
             if (this->transformation == PLAYER_FORM_ZORA) {
                 func_80834104(play, this);
                 this->skelAnime.animation = NULL;
-                this->unk_AE8 = -0x28;
-                this->unk_AE7 = 1;
+                this->actionVar2 = -0x28;
+                this->actionVar1 = 1;
                 this->linearVelocity = 0.0f;
             } else if (play->gameplayFrames % 4 == 0) {
                 Player_InflictDamage(play, -1);
@@ -17428,8 +17429,8 @@ void Player_Action_83(Player* this, PlayState* play) {
     PlayerAnimation_Update(play, &this->skelAnime);
     func_808345A8(this);
 
-    if (((this->unk_AE8 % 25) != 0) || (func_808339D4(play, this, -1) != 0)) {
-        if (DECR(this->unk_AE8) == 0) {
+    if (((this->actionVar2 % 25) != 0) || (func_808339D4(play, this, -1) != 0)) {
+        if (DECR(this->actionVar2) == 0) {
             func_80836988(this, play);
         }
     }
@@ -17479,7 +17480,7 @@ void Player_Action_84(Player* this, PlayState* play) {
         ((this->meleeWeaponAnimation >= PLAYER_MWA_FLIPSLASH_FINISH) &&
          (this->meleeWeaponAnimation <= PLAYER_MWA_ZORA_JUMPKICK_FINISH) && (this->skelAnime.curFrame > 2.0f) &&
          func_808333CC(this))) {
-        D_80862B48 = this->unk_AE8;
+        D_80862B48 = this->actionVar2;
 
         if (!func_80848570(this, play)) {
             PlayerAnimationHeader* anim = func_80123420(this) ? attackInfoEntry->unk_8 : attackInfoEntry->unk_4;
@@ -17515,7 +17516,7 @@ void Player_Action_84(Player* this, PlayState* play) {
                 (this->meleeWeaponAnimation != PLAYER_MWA_ZORA_JUMPKICK_FINISH)) ||
                ((this->transformation == PLAYER_FORM_GORON) &&
                 (this->meleeWeaponAnimation != PLAYER_MWA_GORON_PUNCH_BUTT))) {
-        this->unk_AE8 |= CHECK_BTN_ALL(sPlayerControlInput->press.button, BTN_B) ? 1 : 0;
+        this->actionVar2 |= CHECK_BTN_ALL(sPlayerControlInput->press.button, BTN_B) ? 1 : 0;
     }
 }
 
@@ -17685,19 +17686,19 @@ void func_80855218(PlayState* play, Player* this, struct_8085D910** arg2) {
         func_8082DB60(play, this, &gPlayerAnim_cl_setmaskend);
     } else if ((this->skelAnime.animation == &gPlayerAnim_cl_setmask) ||
                (this->skelAnime.animation == &gPlayerAnim_cl_setmaskend)) {
-        if (this->unk_AE7 >= 58) {
-            Math_StepToS(&this->unk_AE8, 255, 50);
+        if (this->actionVar1 >= 58) {
+            Math_StepToS(&this->actionVar2, 255, 50);
         }
 
-        if (this->unk_AE7 >= 64) {
+        if (this->actionVar1 >= 64) {
             Math_StepToF(&this->unk_B10[2], 0.0f, 0.015f);
-        } else if (this->unk_AE7 >= 0xE) {
+        } else if (this->actionVar1 >= 0xE) {
             Math_StepToF(&this->unk_B10[2], 0.3f, 0.3f);
         }
 
-        if (this->unk_AE7 > 65) {
+        if (this->actionVar1 > 65) {
             Math_StepToF(&this->unk_B10[3], 0.0f, 0.02f);
-        } else if (this->unk_AE7 >= 0x10) {
+        } else if (this->actionVar1 >= 0x10) {
             Math_StepToF(&this->unk_B10[3], -0.1f, 0.1f);
         }
 
@@ -17705,13 +17706,13 @@ void func_80855218(PlayState* play, Player* this, struct_8085D910** arg2) {
             Player_PlayAnimSfx(this, D_8085D8F0);
         }
     } else {
-        if (this->unk_AE7 >= 20) {
-            Math_StepToS(&this->unk_AE8, 255, 20);
+        if (this->actionVar1 >= 20) {
+            Math_StepToS(&this->actionVar2, 255, 20);
         }
 
         if (R_PLAY_FILL_SCREEN_ON == 0) {
             Player_PlayAnimSfx(this, D_8085D904);
-            if (this->unk_AE7 == 15) {
+            if (this->actionVar1 == 15) {
                 Player_PlaySfx(this, NA_SE_PL_FACE_CHANGE);
             }
         }
@@ -17743,7 +17744,7 @@ void Player_Action_86(Player* this, PlayState* play) {
 
     func_80855218(play, this, &sp4C);
 
-    if (this->unk_AE7 == 0x14) {
+    if (this->actionVar1 == 0x14) {
         Play_EnableMotionBlurPriority(100);
     }
 
@@ -17753,12 +17754,12 @@ void Player_Action_86(Player* this, PlayState* play) {
             R_PLAY_FILL_SCREEN_ALPHA = 255;
             this->actor.update = func_8012301C;
             this->actor.draw = NULL;
-            this->unk_AE7 = 0;
+            this->actionVar1 = 0;
             Play_DisableMotionBlurPriority();
             SET_WEEKEVENTREG(D_8085D908[GET_PLAYER_FORM]);
         }
-    } else if ((this->unk_AE7++ > ((this->transformation == PLAYER_FORM_HUMAN) ? 0x53 : 0x37)) ||
-               ((this->unk_AE7 >= 5) &&
+    } else if ((this->actionVar1++ > ((this->transformation == PLAYER_FORM_HUMAN) ? 0x53 : 0x37)) ||
+               ((this->actionVar1 >= 5) &&
                 (sp48 =
                      ((this->transformation != PLAYER_FORM_HUMAN) || CHECK_WEEKEVENTREG(D_8085D908[GET_PLAYER_FORM])) &&
                      CHECK_BTN_ANY(sPlayerControlInput->press.button,
@@ -17785,11 +17786,11 @@ void Player_Action_86(Player* this, PlayState* play) {
         Player_PlaySfx(this, NA_SE_SY_TRANSFORM_MASK_FLASH);
     }
 
-    if (this->unk_AE7 >= sp4C->unk_0) {
-        if (this->unk_AE7 < sp4C->unk_2) {
+    if (this->actionVar1 >= sp4C->unk_0) {
+        if (this->actionVar1 < sp4C->unk_2) {
             Math_StepToF(&this->unk_B10[4], 1.0f, sp4C->unk_1 / 100.0f);
-        } else if (this->unk_AE7 < sp4C->unk_3) {
-            if (this->unk_AE7 == sp4C->unk_2) {
+        } else if (this->actionVar1 < sp4C->unk_3) {
+            if (this->actionVar1 == sp4C->unk_2) {
                 Lib_PlaySfx_2(NA_SE_EV_LIGHTNING_HARD);
             }
 
@@ -17799,10 +17800,10 @@ void Player_Action_86(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_AE7 >= 0x10) {
-        if (this->unk_AE7 < 0x40) {
+    if (this->actionVar1 >= 0x10) {
+        if (this->actionVar1 < 0x40) {
             Math_StepToF(&this->unk_B10[5], 1.0f, 0.2f);
-        } else if (this->unk_AE7 < 0x37) {
+        } else if (this->actionVar1 < 0x37) {
             Math_StepToF(&this->unk_B10[5], 2.0f, 1.0f);
         } else {
             Math_StepToF(&this->unk_B10[5], 3.0f, 0.55f);
@@ -17824,8 +17825,8 @@ void Player_Action_87(Player* this, PlayState* play) {
         }
     }
 
-    if (this->unk_AE7++ < 4) {
-        if ((this->prevMask == PLAYER_MASK_NONE) && (this->unk_AE7 == 4)) {
+    if (this->actionVar1++ < 4) {
+        if ((this->prevMask == PLAYER_MASK_NONE) && (this->actionVar1 == 4)) {
             PlayerAnimation_Change(play, &this->skelAnime, func_8082ED20(this), 1.0f, 0.0f, 20.0f, ANIMMODE_ONCE,
                                    20.0f);
         }
@@ -17835,7 +17836,7 @@ void Player_Action_87(Player* this, PlayState* play) {
         s16 angle;
 
         Lib_GetControlStickData(&dist, &angle, play->state.input);
-        if (PlayerAnimation_Update(play, &this->skelAnime) || ((this->unk_AE7 > 10) && (dist != 0.0f))) {
+        if (PlayerAnimation_Update(play, &this->skelAnime) || ((this->actionVar1 > 10) && (dist != 0.0f))) {
             if (R_PLAY_FILL_SCREEN_ON == 0) {
                 this->stateFlags1 &= ~PLAYER_STATE1_2;
                 this->prevMask = this->currentMask;
@@ -17854,10 +17855,10 @@ void Player_Action_87(Player* this, PlayState* play) {
 }
 
 void Player_Action_88(Player* this, PlayState* play) {
-    if (this->unk_AE8++ > 90) {
+    if (this->actionVar2++ > 90) {
         play->msgCtx.ocarinaMode = 4;
         func_8085B384(this, play);
-    } else if (this->unk_AE8 == 10) {
+    } else if (this->actionVar2 == 10) {
         func_80848640(play, this);
     }
 }
@@ -17867,7 +17868,7 @@ void Player_Action_89(Player* this, PlayState* play) {
     this->stateFlags2 |= PLAYER_STATE2_40;
 
     func_80855218(play, this, NULL);
-    this->unk_AE7++;
+    this->actionVar1++;
 
     if (!(this->stateFlags1 & PLAYER_STATE1_100)) {
         this->prevMask = this->currentMask;
@@ -17909,10 +17910,10 @@ void Player_Action_91(Player* this, PlayState* play) {
     var_a0 = 0;
     if ((this->actor.floorHeight - this->actor.world.pos.y) < 60.0f) {
         Math_StepToF(&this->unk_B10[5], 200.0f, 150.0f);
-        var_a0 = Math_StepToS(&this->unk_AE8, 0xFA0, 0x15E);
+        var_a0 = Math_StepToS(&this->actionVar2, 0xFA0, 0x15E);
     }
 
-    this->actor.shape.rot.y += this->unk_AE8;
+    this->actor.shape.rot.y += this->actionVar2;
     this->skelAnime.jointTable[PLAYER_LIMB_ROOT - 1].x = 0;
     this->skelAnime.jointTable[PLAYER_LIMB_ROOT - 1].z = 0;
     this->unk_ABC += this->unk_B10[5];
@@ -17933,9 +17934,9 @@ void Player_Action_91(Player* this, PlayState* play) {
                 }
             }
         }
-    } else if (this->unk_AE7 == 0) {
+    } else if (this->actionVar1 == 0) {
         Player_PlaySfx(this, NA_SE_PL_WARP_PLATE_OUT);
-        this->unk_AE7 = 1;
+        this->actionVar1 = 1;
     }
 }
 
@@ -18030,15 +18031,15 @@ void Player_Action_93(Player* this, PlayState* play) {
         return;
     }
 
-    if (this->unk_AE7 == 0) {
+    if (this->actionVar1 == 0) {
         this->unk_ABC += this->unk_B48;
         if (this->unk_ABC < -1000.0f) {
             this->unk_ABC = -1000.0f;
-            this->unk_AE7 = 1;
+            this->actionVar1 = 1;
             this->unk_B48 = 0.0f;
         }
         func_80856074(play, this);
-    } else if (this->unk_AE7 == 1) {
+    } else if (this->actionVar1 == 1) {
         this->unk_B48 += -22.0f;
         if (this->unk_B48 < -170.0f) {
             this->unk_B48 = -170.0f;
@@ -18046,7 +18047,7 @@ void Player_Action_93(Player* this, PlayState* play) {
         this->unk_ABC += this->unk_B48;
         if (this->unk_ABC < -3900.0f) {
             this->unk_ABC = -3900.0f;
-            this->unk_AE7 = 2;
+            this->actionVar1 = 2;
             this->actor.shape.rot.y = Camera_GetInputDirYaw(play->cameraPtrs[play->activeCamId]);
             this->actor.scale.y = 0.01f;
             this->currentYaw = this->actor.world.rot.y = this->actor.shape.rot.y;
@@ -18066,22 +18067,22 @@ void Player_Action_93(Player* this, PlayState* play) {
         }
 
         func_80856074(play, this);
-    } else if (this->unk_AE7 == 2) {
+    } else if (this->actionVar1 == 2) {
         if (!CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A)) {
             if (func_80856000(play, this)) {
-                this->unk_AE8 = 0;
+                this->actionVar2 = 0;
             } else {
-                this->unk_AE7 = 3;
-                if (this->unk_AE8 >= 10) {
+                this->actionVar1 = 3;
+                if (this->actionVar2 >= 10) {
                     this->unk_B48 = 2700.0f;
                 } else {
                     this->unk_B48 = 1450.0f;
                 }
                 func_8082E1F0(this, NA_SE_PL_DEKUNUTS_OUT_GRD);
             }
-        } else if (this->unk_AE8 < 15) {
-            this->unk_AE8++;
-            if (this->unk_AE8 == 10) {
+        } else if (this->actionVar2 < 15) {
+            this->actionVar2++;
+            if (this->actionVar2 == 10) {
                 func_80856110(play, this, 20.0f, 3.8f, -0.1f, 140, 23, 15);
             }
         }
@@ -18093,7 +18094,7 @@ void Player_Action_93(Player* this, PlayState* play) {
         if (temp_fv0_2 >= 0.0f) {
             f32 speed;
 
-            sp38 = (this->unk_AE8 >= 10);
+            sp38 = (this->actionVar2 >= 10);
             var_v1 = -1;
             speed = this->unk_B48 * this->actor.scale.y;
             if (this->actor.floorBgId != BGCHECK_SCENE) {
@@ -18120,8 +18121,8 @@ void Player_Action_93(Player* this, PlayState* play) {
                 this->stateFlags3 |= PLAYER_STATE3_40000;
             }
 
-            this->unk_AE7 = var_v1;
-            this->unk_AE8 = 9999;
+            this->actionVar1 = var_v1;
+            this->actionVar2 = 9999;
             Player_SetCylinderForAttack(this, DMG_DEKU_LAUNCH, 2, 20);
         } else if (this->unk_ABC < 0.0f) {
             func_80856074(play, this);
@@ -18232,7 +18233,7 @@ void Player_Action_94(Player* this, PlayState* play) {
         func_80833AA0(this, play);
     } else if (this->stateFlags3 & PLAYER_STATE3_200) {
         if (this->actor.velocity.y < 0.0f) {
-            if (this->unk_AE7 < 0) {
+            if (this->actionVar1 < 0) {
                 func_80833AA0(this, play);
             } else {
                 PlayerAnimation_Update(play, &this->skelAnime);
@@ -18282,14 +18283,14 @@ void Player_Action_94(Player* this, PlayState* play) {
 
         func_8085687C(this);
 
-        if (this->unk_AE8 != 0) {
-            this->unk_AE8--;
+        if (this->actionVar2 != 0) {
+            this->actionVar2--;
         }
 
-        temp_fv1 = D_8085D958[this->unk_AE7] - Math_Vec3f_DistXZ(&this->actor.world.pos, this->unk_AF0);
+        temp_fv1 = D_8085D958[this->actionVar1] - Math_Vec3f_DistXZ(&this->actor.world.pos, this->unk_AF0);
         PlayerAnimation_Update(play, &this->skelAnime);
 
-        if ((this->unk_AE8 != 0) && (temp_fv1 > 300.0f)) {
+        if ((this->actionVar2 != 0) && (temp_fv1 > 300.0f)) {
             sp76 = 0x1770;
             if (this->skelAnime.animation != &gPlayerAnim_pn_kakku) {
                 func_8082E5EC(play, this, &gPlayerAnim_pn_kakkufinish);
@@ -18306,7 +18307,7 @@ void Player_Action_94(Player* this, PlayState* play) {
                     func_808566C0(play, this, PLAYER_BODYPART_RIGHT_HAND, 0.6f, 1.0f, 0.8f, 17);
                 }
             }
-        } else if ((this->unk_AE8 == 0) || (temp_fv1 < 0.0f)) {
+        } else if ((this->actionVar2 == 0) || (temp_fv1 < 0.0f)) {
             sp76 = 0;
             func_808355D8(play, this, &gPlayerAnim_pn_rakkafinish);
         } else {
@@ -18445,10 +18446,10 @@ void func_80857640(Player* this, f32 arg1, s32 arg2) {
     func_80834CD0(this, arg1, NA_SE_VO_LI_SWORD_N);
     Player_PlaySfx(this, NA_SE_PL_GORON_BALLJUMP);
     Player_StopHorizontalMovement(this);
-    if (this->unk_AE8 < arg2) {
-        this->unk_AE8 = arg2;
+    if (this->actionVar2 < arg2) {
+        this->actionVar2 = arg2;
     }
-    this->unk_AE7 = 1;
+    this->actionVar1 = 1;
     this->unk_B48 = 1.0f;
 }
 
@@ -18457,7 +18458,7 @@ void func_808576BC(PlayState* play, Player* this) {
                   (this->actor.velocity.x * Math_SinS(this->currentYaw))) *
                  800.0f;
 
-    var_v0 -= this->unk_AE8;
+    var_v0 -= this->actionVar2;
     var_v0 = ABS_ALT(var_v0);
 
     if (var_v0 <= 0x7D0) {
@@ -18476,7 +18477,7 @@ void func_808576BC(PlayState* play, Player* this) {
 }
 
 void func_808577E0(Player* this) {
-    f32 temp_fa1 = ABS_ALT(this->unk_AE8) * 0.00004f;
+    f32 temp_fa1 = ABS_ALT(this->actionVar2) * 0.00004f;
 
     if (this->unk_ABC < temp_fa1) {
         this->unk_B48 += 0.08f;
@@ -18497,7 +18498,7 @@ void func_808577E0(Player* this) {
 
 s32 func_80857950(PlayState* play, Player* this) {
     if (((this->unk_B86[1] == 0) && !CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A)) ||
-        ((this->unk_AE7 == 3) && (this->actor.velocity.y < 0.0f))) {
+        ((this->actionVar1 == 3) && (this->actor.velocity.y < 0.0f))) {
         Player_SetAction(play, this, Player_Action_4, 1);
         Math_Vec3f_Copy(&this->actor.world.pos, &this->actor.prevPos);
         PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_pg_maru_change, -2.0f / 3.0f, 7.0f, 0.0f,
@@ -18515,9 +18516,9 @@ s32 func_80857A44(PlayState* play, Player* this) {
 
         this->actor.shape.shadowDraw = ActorShadow_DrawCircle;
         this->actor.bgCheckFlags |= BGCHECKFLAG_PLAYER_800;
-        this->unk_AE7 = 4;
+        this->actionVar1 = 4;
         this->actor.shape.shadowScale = 30.0f;
-        this->unk_AE8 = this->linearVelocity * 500.0f;
+        this->actionVar2 = this->linearVelocity * 500.0f;
         this->unk_B08 = this->linearVelocity;
         this->unk_B0C = 0.0f;
         this->actor.home.rot.y = this->currentYaw;
@@ -18533,17 +18534,17 @@ void func_80857AEC(PlayState* play, Player* this) {
         this->unk_B0C += this->unk_B08 * 0.05f;
 
         if (this->unk_B86[1] == 0) {
-            if (this->unk_AE7 == 1) {
-                this->unk_AE7 = 2;
+            if (this->actionVar1 == 1) {
+                this->actionVar1 = 2;
                 Player_RequestQuakeAndRumble(play, this, NA_SE_PL_GORON_PUNCH);
                 play->actorCtx.unk2 = 4;
                 EffectSsBlast_SpawnWhiteShockwave(play, &this->actor.world.pos, &gZeroVec3f, &gZeroVec3f);
-                this->unk_AE8 = 0;
+                this->actionVar2 = 0;
                 this->unk_B08 = 0.0f;
                 Actor_Spawn(&play->actorCtx, play, ACTOR_EN_TEST, this->actor.world.pos.x, this->actor.world.pos.y,
                             this->actor.world.pos.z, 0, 0, 0, 0);
             } else {
-                this->unk_AE7 = 4;
+                this->actionVar1 = 4;
             }
         }
 
@@ -18557,7 +18558,7 @@ void Player_Action_96(Player* this, PlayState* play) {
         return;
     }
 
-    if ((this->unk_AE7 == 0) && !func_80857A44(play, this)) {
+    if ((this->actionVar1 == 0) && !func_80857A44(play, this)) {
         return;
     }
 
@@ -18580,7 +18581,7 @@ void Player_Action_96(Player* this, PlayState* play) {
             func_80834CD0(this, 10.0f, 0);
             if (this->unk_B86[1] != 0) {
                 this->unk_B86[1] = 0;
-                this->unk_AE7 = 3;
+                this->actionVar1 = 3;
             }
         } else if ((this->actor.bgCheckFlags & BGCHECKFLAG_WALL) && (this->unk_B08 >= 12.0f)) {
             s16 temp_v0 = this->currentYaw - BINANG_ADD(this->actor.wallYaw, 0x8000);
@@ -18613,17 +18614,17 @@ void Player_Action_96(Player* this, PlayState* play) {
 
         if (this->unk_B86[1] != 0) {
             speedTarget = 18.0f;
-            Math_StepToC(&this->unk_AE7, 4, 1);
+            Math_StepToC(&this->actionVar1, 4, 1);
 
             if ((this->stateFlags3 & PLAYER_STATE3_80000) && (!CHECK_BTN_ALL(sPlayerControlInput->cur.button, BTN_A) ||
                                                               (gSaveContext.save.saveInfo.playerData.magic == 0) ||
-                                                              ((this->unk_AE7 == 4) && (this->unk_B08 < 12.0f)))) {
+                                                              ((this->actionVar1 == 4) && (this->unk_B08 < 12.0f)))) {
                 if (Math_StepToS(&this->unk_B86[1], 0, 1)) {
                     this->stateFlags3 &= ~PLAYER_STATE3_80000;
                     Magic_Reset(play);
                     Player_PlaySfx(this, NA_SE_PL_GORON_BALL_CHARGE_FAILED);
                 }
-                this->unk_AE7 = 4;
+                this->actionVar1 = 4;
             } else if (this->unk_B86[1] < 7) {
                 if (!(this->stateFlags3 & PLAYER_STATE3_80000)) {
                     this->unk_3D0.unk_00 = 2;
@@ -18637,9 +18638,9 @@ void Player_Action_96(Player* this, PlayState* play) {
         Math_AsymStepToF(&this->unk_B10[0], (this->unk_B8A != 0) ? 1.0f : 0.0f, 0.8f, 0.05f);
         if (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) {
             func_80857AEC(play, this);
-            if (this->unk_AE7 == 2) {
+            if (this->actionVar1 == 2) {
                 if (this->unk_B8A == 0) {
-                    this->unk_AE7 = 4;
+                    this->actionVar1 = 4;
                 } else {
                     this->unk_B8A--;
                     this->unk_ABC = 0.0f;
@@ -18670,7 +18671,7 @@ void Player_Action_96(Player* this, PlayState* play) {
 
                 if (this->unk_B86[1] == 0) {
                     this->unk_B0C = 0.0f;
-                    if (this->unk_AE7 >= 0x36) {
+                    if (this->actionVar1 >= 0x36) {
                         Magic_Consume(play, 2, MAGIC_CONSUME_GORON_ZORA);
                         this->unk_B08 = 18.0f;
                         this->unk_B86[1] = 1;
@@ -18707,12 +18708,12 @@ void Player_Action_96(Player* this, PlayState* play) {
                 spCC = speedTarget;
                 spCA = yawTarget;
 
-                if (func_8083A4A4(this, &spCC, &spCA, (this->unk_AE7 >= 5) ? 0.0f : 1.0f)) {
+                if (func_8083A4A4(this, &spCC, &spCA, (this->actionVar1 >= 5) ? 0.0f : 1.0f)) {
                     if (this->unk_B86[1] == 0) {
-                        this->unk_AE7 = 4;
+                        this->actionVar1 = 4;
                     }
 
-                    if (this->unk_AE7 == 4) {
+                    if (this->actionVar1 == 4) {
                         spDC = -0xFA0;
                     }
                 } else {
@@ -18724,7 +18725,7 @@ void Player_Action_96(Player* this, PlayState* play) {
                                  (sPlayerFloorType == FLOOR_TYPE_5)) &&
                                 (spC0 >= 0x7D0))
                                    ? 0.08f
-                                   : this->unk_AE8 * 0.0003f;
+                                   : this->actionVar2 * 0.0003f;
                     f32 sp80 = (Math_SinS(this->floorPitch) * 8.0f) + 0.6f;
                     s16 var_a3;
                     s16 sp7C;
@@ -18734,11 +18735,11 @@ void Player_Action_96(Player* this, PlayState* play) {
 
                     if (this->unk_B86[1] == 0) {
                         if ((gSaveContext.magicState == MAGIC_STATE_IDLE) &&
-                            (gSaveContext.save.saveInfo.playerData.magic >= 2) && (this->unk_AE8 >= 0x36B0)) {
-                            this->unk_AE7++;
+                            (gSaveContext.save.saveInfo.playerData.magic >= 2) && (this->actionVar2 >= 0x36B0)) {
+                            this->actionVar1++;
                             Actor_PlaySfx_FlaggedCentered1(&this->actor, NA_SE_PL_GORON_BALL_CHARGE - SFX_FLAG);
                         } else {
-                            this->unk_AE7 = 4;
+                            this->actionVar1 = 4;
                         }
                     }
 
@@ -18780,9 +18781,9 @@ void Player_Action_96(Player* this, PlayState* play) {
                 if (this->unk_B86[1] != 0) {
                     if ((ABS_ALT(sp8E) + ABS_ALT(this->floorPitch)) > 0x3A98) {
                         this->unk_B86[1] = 0;
-                        this->unk_AE7 = 4;
+                        this->actionVar1 = 4;
                         this->unk_B8E = 0x14;
-                        this->unk_AE8 = 0;
+                        this->actionVar2 = 0;
                         this->stateFlags3 &= ~PLAYER_STATE3_80000;
                         Magic_Reset(play);
                     }
@@ -18813,7 +18814,7 @@ void Player_Action_96(Player* this, PlayState* play) {
                         this->unk_B28 = Math_Atan2S_XY(spA0, spA4);
                     }
 
-                    if (this->unk_AE8 == 0) {
+                    if (this->actionVar2 == 0) {
                         s32 temp_v0_10 = this->unk_B86[0];
                         s32 temp_ft3_2 = sp54 * 800.0f;
 
@@ -18840,7 +18841,7 @@ void Player_Action_96(Player* this, PlayState* play) {
 
             func_808576BC(play, this);
 
-            if (ABS_ALT(this->unk_AE8) > 0xFA0) {
+            if (ABS_ALT(this->actionVar2) > 0xFA0) {
                 this->stateFlags2 |= PLAYER_STATE2_8;
             }
 
@@ -18870,7 +18871,7 @@ void Player_Action_96(Player* this, PlayState* play) {
                 this->unk_B08 = CLAMP_MAX(this->unk_B08, 18.0f);
             } else {
                 this->unk_B48 += this->actor.velocity.y * 0.005f;
-                if (this->unk_AE7 == 1) {
+                if (this->actionVar1 == 1) {
                     if (this->actor.velocity.y > 0.0f) {
                         if ((this->actor.velocity.y + this->actor.gravity) < 0.0f) {
                             this->actor.velocity.y = -this->actor.gravity;
@@ -18893,21 +18894,21 @@ void Player_Action_96(Player* this, PlayState* play) {
 
         Math_ScaledStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 0x7D0);
 
-        Math_AsymStepToS(&this->unk_AE8, spDC, (spDC >= 0) ? 0x7D0 : 0x3E8, 0x4B0);
+        Math_AsymStepToS(&this->actionVar2, spDC, (spDC >= 0) ? 0x7D0 : 0x3E8, 0x4B0);
 
-        if (this->unk_AE8 != 0) {
+        if (this->actionVar2 != 0) {
             spD8 = this->actor.shape.rot.x;
-            this->actor.shape.rot.x += this->unk_AE8;
+            this->actor.shape.rot.x += this->actionVar2;
 
-            Math_ScaledStepToS(&this->unk_B86[0], 0, ABS_ALT(this->unk_AE8));
-            if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (((this->unk_AE8 + spD8) * spD8) <= 0)) {
+            Math_ScaledStepToS(&this->unk_B86[0], 0, ABS_ALT(this->actionVar2));
+            if ((this->actor.bgCheckFlags & BGCHECKFLAG_GROUND) && (((this->actionVar2 + spD8) * spD8) <= 0)) {
                 spE0 =
                     Player_GetFloorSfx(this, (this->unk_B86[1] != 0) ? NA_SE_PL_GORON_CHG_ROLL : NA_SE_PL_GORON_ROLL);
                 Audio_PlaySfx_AtPosWithSyncedFreqAndVolume(&this->actor.projectedPos, spE0, this->unk_B08);
             }
         }
 
-        if (this->unk_AE7 == 2) {
+        if (this->actionVar1 == 2) {
             Player_SetCylinderForAttack(this, DMG_GORON_POUND, 4, 60);
             Actor_SetPlayerImpact(play, PLAYER_IMPACT_GORON_GROUND_POUND, 2, 100.0f, &this->actor.world.pos);
         } else if (this->unk_B86[1] != 0) {
@@ -19124,7 +19125,7 @@ AnimSfxEntry D_8085DA90[] = {
 void Player_CsAnim_12(PlayState* play, Player* this, void* anim) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         func_80858D48(play, this, anim);
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
 
     if (this->skelAnime.animation == &gPlayerAnim_okiagaru_tatu) {
@@ -19154,7 +19155,7 @@ void Player_CsAnim_17(PlayState* play, Player* this, void* anim) {
 void Player_CsAnim_13(PlayState* play, Player* this, void* anim) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         func_8082EB18(play, this, anim);
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
 }
 
@@ -19184,9 +19185,9 @@ void func_8085929C(PlayState* play, Player* this, UNK_TYPE arg2) {
 void func_80859300(PlayState* play, Player* this, UNK_TYPE arg2) {
     this->actor.gravity = 0.0f;
 
-    if (this->unk_AE7 == 0) {
+    if (this->actionVar1 == 0) {
         if ((this->transformation == PLAYER_FORM_DEKU) || func_8083B3B4(play, this, NULL)) {
-            this->unk_AE7 = 1;
+            this->actionVar1 = 1;
         } else {
             func_808477D0(play, this, NULL, fabsf(this->actor.velocity.y));
             Math_ScaledStepToS(&this->unk_AAA, -0x2710, 0x320);
@@ -19194,7 +19195,7 @@ void func_80859300(PlayState* play, Player* this, UNK_TYPE arg2) {
         }
     } else {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
-            if (this->unk_AE7 == 1) {
+            if (this->actionVar1 == 1) {
                 func_8082E634(play, this, &gPlayerAnim_link_swimer_swim_wait);
             } else {
                 Player_AnimationPlayLoop(play, this, &gPlayerAnim_link_swimer_swim_wait);
@@ -19598,7 +19599,7 @@ void Player_CsAction_6(PlayState* play, Player* this, CsCmdActorCue* cue) {
             gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
             this->actor.update = func_8012301C;
             this->actor.draw = NULL;
-            this->unk_AE7 = 0;
+            this->actionVar1 = 0;
         }
     } else if (R_PLAY_FILL_SCREEN_ON < 0) {
         R_PLAY_FILL_SCREEN_ALPHA += R_PLAY_FILL_SCREEN_ON;
@@ -19609,8 +19610,8 @@ void Player_CsAction_6(PlayState* play, Player* this, CsCmdActorCue* cue) {
     } else {
         sp24 = 2.5f;
         func_808411D4(play, this, &sp24, 0xA);
-        this->unk_AE8++;
-        if (this->unk_AE8 >= 0x15) {
+        this->actionVar2++;
+        if (this->actionVar2 >= 0x15) {
             this->csMode = PLAYER_CSMODE_10;
         }
     }
@@ -19633,10 +19634,10 @@ void Player_CsAction_9(PlayState* play, Player* this, CsCmdActorCue* cue) {
 
 void Player_CsAction_10(PlayState* play, Player* this, CsCmdActorCue* cue) {
     func_80859248(this);
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         if (PlayerAnimation_Update(play, &this->skelAnime)) {
             Player_AnimationPlayLoop(play, this, func_8082EF54(this));
-            this->unk_AE8 = 0;
+            this->actionVar2 = 0;
         }
         func_8082FC60(this);
     } else {
@@ -19744,7 +19745,7 @@ void Player_CsAction_19(PlayState* play, Player* this, CsCmdActorCue* cue) {
 void Player_CsAction_20(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
         Player_CsAction_End(play, this, cue);
-    } else if (this->unk_AE8 == 0) {
+    } else if (this->actionVar2 == 0) {
         Item_Give(play, ITEM_SWORD_RAZOR);
         func_80841358(play, this, false);
     } else {
@@ -19841,7 +19842,7 @@ void Player_CsAction_30(PlayState* play, Player* this, CsCmdActorCue* cue) {
         func_808525C4(play, this);
         return;
     }
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         func_8085255C(play, this);
     }
 }
@@ -19876,12 +19877,12 @@ void Player_CsAction_33(PlayState* play, Player* this, CsCmdActorCue* cue) {
 }
 
 void Player_CsAction_34(PlayState* play, Player* this, CsCmdActorCue* cue) {
-    if (PlayerAnimation_Update(play, &this->skelAnime) && (this->unk_AE8 == 0) &&
+    if (PlayerAnimation_Update(play, &this->skelAnime) && (this->actionVar2 == 0) &&
         (this->actor.bgCheckFlags & BGCHECKFLAG_GROUND)) {
         Player_AnimationPlayOnce(play, this, &gPlayerAnim_link_normal_back_downB);
-        this->unk_AE8 = 1;
+        this->actionVar2 = 1;
     }
-    if (this->unk_AE8 != 0) {
+    if (this->actionVar2 != 0) {
         func_80832F24(this);
     }
 }
@@ -19894,7 +19895,7 @@ void Player_CsAction_35(PlayState* play, Player* this, CsCmdActorCue* cue) {
 
 void Player_CsAction_36(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE8++ >= 0x15) {
+        if (this->actionVar2++ >= 0x15) {
             PlayerAnimation_Change(play, &this->skelAnime, &gPlayerAnim_pz_wait, 1.0f, 0.0f, 0.0f, ANIMMODE_LOOP,
                                    -16.0f);
         }
@@ -19933,18 +19934,18 @@ void Player_CsAction_40(PlayState* play, Player* this, CsCmdActorCue* cue) {
 
 void Player_CsAction_41(PlayState* play, Player* this, CsCmdActorCue* cue) {
     if (PlayerAnimation_Update(play, &this->skelAnime)) {
-        if (this->unk_AE8 == 0) {
+        if (this->actionVar2 == 0) {
             if ((Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) ||
                 (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE)) {
                 this->getItemDrawIdPlusOne = GID_NONE + 1;
-                this->unk_AE8 = -1;
+                this->actionVar2 = -1;
             } else {
                 this->getItemDrawIdPlusOne = GID_PENDANT_OF_MEMORIES + 1;
             }
-        } else if (this->unk_AE8 < 0) {
+        } else if (this->actionVar2 < 0) {
             if (Actor_HasParent(&this->actor, play)) {
                 this->actor.parent = NULL;
-                this->unk_AE8 = 1;
+                this->actionVar2 = 1;
             } else {
                 Actor_OfferGetItem(&this->actor, play, GI_PENDANT_OF_MEMORIES, 9999.9f, 9999.9f);
             }
@@ -19974,7 +19975,7 @@ void Player_CsAction_43(PlayState* play, Player* this, CsCmdActorCue* cue) {
             gSaveContext.save.playerForm = PLAYER_FORM_HUMAN;
             this->actor.update = func_8012301C;
             this->actor.draw = NULL;
-            this->unk_AE7 = 0;
+            this->actionVar1 = 0;
         }
     } else if (R_PLAY_FILL_SCREEN_ON < 0) {
         R_PLAY_FILL_SCREEN_ALPHA += R_PLAY_FILL_SCREEN_ON;
@@ -20124,8 +20125,8 @@ void Player_CsAction_48(PlayState* play, Player* this, CsCmdActorCue* cue) {
         func_8085AD5C(play, this, ABS_ALT(csMode));
         func_8085AC9C(play, this, playerCue, &sPlayerCsModeInitFuncs[ABS_ALT(csMode)]);
 
-        this->unk_AE8 = 0;
-        this->unk_AE7 = 0;
+        this->actionVar2 = 0;
+        this->actionVar1 = 0;
         this->cueId = playerCue->id;
     }
 
@@ -20264,11 +20265,11 @@ void Player_TalkWithPlayer(PlayState* play, Actor* actor) {
         }
 
         if (player->stateFlags1 & PLAYER_STATE1_800000) {
-            s32 sp24 = player->unk_AE8;
+            s32 sp24 = player->actionVar2;
 
             func_8082DE14(play, player);
             func_80837B60(play, player);
-            player->unk_AE8 = sp24;
+            player->actionVar2 = sp24;
         } else {
             if (func_801242B4(player)) {
                 func_80832558(play, player, func_80837B60);

--- a/tools/namefixer.py
+++ b/tools/namefixer.py
@@ -1049,6 +1049,8 @@ wordReplace = {
     "player->unk_AA0": "player->closestSecretDistSq",
     "player->unk_AAC": "player->headLimbRot",
     "player->unk_AB2": "player->upperLimbRot",
+    "player->unk_AE7": "player->actionVar1",
+    "player->unk_AE8": "player->actionVar2",
     "player->unk_B2A": "player->getItemDrawIdPlusOne",
     "player->getItemDrawId": "player->getItemDrawIdPlusOne",
     "player->unk_B68": "player->fallStartHeight",


### PR DESCRIPTION
Taken from Fig/OoT's PR here: https://github.com/zeldaret/oot/pull/1538, which has a good description of these variables.
This is a variable that changes purposes based on what player action is currently running (there are a lot of player actions so a lot of different uses for this). Anytime the player action changes, this variable is reset to 0 so that no previous action influences its value and it can start its new purpose.