### PR TITLE
Add original asset names to all `object_l*` and `object_m*` files

### DIFF
--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -1159,7 +1159,7 @@
         <Texture Name="gElegyShellGoronPlatformTex" OutName="elegy_shell_goron_platform" Format="ci8" Width="8" Height="16" Offset="0x4E1A0" />
 
         <Texture Name="gHookshotReticleTex" OutName="tex_04E220" Format="i8" Width="64" Height="64" Offset="0x4E220" />
-        <DList Name="gHookshotReticleDL" Offset="0x4F250" />
+        <DList Name="gHookshotReticleDL" Offset="0x4F250" /> <!-- Original name might be "pointer_modelT" -->
         <Texture Name="gameplay_keep_Tex_04F2C0" OutName="tex_04F2C0" Format="ia16" Width="32" Height="64" Offset="0x4F2C0" />
         <DList Name="gEffIceFragment1DL" Offset="0x50550" />
         <DList Name="gEffIceFragment2MaterialDL" Offset="0x50648" />

--- a/assets/xml/objects/object_ladder.xml
+++ b/assets/xml/objects/object_ladder.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_ladder" Segment="6">
-        <DList Name="object_ladder_DL_0000A0" Offset="0xA0" />
-        <Collision Name="object_ladder_Colheader_0001D8" Offset="0x1D8" />
-        <DList Name="object_ladder_DL_0002D0" Offset="0x2D0" />
-        <Collision Name="object_ladder_Colheader_000408" Offset="0x408" />
-        <DList Name="object_ladder_DL_000500" Offset="0x500" />
-        <Collision Name="object_ladder_Colheader_000638" Offset="0x638" />
-        <DList Name="object_ladder_DL_000730" Offset="0x730" />
-        <Collision Name="object_ladder_Colheader_000868" Offset="0x868" />
+        <DList Name="object_ladder_DL_0000A0" Offset="0xA0" /> <!-- Original name is "m2_HASIGO_45_model" -->
+        <Collision Name="object_ladder_Colheader_0001D8" Offset="0x1D8" /> <!-- Original name is "m2_HASIGO_45_bgdatainfo" -->
+        <DList Name="object_ladder_DL_0002D0" Offset="0x2D0" /> <!-- Original name is "m2_HASIGO_60_model" -->
+        <Collision Name="object_ladder_Colheader_000408" Offset="0x408" /> <!-- Original name is "m2_HASIGO_60_bgdatainfo" -->
+        <DList Name="object_ladder_DL_000500" Offset="0x500" /> <!-- Original name is "m2_HASIGO_75_model" -->
+        <Collision Name="object_ladder_Colheader_000638" Offset="0x638" /> <!-- Original name is "m2_HASIGO_75_bgdatainfo" -->
+        <DList Name="object_ladder_DL_000730" Offset="0x730" /> <!-- Original name is "m2_HASIGO_90_model" -->
+        <Collision Name="object_ladder_Colheader_000868" Offset="0x868" /> <!-- Original name is "m2_HASIGO_90_bgdatainfo" -->
         <Texture Name="object_ladder_Tex_0008A0" OutName="tex_0008A0" Format="rgba16" Width="32" Height="32" Offset="0x8A0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_last_obj.xml
+++ b/assets/xml/objects/object_last_obj.xml
@@ -1,21 +1,21 @@
 ﻿<Root>
     <File Name="object_last_obj" Segment="6">
         <DList Name="object_last_obj_DL_000090" Offset="0x90" />
-        <DList Name="object_last_obj_DL_000098" Offset="0x98" />
+        <DList Name="object_last_obj_DL_000098" Offset="0x98" /> <!-- Original name is "i2_bomH1_sep__L_model" -->
         <DList Name="object_last_obj_DL_0001A0" Offset="0x1A0" />
-        <DList Name="object_last_obj_DL_0001A8" Offset="0x1A8" />
-        <Collision Name="object_last_obj_Colheader_000288" Offset="0x288" />
+        <DList Name="object_last_obj_DL_0001A8" Offset="0x1A8" /> <!-- Original name is "i2_last_L031_model" -->
+        <Collision Name="object_last_obj_Colheader_000288" Offset="0x288" /> <!-- Original name is "i2_last_L031_bgdatainfo" -->
         <Texture Name="object_last_obj_Tex_0002C0" OutName="tex_0002C0" Format="rgba16" Width="32" Height="64" Offset="0x2C0" />
         <DList Name="object_last_obj_DL_001310" Offset="0x1310" />
-        <DList Name="object_last_obj_DL_001318" Offset="0x1318" />
-        <Collision Name="object_last_obj_Colheader_001450" Offset="0x1450" />
+        <DList Name="object_last_obj_DL_001318" Offset="0x1318" /> <!-- Original name is "i2_last_L041_model" -->
+        <Collision Name="object_last_obj_Colheader_001450" Offset="0x1450" /> <!-- Original name is "i2_last_L041_bgdatainfo" -->
         <!-- <Blob Name="object_last_obj_Blob_00147C" Size="0x284" Offset="0x147C" /> -->
         <Texture Name="object_last_obj_TLUT_001700" OutName="tlut_001700" Format="rgba16" Width="4" Height="4" Offset="0x1700" />
         <!-- <Blob Name="object_last_obj_Blob_001720" Size="0x180" Offset="0x1720" /> -->
         <Texture Name="object_last_obj_Tex_0018A0" OutName="tex_0018A0" Format="rgba16" Width="32" Height="32" Offset="0x18A0" />
         <!-- <Blob Name="object_last_obj_Blob_0020A0" Size="0x1000" Offset="0x20A0" /> -->
         <Texture Name="object_last_obj_Tex_0030A0" OutName="tex_0030A0" Format="ci4" Width="64" Height="64" Offset="0x30A0" />
-        <DList Name="object_last_obj_DL_0039C0" Offset="0x39C0" />
+        <DList Name="object_last_obj_DL_0039C0" Offset="0x39C0" /> <!-- Original name is "i2_L_shutter1_model" -->
         <Texture Name="object_last_obj_Tex_003B20" OutName="tex_003B20" Format="rgba16" Width="32" Height="64" Offset="0x3B20" />
     </File>
 </Root>

--- a/assets/xml/objects/object_lastday.xml
+++ b/assets/xml/objects/object_lastday.xml
@@ -3,13 +3,13 @@
         <Array Name="object_lastday_Vtx_000000" Count="6" Offset="0x0">
             <Vtx/>
         </Array>
-        <DList Name="object_lastday_DL_000060" Offset="0x60" />
+        <DList Name="object_lastday_DL_000060" Offset="0x60" /> <!-- Original name is "houkai_core_model" -->
         <TextureAnimation Name="object_lastday_Matanimheader_000148" Offset="0x148" />
-        <DList Name="object_lastday_DL_000210" Offset="0x210" />
+        <DList Name="object_lastday_DL_000210" Offset="0x210" /> <!-- Original name is "houkai_fire_model" -->
         <TextureAnimation Name="object_lastday_Matanimheader_000308" Offset="0x308" />
-        <DList Name="object_lastday_DL_000370" Offset="0x370" />
+        <DList Name="object_lastday_DL_000370" Offset="0x370" /> <!-- Original name is "houkai_horizon_model" -->
         <TextureAnimation Name="object_lastday_Matanimheader_000448" Offset="0x448" />
-        <DList Name="object_lastday_DL_000510" Offset="0x510" />
+        <DList Name="object_lastday_DL_000510" Offset="0x510" /> <!-- Original name is "houkai_smoke_model" -->
         <TextureAnimation Name="object_lastday_Matanimheader_000608" Offset="0x608" />
         <Texture Name="object_lastday_Tex_000610" OutName="tex_000610" Format="ia16" Width="32" Height="32" Offset="0x610" />
         <Texture Name="object_lastday_Tex_000E10" OutName="tex_000E10" Format="i8" Width="64" Height="32" Offset="0xE10" />

--- a/assets/xml/objects/object_lbfshot.xml
+++ b/assets/xml/objects/object_lbfshot.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_lbfshot" Segment="6">
-        <DList Name="object_lbfshot_DL_000220" Offset="0x220" />
-        <DList Name="object_lbfshot_DL_000228" Offset="0x228" />
+        <DList Name="object_lbfshot_DL_000220" Offset="0x220" /> <!-- Original name is "z2_lbfshot_modelT" -->
+        <DList Name="object_lbfshot_DL_000228" Offset="0x228" /> <!-- Original name is "z2_lbfshot_model" -->
         <Texture Name="object_lbfshot_Tex_000340" OutName="tex_000340" Format="rgba16" Width="16" Height="64" Offset="0x340" />
         <Texture Name="object_lbfshot_Tex_000B40" OutName="tex_000B40" Format="rgba16" Width="32" Height="32" Offset="0xB40" />
-        <Collision Name="object_lbfshot_Colheader_0014D8" Offset="0x14D8" />
+        <Collision Name="object_lbfshot_Colheader_0014D8" Offset="0x14D8" /> <!-- Original name is "z2_lbfshot_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_lightblock.xml
+++ b/assets/xml/objects/object_lightblock.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_lightblock" Segment="6">
-        <DList Name="object_lightblock_DL_000170" Offset="0x170" />
-        <DList Name="object_lightblock_DL_000178" Offset="0x178" />
+        <DList Name="object_lightblock_DL_000170" Offset="0x170" /> <!-- Original name is "z2_brick_light_modelT" -->
+        <DList Name="object_lightblock_DL_000178" Offset="0x178" /> <!-- Original name is "z2_brick_light_model" -->
         <Texture Name="object_lightblock_TLUT_000258" OutName="tlut_000258" Format="rgba16" Width="4" Height="4" Offset="0x258" />
         <Texture Name="object_lightblock_Tex_000278" OutName="tex_000278" Format="ci4" Width="64" Height="64" Offset="0x278" />
-        <Collision Name="object_lightblock_Colheader_000B80" Offset="0xB80" />
+        <Collision Name="object_lightblock_Colheader_000B80" Offset="0xB80" /> <!-- Original name is "z2_brick_light_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_lightswitch.xml
+++ b/assets/xml/objects/object_lightswitch.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_lightswitch" Segment="6">
-        <DList Name="object_lightswitch_DL_000260" Offset="0x260" />
-        <DList Name="object_lightswitch_DL_000398" Offset="0x398" />
+        <DList Name="object_lightswitch_DL_000260" Offset="0x260" /> <!-- Original name is "switch_8_model" -->
+        <DList Name="object_lightswitch_DL_000398" Offset="0x398" /> <!-- Original name is "switch_8_fire1_model" -->
         <!-- a square, geometry only -->
-        <DList Name="object_lightswitch_DL_000408" Offset="0x408" />
+        <DList Name="object_lightswitch_DL_000408" Offset="0x408" /> <!-- Original name is "switch_8_fire2_model" -->
         <Texture Name="object_lightswitch_Tex_000420" OutName="tex_000420" Format="rgba16" Width="32" Height="32" Offset="0x420" /> <!-- eyes open -->
         <Texture Name="object_lightswitch_Tex_000C20" OutName="tex_000C20" Format="rgba16" Width="32" Height="32" Offset="0xC20" /> <!-- eyes closed -->
         <Texture Name="object_lightswitch_Tex_001420" OutName="tex_001420" Format="rgba16" Width="32" Height="32" Offset="0x1420" /> <!-- eyes open, smiling -->

--- a/assets/xml/objects/object_link_goron.xml
+++ b/assets/xml/objects/object_link_goron.xml
@@ -42,7 +42,7 @@
         <DList Name="gLinkGoronLeftForearmDL" Offset="0xA220" />
         <DList Name="gLinkGoronLeftHandOpenDL" Offset="0xA500" />
         <DList Name="gLinkGoronCurledDL" Offset="0xBDD8" />
-        <DList Name="object_link_goron_DL_00C540" Offset="0xC540" />
+        <DList Name="object_link_goron_DL_00C540" Offset="0xC540" /> <!-- Original name is "lg_spike_model" -->
 
         <Texture Name="object_link_goron_Tex_00C6B8" OutName="tex_00C6B8" Format="ci8" Width="32" Height="64" Offset="0xC6B8" />
         <Texture Name="object_link_goron_Tex_00CEB8" OutName="tex_00CEB8" Format="rgba16" Width="8" Height="16" Offset="0xCEB8" />
@@ -72,10 +72,10 @@
         <DList Name="gLinkGoronGoronPunchEffectDL" Offset="0x11AB8" />
         <Texture Name="object_link_goron_Tex_011C10" OutName="tex_011C10" Format="i4" Width="32" Height="32" Offset="0x11C10" />
         <Texture Name="object_link_goron_Tex_011E10" OutName="tex_011E10" Format="i4" Width="64" Height="64" Offset="0x11E10" />
-        <DList Name="object_link_goron_DL_0127B0" Offset="0x127B0" />
+        <DList Name="object_link_goron_DL_0127B0" Offset="0x127B0" /> <!-- Original name is "grt_01_model" -->
         <Texture Name="object_link_goron_Tex_012930" OutName="tex_012930" Format="i4" Width="64" Height="64" Offset="0x12930" />
         <TextureAnimation Name="object_link_goron_Matanimheader_013138" Offset="0x13138" />
-        <DList Name="object_link_goron_DL_0134D0" Offset="0x134D0" />
+        <DList Name="object_link_goron_DL_0134D0" Offset="0x134D0" /> <!-- Original name is "grt_02_model" -->
         <Texture Name="object_link_goron_Tex_013660" OutName="tex_013660" Format="i4" Width="64" Height="64" Offset="0x13660" />
         <Texture Name="object_link_goron_Tex_013E60" OutName="tex_013E60" Format="i4" Width="64" Height="64" Offset="0x13E60" />
         <TextureAnimation Name="object_link_goron_Matanimheader_014684" Offset="0x14684" />
@@ -90,7 +90,7 @@
         <Limb Name="gLinkGoronShieldingArmsAndLegsLimb" Type="Standard" EnumName="LINK_GORON_SHIELDING_LIMB_ARMS_AND_LEGS" Offset="0x1779C" />
         <Skeleton Name="gLinkGoronShieldingSkel" Type="Flex" LimbType="Standard" LimbNone="LINK_GORON_SHIELDING_LIMB_NONE" LimbMax="LINK_GORON_SHIELDING_LIMB_MAX" EnumName="LinkGoronShieldingLimb" Offset="0x177B8" />
 
-        <Animation Name="gLinkGoronShieldingAnim" Offset="0x178D0" />
+        <Animation Name="gLinkGoronShieldingAnim" Offset="0x178D0" /> <!-- Original name is "pg_gurdmotion" -->
 
         <Limb Name="gLinkGoronRootLimb" Type="LOD" EnumName="LINK_GORON_LIMB_ROOT" Offset="0x178E0" />
         <Limb Name="gLinkGoronWaistLimb" Type="LOD" EnumName="LINK_GORON_LIMB_WAIST" Offset="0x178F0" />

--- a/assets/xml/objects/object_link_zora.xml
+++ b/assets/xml/objects/object_link_zora.xml
@@ -80,7 +80,7 @@
             <Scalar Type="x8"/>
         </Array>
 
-        <DList Name="object_link_zora_DL_011760" Offset="0x11760" />
+        <DList Name="object_link_zora_DL_011760" Offset="0x11760" /> <!-- Original name is "zora_thunder_modelT" -->
         <DList Name="object_link_zora_DL_011A58" Offset="0x11A58" />
         <Texture Name="object_link_zora_Tex_011A60" OutName="tex_011A60" Format="i8" Width="64" Height="32" Offset="0x11A60" />
         <Texture Name="object_link_zora_Tex_012260" OutName="tex_012260" Format="i8" Width="32" Height="64" Offset="0x12260" />

--- a/assets/xml/objects/object_lotus.xml
+++ b/assets/xml/objects/object_lotus.xml
@@ -4,6 +4,6 @@
         <DList Name="gLilyPadDL" Offset="0x40" /> <!-- Original name is "z2_hasu_model" ("lotus​") -->
         <Texture Name="gLilyPadTLUT" OutName="lily_pad_tlut" Format="rgba16" Width="4" Height="4" Offset="0x100" />
         <Texture Name="gLilyPadTex" OutName="lily_pad" Format="ci4" Width="64" Height="64" Offset="0x120" />
-        <Collision Name="gLilyPadCol" Offset="0xA20" />
+        <Collision Name="gLilyPadCol" Offset="0xA20" /> <!-- Original name is "z2_hasu_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_mamenoki.xml
+++ b/assets/xml/objects/object_mamenoki.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_mamenoki" Segment="6">
-        <DList Name="object_mamenoki_DL_000090" Offset="0x90" />
-        <DList Name="object_mamenoki_DL_0002D0" Offset="0x2D0" />
-        <Collision Name="object_mamenoki_Colheader_0004BC" Offset="0x4BC" />
-        <DList Name="object_mamenoki_DL_000530" Offset="0x530" />
+        <DList Name="object_mamenoki_DL_000090" Offset="0x90" /> <!-- Original name is "c_mame_jr_model" -->
+        <DList Name="object_mamenoki_DL_0002D0" Offset="0x2D0" /> <!-- Original name is "c_mame_lift_model" -->
+        <Collision Name="object_mamenoki_Colheader_0004BC" Offset="0x4BC" /> <!-- Original name is "c_mame_lift_bgdatainfo" -->
+        <DList Name="object_mamenoki_DL_000530" Offset="0x530" /> <!-- Original name is "c_mame_place_model" -->
         <Texture Name="object_mamenoki_Tex_0005C0" OutName="tex_0005C0" Format="rgba16" Width="32" Height="32" Offset="0x5C0" />
         <Texture Name="object_mamenoki_Tex_000DC0" OutName="tex_000DC0" Format="rgba16" Width="16" Height="32" Offset="0xDC0" />
         <Texture Name="object_mamenoki_Tex_0011C0" OutName="tex_0011C0" Format="rgba16" Width="32" Height="32" Offset="0x11C0" />

--- a/assets/xml/objects/object_maruta.xml
+++ b/assets/xml/objects/object_maruta.xml
@@ -3,14 +3,14 @@
         <Texture Name="object_maruta_Tex_000000" OutName="tex_000000" Format="rgba16" Width="32" Height="32" Offset="0x0" />
         <Texture Name="object_maruta_Tex_000800" OutName="tex_000800" Format="rgba16" Width="32" Height="32" Offset="0x800" />
         <Texture Name="object_maruta_Tex_001000" OutName="tex_001000" Format="rgba16" Width="32" Height="32" Offset="0x1000" />
-        <DList Name="object_maruta_DL_002220" Offset="0x2220" />
-        <DList Name="object_maruta_DL_0023D0" Offset="0x23D0" />
-        <DList Name="object_maruta_DL_002568" Offset="0x2568" />
-        <DList Name="object_maruta_DL_002660" Offset="0x2660" />
-        <DList Name="object_maruta_DL_002758" Offset="0x2758" />
-        <DList Name="object_maruta_DL_002850" Offset="0x2850" />
-        <DList Name="object_maruta_DL_002948" Offset="0x2948" />
-        <DList Name="object_maruta_DL_002AE0" Offset="0x2AE0" />
-        <DList Name="object_maruta_DL_002EC0" Offset="0x2EC0" />
+        <DList Name="object_maruta_DL_002220" Offset="0x2220" /> <!-- Original name is "parts_1_model" -->
+        <DList Name="object_maruta_DL_0023D0" Offset="0x23D0" /> <!-- Original name is "parts_2_model" -->
+        <DList Name="object_maruta_DL_002568" Offset="0x2568" /> <!-- Original name is "parts_3_model" -->
+        <DList Name="object_maruta_DL_002660" Offset="0x2660" /> <!-- Original name is "parts_4_model" -->
+        <DList Name="object_maruta_DL_002758" Offset="0x2758" /> <!-- Original name is "parts_5_model" -->
+        <DList Name="object_maruta_DL_002850" Offset="0x2850" /> <!-- Original name is "parts_6_model" -->
+        <DList Name="object_maruta_DL_002948" Offset="0x2948" /> <!-- Original name is "parts_7_model" -->
+        <DList Name="object_maruta_DL_002AE0" Offset="0x2AE0" /> <!-- Original name is "parts_8_model" -->
+        <DList Name="object_maruta_DL_002EC0" Offset="0x2EC0" /> <!-- Original name is "kiretenaimaruta_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_mastergolon.xml
+++ b/assets/xml/objects/object_mastergolon.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <!-- Object for the Goron Shopkeeper's animation -->
     <File Name="object_mastergolon" Segment="6">
-        <Animation Name="gGoronShopkeeperAnim" Offset="0xFC" />
+        <Animation Name="gGoronShopkeeperAnim" Offset="0xFC" /> <!-- Original name is "oF1d_omise" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_masterzoora.xml
+++ b/assets/xml/objects/object_masterzoora.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <!-- Object for the Zora Shopkeeper's animation -->
     <File Name="object_masterzoora" Segment="6">
-        <Animation Name="gZoraShopkeeperAnim" Offset="0x78C" />
+        <Animation Name="gZoraShopkeeperAnim" Offset="0x78C" /> <!-- Original name is "zo_omise" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_milkbar.xml
+++ b/assets/xml/objects/object_milkbar.xml
@@ -1,27 +1,27 @@
 ﻿<Root>
     <File Name="object_milkbar" Segment="6">
-        <DList Name="object_milkbar_DL_000100" Offset="0x100" />
+        <DList Name="object_milkbar_DL_000100" Offset="0x100" /> <!-- Original name is "z2_milk_bar_light_1_modelT" -->
         <DList Name="object_milkbar_DL_000240" Offset="0x240" />
         <Texture Name="object_milkbar_Tex_000248" OutName="tex_000248" Format="ia16" Width="16" Height="16" Offset="0x248" />
         <Texture Name="object_milkbar_Tex_000448" OutName="tex_000448" Format="ia8" Width="16" Height="16" Offset="0x448" />
-        <DList Name="object_milkbar_DL_000650" Offset="0x650" />
+        <DList Name="object_milkbar_DL_000650" Offset="0x650" /> <!-- Original name is "z2_milk_bar_light_2_modelT" -->
         <DList Name="object_milkbar_DL_000790" Offset="0x790" />
         <Texture Name="object_milkbar_Tex_000798" OutName="tex_000798" Format="ia16" Width="16" Height="16" Offset="0x798" />
         <Texture Name="object_milkbar_Tex_000998" OutName="tex_000998" Format="ia8" Width="16" Height="16" Offset="0x998" />
-        <DList Name="object_milkbar_DL_000B80" Offset="0xB80" />
+        <DList Name="object_milkbar_DL_000B80" Offset="0xB80" /> <!-- Original name is "z2_milk_bar_light_3_modelT" -->
         <DList Name="object_milkbar_DL_000CC0" Offset="0xCC0" />
         <Texture Name="object_milkbar_Tex_000CC8" OutName="tex_000CC8" Format="ia16" Width="16" Height="16" Offset="0xCC8" />
         <Texture Name="object_milkbar_Tex_000EC8" OutName="tex_000EC8" Format="ia8" Width="16" Height="16" Offset="0xEC8" />
-        <DList Name="object_milkbar_DL_0010D0" Offset="0x10D0" />
+        <DList Name="object_milkbar_DL_0010D0" Offset="0x10D0" /> <!-- Original name is "z2_milk_bar_light_4_modelT" -->
         <DList Name="object_milkbar_DL_001210" Offset="0x1210" />
         <Texture Name="object_milkbar_Tex_001218" OutName="tex_001218" Format="ia16" Width="16" Height="16" Offset="0x1218" />
         <Texture Name="object_milkbar_Tex_001418" OutName="tex_001418" Format="ia8" Width="16" Height="16" Offset="0x1418" />
-        <DList Name="object_milkbar_DL_0015E0" Offset="0x15E0" />
+        <DList Name="object_milkbar_DL_0015E0" Offset="0x15E0" /> <!-- Original name is "z2_milk_bar_light_5_modelT" -->
         <DList Name="object_milkbar_DL_0016B8" Offset="0x16B8" />
         <Texture Name="object_milkbar_Tex_0016C0" OutName="tex_0016C0" Format="ia16" Width="16" Height="16" Offset="0x16C0" />
         <Texture Name="object_milkbar_Tex_0018C0" OutName="tex_0018C0" Format="ia8" Width="16" Height="16" Offset="0x18C0" />
-        <DList Name="object_milkbar_DL_002BA0" Offset="0x2BA0" />
-        <DList Name="object_milkbar_DL_002CD0" Offset="0x2CD0" />
+        <DList Name="object_milkbar_DL_002BA0" Offset="0x2BA0" /> <!-- Not present in MM3D, but it was probably named "z2_milk_bar_stage_1_modelT" based on the rest of this object. -->
+        <DList Name="object_milkbar_DL_002CD0" Offset="0x2CD0" /> <!-- Original name is "z2_milk_bar_stage_1_model" -->
         <Texture Name="object_milkbar_Tex_003320" OutName="tex_003320" Format="i8" Width="64" Height="64" Offset="0x3320" />
         <Texture Name="object_milkbar_Tex_004320" OutName="tex_004320" Format="i8" Width="32" Height="32" Offset="0x4320" />
         <Texture Name="object_milkbar_Tex_004720" OutName="tex_004720" Format="ia16" Width="16" Height="32" Offset="0x4720" />
@@ -33,12 +33,12 @@
         <Texture Name="object_milkbar_Tex_005D60" OutName="tex_005D60" Format="i4" Width="16" Height="32" Offset="0x5D60" />
         <Texture Name="object_milkbar_Tex_005E60" OutName="tex_005E60" Format="i8" Width="32" Height="32" Offset="0x5E60" />
         <Texture Name="object_milkbar_Tex_006260" OutName="tex_006260" Format="i4" Width="32" Height="32" Offset="0x6260" />
-        <Collision Name="object_milkbar_Colheader_006688" Offset="0x6688" />
+        <Collision Name="object_milkbar_Colheader_006688" Offset="0x6688" /> <!-- Original name is "z2_milk_bar_stage_1_bgdatainfo" -->
         <Mtx Name="object_milkbar_Mtx_0075E0" Offset="0x75E0" />
         <Mtx Name="object_milkbar_Mtx_007620" Offset="0x7620" />
         <Mtx Name="object_milkbar_Mtx_007660" Offset="0x7660" />
-        <DList Name="object_milkbar_DL_0076A0" Offset="0x76A0" />
-        <DList Name="object_milkbar_DL_007918" Offset="0x7918" />
+        <DList Name="object_milkbar_DL_0076A0" Offset="0x76A0" /> <!-- Original name is "z2_milk_bar_stage_2_modelT" -->
+        <DList Name="object_milkbar_DL_007918" Offset="0x7918" /> <!-- Original name is "z2_milk_bar_stage_2_model" -->
         <Texture Name="object_milkbar_Tex_007FA0" OutName="tex_007FA0" Format="ia16" Width="64" Height="32" Offset="0x7FA0" />
         <Texture Name="object_milkbar_Tex_008FA0" OutName="tex_008FA0" Format="rgba16" Width="32" Height="32" Offset="0x8FA0" />
         <Texture Name="object_milkbar_Tex_0097A0" OutName="tex_0097A0" Format="rgba16" Width="32" Height="32" Offset="0x97A0" />

--- a/assets/xml/objects/object_mir_ray.xml
+++ b/assets/xml/objects/object_mir_ray.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_mir_ray" Segment="6">
         <DList Name="object_mir_ray_DL_000160" Offset="0x160" />
-        <DList Name="object_mir_ray_DL_000168" Offset="0x168" />
+        <DList Name="object_mir_ray_DL_000168" Offset="0x168" /> <!-- Original name is "cl_sMLightSyl_model" -->
         <Texture Name="object_mir_ray_Tex_000270" OutName="tex_000270" Format="i4" Width="16" Height="16" Offset="0x270" />
         <Texture Name="object_mir_ray_Tex_0002F0" OutName="tex_0002F0" Format="i4" Width="16" Height="32" Offset="0x2F0" />
         <TextureAnimation Name="object_mir_ray_Matanimheader_0003F8" Offset="0x3F8" />

--- a/assets/xml/objects/object_mk.xml
+++ b/assets/xml/objects/object_mk.xml
@@ -1,11 +1,11 @@
 ﻿<Root>
     <!-- Assets for the Marine Researcher -->
     <File Name="object_mk" Segment="6">
-        <Animation Name="gMarineResearcherHeadWaggleAnim" Offset="0x438" />
-        <Animation Name="gMarineResearcherYellAnim" Offset="0x7D8" />
-        <Animation Name="gMarineResearcherShakeInFearAnim" Offset="0x10F4" />
-        <Animation Name="gMarineResearcherStrokeChinAnim" Offset="0x1964" />
-        <Animation Name="gMarineResearcherIdleAnim" Offset="0x1C38" />
+        <Animation Name="gMarineResearcherHeadWaggleAnim" Offset="0x438" /> <!-- Original name is "lake_dameja" -->
+        <Animation Name="gMarineResearcherYellAnim" Offset="0x7D8" /> <!-- Original name is "lake_isogunoja" -->
+        <Animation Name="gMarineResearcherShakeInFearAnim" Offset="0x10F4" /> <!-- Original name is "lake_sorewa" -->
+        <Animation Name="gMarineResearcherStrokeChinAnim" Offset="0x1964" /> <!-- Original name is "lake_u_m" -->
+        <Animation Name="gMarineResearcherIdleAnim" Offset="0x1C38" /> <!-- Original name is "mk_matsu" -->
         <DList Name="gMarineResearcherMidTorsoDL" Offset="0x4320" />
         <DList Name="gMarineResearcherUpperTorsoDL" Offset="0x4610" />
         <DList Name="gMarineResearcherNeckDL" Offset="0x4960" />

--- a/assets/xml/objects/object_mm.xml
+++ b/assets/xml/objects/object_mm.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_mm" Segment="6">
-        <Animation Name="object_mm_Anim_000468" Offset="0x468" />
-        <Animation Name="object_mm_Anim_00099C" Offset="0x99C" />
-        <Animation Name="object_mm_Anim_000FC4" Offset="0xFC4" />
-        <Animation Name="object_mm_Anim_001F84" Offset="0x1F84" />
-        <Animation Name="object_mm_Anim_002238" Offset="0x2238" />
+        <Animation Name="object_mm_Anim_000468" Offset="0x468" /> <!-- Original name is "hasiruu" -->
+        <Animation Name="object_mm_Anim_00099C" Offset="0x99C" /> <!-- Original name is "mm_kunou" -->
+        <Animation Name="object_mm_Anim_000FC4" Offset="0xFC4" /> <!-- Original name is "mm_neru" -->
+        <Animation Name="object_mm_Anim_001F84" Offset="0x1F84" /> <!-- Original name is "mm_postcheck" -->
+        <Animation Name="object_mm_Anim_002238" Offset="0x2238" /> <!-- Original name is "mm_run01" -->
         <Texture Name="object_mm_TLUT_002250" OutName="tlut_002250" Format="rgba16" Width="16" Height="16" Offset="0x2250" />
         <Texture Name="object_mm_Tex_002450" OutName="tex_002450" Format="ci8" Width="8" Height="8" Offset="0x2450" />
         <Texture Name="object_mm_Tex_002490" OutName="tex_002490" Format="ci8" Width="8" Height="8" Offset="0x2490" />
@@ -32,9 +32,9 @@
         <DList Name="object_mm_DL_007430" Offset="0x7430" />
         <DList Name="object_mm_DL_007610" Offset="0x7610" />
         <DList Name="object_mm_DL_007780" Offset="0x7780" />
-        <DList Name="object_mm_DL_008348" Offset="0x8348" />
-        <DList Name="object_mm_DL_0083E0" Offset="0x83E0" />
-        <DList Name="object_mm_DL_0085C8" Offset="0x85C8" />
+        <DList Name="object_mm_DL_008348" Offset="0x8348" /> <!-- Original name is "mm_letter_model" -->
+        <DList Name="object_mm_DL_0083E0" Offset="0x83E0" /> <!-- Original name is "mm_bag_model" -->
+        <DList Name="object_mm_DL_0085C8" Offset="0x85C8" /> <!-- Original name is "mm_cap_model" -->
         <Texture Name="object_mm_Tex_008778" OutName="tex_008778" Format="rgba16" Width="8" Height="8" Offset="0x8778" />
         <Texture Name="object_mm_Tex_0087F8" OutName="tex_0087F8" Format="rgba16" Width="16" Height="16" Offset="0x87F8" />
         <Texture Name="object_mm_Tex_0089F8" OutName="tex_0089F8" Format="rgba16" Width="32" Height="32" Offset="0x89F8" />
@@ -55,14 +55,14 @@
         <Limb Name="object_mm_Standardlimb_009694" Type="Standard" EnumName="OBJECT_MM_LIMB_0E" Offset="0x9694" />
         <Limb Name="object_mm_Standardlimb_0096A0" Type="Standard" EnumName="OBJECT_MM_LIMB_0F" Offset="0x96A0" />
         <Skeleton Name="object_mm_Skel_0096E8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MM_LIMB_NONE" LimbMax="OBJECT_MM_LIMB_MAX" EnumName="ObjectMmLimb" Offset="0x96E8" />
-        <Animation Name="object_mm_Anim_0099B4" Offset="0x99B4" />
-        <Animation Name="object_mm_Anim_00A4E0" Offset="0xA4E0" />
-        <Animation Name="object_mm_Anim_00A8D8" Offset="0xA8D8" />
-        <Animation Name="object_mm_Anim_00B09C" Offset="0xB09C" />
-        <Animation Name="object_mm_Anim_00BA78" Offset="0xBA78" />
-        <Animation Name="object_mm_Anim_00C32C" Offset="0xC32C" />
-        <Animation Name="object_mm_Anim_00C640" Offset="0xC640" />
-        <Animation Name="object_mm_Anim_00CD90" Offset="0xCD90" />
-        <Animation Name="object_mm_Anim_00DA50" Offset="0xDA50" />
+        <Animation Name="object_mm_Anim_0099B4" Offset="0x99B4" /> <!-- Original name is "mm_runwait" -->
+        <Animation Name="object_mm_Anim_00A4E0" Offset="0xA4E0" /> <!-- Original name is "mm_tatsu" -->
+        <Animation Name="object_mm_Anim_00A8D8" Offset="0xA8D8" /> <!-- Original name is "mm_uzukumaru" -->
+        <Animation Name="object_mm_Anim_00B09C" Offset="0xB09C" /> <!-- Original name is "mm_wait01" -->
+        <Animation Name="object_mm_Anim_00BA78" Offset="0xBA78" /> <!-- Original name is "mm_watasu" -->
+        <Animation Name="object_mm_Anim_00C32C" Offset="0xC32C" /> <!-- Original name is "mm_watasuwait" -->
+        <Animation Name="object_mm_Anim_00C640" Offset="0xC640" /> <!-- Original name is "mm_yoru" -->
+        <Animation Name="object_mm_Anim_00CD90" Offset="0xCD90" /> <!-- Original name is "uttekure" -->
+        <Animation Name="object_mm_Anim_00DA50" Offset="0xDA50" /> <!-- Original name is "yorokobi_long" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_mnk.xml
+++ b/assets/xml/objects/object_mnk.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_mnk" Segment="6">
         <DList Name="object_mnk_DL_000F50" Offset="0xF50" />
-        <DList Name="object_mnk_DL_000F58" Offset="0xF58" />
+        <DList Name="object_mnk_DL_000F58" Offset="0xF58" /> <!-- Original name is "z2_25_tubo_model" -->
         <Texture Name="object_mnk_TLUT_001620" OutName="tlut_001620" Format="rgba16" Width="16" Height="16" Offset="0x1620" />
         <Texture Name="object_mnk_Tex_001820" OutName="tex_001820" Format="ci8" Width="16" Height="64" Offset="0x1820" />
         <Texture Name="object_mnk_Tex_001C20" OutName="tex_001C20" Format="ci8" Width="16" Height="16" Offset="0x1C20" />
@@ -9,11 +9,11 @@
         <Texture Name="object_mnk_Tex_001E20" OutName="tex_001E20" Format="ci8" Width="16" Height="128" Offset="0x1E20" />
         <Texture Name="object_mnk_Tex_002620" OutName="tex_002620" Format="rgba16" Width="32" Height="32" Offset="0x2620" />
         <TextureAnimation Name="object_mnk_Matanimheader_002E28" Offset="0x2E28" />
-        <Collision Name="object_mnk_Colheader_0033E8" Offset="0x33E8" />
-        <Animation Name="object_mnk_Anim_003504" Offset="0x3504" />
-        <Animation Name="object_mnk_Anim_003584" Offset="0x3584" />
-        <Animation Name="object_mnk_Anim_0037E8" Offset="0x37E8" />
-        <Animation Name="object_mnk_Anim_003854" Offset="0x3854" />
+        <Collision Name="object_mnk_Colheader_0033E8" Offset="0x33E8" /> <!-- Original name is "z2_25_tubo_bgdatainfo" -->
+        <Animation Name="object_mnk_Anim_003504" Offset="0x3504" /> <!-- Original name is "mnk_hashira_hatena" -->
+        <Animation Name="object_mnk_Anim_003584" Offset="0x3584" /> <!-- Original name is "mnk_hashira_mogaku" -->
+        <Animation Name="object_mnk_Anim_0037E8" Offset="0x37E8" /> <!-- Original name is "mnk_hashira_sadtalk" -->
+        <Animation Name="object_mnk_Anim_003854" Offset="0x3854" /> <!-- Original name is "mnk_hashira_sing" -->
         <DList Name="object_mnk_DL_003C70" Offset="0x3C70" />
         <DList Name="object_mnk_DL_003D40" Offset="0x3D40" />
         <DList Name="object_mnk_DL_003DF8" Offset="0x3DF8" />
@@ -24,31 +24,31 @@
         <Limb Name="object_mnk_Standardlimb_005128" Type="Standard" EnumName="OBJECT_MNK_1_LIMB_03" Offset="0x5128" />
         <Limb Name="object_mnk_Standardlimb_005134" Type="Standard" EnumName="OBJECT_MNK_1_LIMB_04" Offset="0x5134" />
         <Skeleton Name="gMonkeyTiedUpPoleSkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_1_LIMB_NONE" LimbMax="OBJECT_MNK_1_LIMB_MAX" EnumName="ObjectMnk1Limb" Offset="0x5150" />
-        <Animation Name="object_mnk_Anim_005194" Offset="0x5194" />
-        <Animation Name="object_mnk_Anim_0052C4" Offset="0x52C4" />
-        <Animation Name="object_mnk_Anim_005390" Offset="0x5390" />
-        <Animation Name="object_mnk_Anim_005414" Offset="0x5414" />
-        <Animation Name="object_mnk_Anim_0054B4" Offset="0x54B4" />
-        <Animation Name="object_mnk_Anim_005A08" Offset="0x5A08" />
-        <Animation Name="object_mnk_Anim_0062D8" Offset="0x62D8" />
-        <Animation Name="object_mnk_Anim_007380" Offset="0x7380" />
-        <Animation Name="gMonkeyHangingStruggleAnim" Offset="0x82C8" />
-        <Animation Name="object_mnk_Anim_008814" Offset="0x8814" />
-        <Animation Name="object_mnk_Anim_0095B4" Offset="0x95B4" />
-        <Animation Name="object_mnk_Anim_0099B0" Offset="0x99B0" />
-        <Animation Name="object_mnk_Anim_009CC0" Offset="0x9CC0" />
-        <Animation Name="object_mnk_Anim_009FE0" Offset="0x9FE0" />
-        <Animation Name="object_mnk_Anim_00B864" Offset="0xB864" />
-        <Animation Name="object_mnk_Anim_00C23C" Offset="0xC23C" />
-        <Animation Name="object_mnk_Anim_00CAE8" Offset="0xCAE8" />
-        <Animation Name="object_mnk_Anim_00CD4C" Offset="0xCD4C" />
-        <Animation Name="object_mnk_Anim_00D1C8" Offset="0xD1C8" />
-        <Animation Name="object_mnk_Anim_00EC44" Offset="0xEC44" />
-        <Animation Name="object_mnk_Anim_00F248" Offset="0xF248" />
-        <Animation Name="object_mnk_Anim_00F9A4" Offset="0xF9A4" />
-        <Animation Name="object_mnk_Anim_00FE34" Offset="0xFE34" />
-        <Animation Name="object_mnk_Anim_010298" Offset="0x10298" />
-        <Animation Name="object_mnk_Anim_0105DC" Offset="0x105DC" />
+        <Animation Name="object_mnk_Anim_005194" Offset="0x5194" /> <!-- Original name is "mnk_hashira_swing" -->
+        <Animation Name="object_mnk_Anim_0052C4" Offset="0x52C4" /> <!-- Original name is "mnk_hashira_tiedNO" -->
+        <Animation Name="object_mnk_Anim_005390" Offset="0x5390" /> <!-- Original name is "mnk_hashira_tiedtalk" -->
+        <Animation Name="object_mnk_Anim_005414" Offset="0x5414" /> <!-- Original name is "mnk_hashira_tiedtalkroud" -->
+        <Animation Name="object_mnk_Anim_0054B4" Offset="0x54B4" /> <!-- Original name is "mnk_hashira_tiedwait" -->
+        <Animation Name="object_mnk_Anim_005A08" Offset="0x5A08" /> <!-- Original name is "mnk_chuugaeri" -->
+        <Animation Name="object_mnk_Anim_0062D8" Offset="0x62D8" /> <!-- Original name is "mnk_hang_guttari" -->
+        <Animation Name="object_mnk_Anim_007380" Offset="0x7380" /> <!-- Original name is "mnk_hang_hikiage" -->
+        <Animation Name="gMonkeyHangingStruggleAnim" Offset="0x82C8" /> <!-- Original name is "mnk_hang_mogaku" -->
+        <Animation Name="object_mnk_Anim_008814" Offset="0x8814" /> <!-- Original name is "mnk_highjump" -->
+        <Animation Name="object_mnk_Anim_0095B4" Offset="0x95B4" /> <!-- Original name is "mnk_hitting" -->
+        <Animation Name="object_mnk_Anim_0099B0" Offset="0x99B0" /> <!-- Original name is "mnk_hop" -->
+        <Animation Name="object_mnk_Anim_009CC0" Offset="0x9CC0" /> <!-- Original name is "mnk_minijump" -->
+        <Animation Name="object_mnk_Anim_009FE0" Offset="0x9FE0" /> <!-- Original name is "mnk_run" -->
+        <Animation Name="object_mnk_Anim_00B864" Offset="0xB864" /> <!-- Original name is "mnk_scratch" -->
+        <Animation Name="object_mnk_Anim_00C23C" Offset="0xC23C" /> <!-- Original name is "mnk_tied_NO" -->
+        <Animation Name="object_mnk_Anim_00CAE8" Offset="0xCAE8" /> <!-- Original name is "mnk_tied_hatena" -->
+        <Animation Name="object_mnk_Anim_00CD4C" Offset="0xCD4C" /> <!-- Original name is "mnk_tied_legswing" -->
+        <Animation Name="object_mnk_Anim_00D1C8" Offset="0xD1C8" /> <!-- Original name is "mnk_tied_mogaku" -->
+        <Animation Name="object_mnk_Anim_00EC44" Offset="0xEC44" /> <!-- Original name is "mnk_tied_sadtalk" -->
+        <Animation Name="object_mnk_Anim_00F248" Offset="0xF248" /> <!-- Original name is "mnk_tied_sing" -->
+        <Animation Name="object_mnk_Anim_00F9A4" Offset="0xF9A4" /> <!-- Original name is "mnk_tied_talk" -->
+        <Animation Name="object_mnk_Anim_00FE34" Offset="0xFE34" /> <!-- Original name is "mnk_tied_talkroud" -->
+        <Animation Name="object_mnk_Anim_010298" Offset="0x10298" /> <!-- Original name is "mnk_tied_wait" -->
+        <Animation Name="object_mnk_Anim_0105DC" Offset="0x105DC" /> <!-- Original name is "mnk_wait"-->
         <DList Name="object_mnk_DL_012770" Offset="0x12770" />
         <DList Name="object_mnk_DL_012918" Offset="0x12918" />
         <DList Name="object_mnk_DL_0129D0" Offset="0x129D0" />
@@ -110,13 +110,13 @@
         <Limb Name="object_mnk_Standardlimb_019B18" Type="Standard" EnumName="OBJECT_MNK_2_LIMB_15" Offset="0x19B18" />
         <Limb Name="object_mnk_Standardlimb_019B24" Type="Standard" EnumName="OBJECT_MNK_2_LIMB_16" Offset="0x19B24" />
         <Skeleton Name="gMonkeySkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_2_LIMB_NONE" LimbMax="OBJECT_MNK_2_LIMB_MAX" EnumName="ObjectMnk2Limb" Offset="0x19B88" />
-        <Animation Name="object_mnk_Anim_01A4F8" Offset="0x1A4F8" />
-        <Animation Name="object_mnk_Anim_01B468" Offset="0x1B468" />
-        <Animation Name="object_mnk_Anim_01BB0C" Offset="0x1BB0C" />
-        <Animation Name="object_mnk_Anim_01C17C" Offset="0x1C17C" />
-        <Animation Name="object_mnk_Anim_01C1B8" Offset="0x1C1B8" />
-        <Animation Name="object_mnk_Anim_01C1F8" Offset="0x1C1F8" />
-        <Animation Name="gMonkeyHangingRopeStruggleAnim" Offset="0x1C3B4" />
+        <Animation Name="object_mnk_Anim_01A4F8" Offset="0x1A4F8" /> <!-- Original name is "mnk_onnikiruze" -->
+        <Animation Name="object_mnk_Anim_01B468" Offset="0x1B468" /> <!-- Original name is "mnk_wakatte" -->
+        <Animation Name="object_mnk_Anim_01BB0C" Offset="0x1BB0C" /> <!-- Original name is "mnk_wakatte_loop" -->
+        <Animation Name="object_mnk_Anim_01C17C" Offset="0x1C17C" /> <!-- Original name is "mnk_wakatte_modori" -->
+        <Animation Name="object_mnk_Anim_01C1B8" Offset="0x1C1B8" /> <!-- Original name is "mnk_rope_guttari" -->
+        <Animation Name="object_mnk_Anim_01C1F8" Offset="0x1C1F8" /> <!-- Original name is "mnk_rope_hikiage" -->
+        <Animation Name="gMonkeyHangingRopeStruggleAnim" Offset="0x1C3B4" /> <!-- Original name is "mnk_rope_mogaku_mdl" -->
         <DList Name="object_mnk_DL_01C660" Offset="0x1C660" />
         <DList Name="object_mnk_DL_01C770" Offset="0x1C770" />
         <DList Name="object_mnk_DL_01C818" Offset="0x1C818" />

--- a/assets/xml/objects/object_moonend.xml
+++ b/assets/xml/objects/object_moonend.xml
@@ -34,7 +34,7 @@
         <!-- <Blob Name="object_moonend_Blob_00E658" Size="0x48" Offset="0xE658" /> -->
         <DList Name="object_moonend_DL_00EB00" Offset="0xEB00" />
         <Texture Name="object_moonend_Tex_00EC58" OutName="tex_00EC58" Format="i8" Width="64" Height="64" Offset="0xEC58" />
-        <DList Name="object_moonend_DL_010C40" Offset="0x10C40" />
+        <DList Name="object_moonend_DL_010C40" Offset="0x10C40" /> <!-- Original name is "rainbow_model" -->
         <Texture Name="object_moonend_Tex_0111E0" OutName="tex_0111E0" Format="i8" Width="64" Height="64" Offset="0x111E0" />
         <Texture Name="object_moonend_Tex_0121E0" OutName="tex_0121E0" Format="i8" Width="32" Height="64" Offset="0x121E0" />
         <TextureAnimation Name="object_moonend_Matanimheader_0129F0" Offset="0x129F0" />

--- a/assets/xml/objects/object_moonston.xml
+++ b/assets/xml/objects/object_moonston.xml
@@ -4,8 +4,8 @@
         along with its associated fire trail.
     -->
     <File Name="object_moonston" Segment="6">
-        <DList Name="gFallingMoonsTearDL" Offset="0x400" />
-        <DList Name="gFallingMoonsTearFireDL" Offset="0x4C8" />
+        <DList Name="gFallingMoonsTearDL" Offset="0x400" /> <!-- Original name is "moon_stone_g1_FT_model" -->
+        <DList Name="gFallingMoonsTearFireDL" Offset="0x4C8" /> <!-- Original name is "moon_stone_g2_FT_model" -->
         <Texture Name="gFallingMoonsTearTex" OutName="falling_moons_tear" Format="i8" Width="32" Height="32" Offset="0x608" />
         <Texture Name="gFallingMoonsTearFireTex" OutName="falling_moons_tear_fire" Format="i8" Width="32" Height="64" Offset="0xA08" />
         <TextureAnimation Name="gFallingMoonsTearTexAnim" Offset="0x1220" />

--- a/assets/xml/objects/object_ms.xml
+++ b/assets/xml/objects/object_ms.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_ms" Segment="6">
         <!-- Bean Salesman Animations -->
-        <Animation Name="gBeanSalesmanEatingAnim" Offset="0x5EC"/>
+        <Animation Name="gBeanSalesmanEatingAnim" Offset="0x5EC"/> <!-- Original name is "ms_matsu" -->
 
         <!-- Bean Salesman Limb DisplayLists -->
         <DList Name="gBeanSalesmanLeftUpperArmDL" Offset="0x2E58"/>

--- a/assets/xml/objects/object_mu.xml
+++ b/assets/xml/objects/object_mu.xml
@@ -1,11 +1,11 @@
 ﻿<Root>
     <!-- Assets for Honey & Darling -->
     <File Name="object_mu" Segment="6">
-        <Animation Name="gHoneyAndDarlingCupCheeksLoopAnim" Offset="0x1F74" />
-        <Animation Name="gHoneyAndDarlingHugLoopAnim" Offset="0x2F64" />
-        <Animation Name="gHoneyAndDarlingGameDanceLoopAnim" Offset="0x4904" />
-        <Animation Name="gHoneyAndDarlingHoldHandsLoopAnim" Offset="0x5304" />
-        <Animation Name="gHoneyAndDarlingIdleAnim" Offset="0x53E0" />
+        <Animation Name="gHoneyAndDarlingCupCheeksLoopAnim" Offset="0x1F74" /> <!-- Original name is "tg_betabeta" -->
+        <Animation Name="gHoneyAndDarlingHugLoopAnim" Offset="0x2F64" /> <!-- Original name is "tg_dakisime" -->
+        <Animation Name="gHoneyAndDarlingGameDanceLoopAnim" Offset="0x4904" /> <!-- Original name is "tg_dance" -->
+        <Animation Name="gHoneyAndDarlingHoldHandsLoopAnim" Offset="0x5304" /> <!-- Original name is "tg_ityaita" -->
+        <Animation Name="gHoneyAndDarlingIdleAnim" Offset="0x53E0" /> <!-- Original name is "tg_matsu" -->
         <Texture Name="gHoneyAndDarlingTLUT" OutName="honey_and_darling_tlut" Format="rgba16" Width="16" Height="16" Offset="0x53F0" />
         <Texture Name="gHoneyAndDarlingShirtsAndShoesTex" OutName="honey_and_darling_shirts_and_shoes" Format="i8" Width="16" Height="16" Offset="0x55F0" />
         <Texture Name="gHoneyAndDarlingWomanDressTex" OutName="honey_and_darling_woman_dress" Format="ci8" Width="16" Height="16" Offset="0x56F0" />
@@ -58,6 +58,6 @@
         <Limb Name="gHoneyAndDarlingWomanRightHandLimb" Type="Standard" EnumName="HONEY_AND_DARLING_LIMB_WOMAN_RIGHT_HAND" Offset="0xB248" />
         <Limb Name="gHoneyAndDarlingWomanHeadLimb" Type="Standard" EnumName="HONEY_AND_DARLING_LIMB_WOMAN_HEAD" Offset="0xB254" />
         <Skeleton Name="gHoneyAndDarlingSkel" Type="Flex" LimbType="Standard" LimbNone="HONEY_AND_DARLING_LIMB_NONE" LimbMax="HONEY_AND_DARLING_LIMB_MAX" EnumName="HoneyAndDarlingLimb" Offset="0xB2B0" />
-        <Animation Name="gHoneyAndDarlingSurpiseAnim" Offset="0xBAC4" />
+        <Animation Name="gHoneyAndDarlingSurpiseAnim" Offset="0xBAC4" /> <!-- Original name is "tg_odoroku" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Mm2.xml
+++ b/assets/xml/overlays/ovl_En_Mm2.xml
@@ -8,7 +8,7 @@
         <Array Name="sEnMm22Vtx" Count="12" Offset="0x8E0">
             <Vtx/>
         </Array>
-        <DList Name="sEnMm2DL" Offset="0x9A8"/>
+        <DList Name="sEnMm2DL" Offset="0x9A8"/> <!-- Original name is "mm_myletter_model" -->
     </File>
 </Root>
 


### PR DESCRIPTION
Some notes on this one:
- Most of the DLs in the various `object_link_*` objects got combined into the skeletal mesh, so we unfortunately can't get names for them:
![image](https://github.com/zeldaret/mm/assets/12245827/c5460ffd-cc1f-41a4-9587-7c1dfea31575)
- All the `object_mask*` stuff got moved to `zelda2_keep`, and similar to the `object_gi*` models, I'm fairly sure Grezzo just named these themselves, so I omitted them.
- `object_mbar_obj` and `object_meganeana_obj` got completely hollowed-out in MM3D, so we don't get names for those.
- For `object_mnk`, the rope that ties the monkey to the pole and the rope winch that holds him above the pot are actually skeletons with animations. These animations are all named in MM3D, but I don't think any human can realistically look at them and line them up visually with the animations in MM64. However, in EnMnk itself, there are arrays that tie these animations back to the Monkey's animations (for example, `sMonkeyTiedUpAnimations` and `sMonkeyTiedUpPoleAnimations`). So I used those arrays to line everything up instead.