### PR TITLE
Skeleton and shin name cleanup

### DIFF
--- a/assets/xml/objects/object_ani.xml
+++ b/assets/xml/objects/object_ani.xml
@@ -8,10 +8,10 @@
         <Animation Name="gAniTreeHangingReachAnim" Offset="0x27A0" /> <!-- Original name is "Ani_ki02" -->
         <Limb Name="gAniPelvisLimb" Type="Standard" EnumName="ANI_LIMB_PELVIS" Offset="0x27B0" />
         <Limb Name="gAniLeftThighLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_THIGH" Offset="0x27BC" />
-        <Limb Name="gAniLeftCalfLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_CALF" Offset="0x27C8" />
+        <Limb Name="gAniLeftShinLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_SHIN" Offset="0x27C8" />
         <Limb Name="gAniLeftFootLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_FOOT" Offset="0x27D4" />
         <Limb Name="gAniRightThighLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_THIGH" Offset="0x27E0" />
-        <Limb Name="gAniRightCalfLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_CALF" Offset="0x27EC" />
+        <Limb Name="gAniRightShinLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_SHIN" Offset="0x27EC" />
         <Limb Name="gAniRightFootLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_FOOT" Offset="0x27F8" />
         <Limb Name="gAniTorsoLimb" Type="Standard" EnumName="ANI_LIMB_TORSO" Offset="0x2804" />
         <Limb Name="gAniLeftUpperArmLimb" Type="Standard" EnumName="ANI_LIMB_LEFT_UPPER_ARM" Offset="0x2810" />
@@ -21,7 +21,7 @@
         <Limb Name="gAniRightForearmLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_FOREARM" Offset="0x2840" />
         <Limb Name="gAniRightHandLimb" Type="Standard" EnumName="ANI_LIMB_RIGHT_HAND" Offset="0x284C" />
         <Limb Name="gAniHeadLimb" Type="Standard" EnumName="ANI_LIMB_HEAD" Offset="0x2858" />
-        <Skeleton Name="gAniSkeleton" Type="Flex" LimbType="Standard" LimbNone="ANI_LIMB_NONE" LimbMax="ANI_LIMB_MAX" EnumName="AniLimb" Offset="0x28A0" />
+        <Skeleton Name="gAniSkel" Type="Flex" LimbType="Standard" LimbNone="ANI_LIMB_NONE" LimbMax="ANI_LIMB_MAX" EnumName="AniLimb" Offset="0x28A0" />
         <DList Name="gAniRightHandDL" Offset="0x4860" />
         <DList Name="gAniRightForearmDL" Offset="0x4A50" />
         <DList Name="gAniRightUpperArmDL" Offset="0x4B38" />
@@ -30,10 +30,10 @@
         <DList Name="gAniLeftUpperArmDL" Offset="0x4F08" />
         <DList Name="gAniTorsoDL" Offset="0x5000" />
         <DList Name="gAniRightFootDL" Offset="0x5270" />
-        <DList Name="gAniRightCalfDL" Offset="0x5420" />
+        <DList Name="gAniRightShinDL" Offset="0x5420" />
         <DList Name="gAniRightThighDL" Offset="0x5668" />
         <DList Name="gAniLeftFootDL" Offset="0x5778" />
-        <DList Name="gAniLeftCalfDL" Offset="0x5928" />
+        <DList Name="gAniLeftShinDL" Offset="0x5928" />
         <DList Name="gAniLeftThighDL" Offset="0x5C50" />
         <DList Name="gAniPelvisDL" Offset="0x5D60" />
         <Texture Name="gAniGeneralTLUT" OutName="ani_general_tlut" Format="rgba16" Width="16" Height="16" Offset="0x5E58" />

--- a/assets/xml/objects/object_bigpo.xml
+++ b/assets/xml/objects/object_bigpo.xml
@@ -58,6 +58,6 @@
         <Limb Name="gBigPoeLanternLimb" Type="Standard" EnumName="BIG_POE_LIMB_LANTERN" Offset="0x5BD0" />
         <Limb Name="gBigPoeHatAndCloakLimb" Type="Standard" EnumName="BIG_POE_LIMB_HAT_AND_CLOAK" Offset="0x5BDC" />
         <Limb Name="gBigPoeLowerRobe" Type="Standard" EnumName="BIG_POE_LIMB_LOWER_ROBE" Offset="0x5BE8" />
-        <Skeleton Name="gBigPoeSkeleton" Type="Normal" LimbType="Standard" LimbNone="BIG_POE_LIMB_NONE" LimbMax="BIG_POE_LIMB_MAX" EnumName="BigPoeLimb" Offset="0x5C18" />
+        <Skeleton Name="gBigPoeSkel" Type="Normal" LimbType="Standard" LimbNone="BIG_POE_LIMB_NONE" LimbMax="BIG_POE_LIMB_MAX" EnumName="BigPoeLimb" Offset="0x5C18" />
     </File>
 </Root>

--- a/assets/xml/objects/object_ds2n.xml
+++ b/assets/xml/objects/object_ds2n.xml
@@ -14,10 +14,10 @@
         <DList Name="gDs2nLeftHandDL" Offset="0x33B0" />
         <DList Name="gDs2nHipsDL" Offset="0x3528" />
         <DList Name="gDs2nRightThighDL" Offset="0x35F0" /> 
-        <DList Name="gDs2nRightCalfDL" Offset="0x36D0" />
+        <DList Name="gDs2nRightShinDL" Offset="0x36D0" />
         <DList Name="gDs2nRightFootDL" Offset="0x37A8" />
         <DList Name="gDs2nLeftThighDL" Offset="0x3988" />
-        <DList Name="gDs2nLeftCalfDL" Offset="0x3A68" />
+        <DList Name="gDs2nLeftShinDL" Offset="0x3A68" />
         <DList Name="gDs2nLeftFootDL" Offset="0x3B40" />
         
         <Texture Name="gDs2nMainTlut" OutName="tlut_main" Format="rgba16" Width="16" Height="16" Offset="0x3CD8" />
@@ -70,10 +70,10 @@
         <!-- z64Utils cannot render this skeleton, no idea what the three limbs with no DL are for, our actor doesnt use them -->
         <Limb Name="gDs2nHipsLimb" Type="Standard" EnumName="DS2N_LIMB_HIPS" Offset="0x8050" />
         <Limb Name="gDs2nLeftThighLimb" Type="Standard" EnumName="DS2N_LIMB_LEFT_THIGH" Offset="0x805C" />
-        <Limb Name="gDs2nLeftCalfLimb" Type="Standard" EnumName="DS2N_LIMB_LEFT_CALF" Offset="0x8068" />
+        <Limb Name="gDs2nLeftShinLimb" Type="Standard" EnumName="DS2N_LIMB_LEFT_SHIN" Offset="0x8068" />
         <Limb Name="gDs2nLeftFootLimb" Type="Standard" EnumName="DS2N_LIMB_LEFT_FOOT" Offset="0x8074" />
         <Limb Name="gDs2nRightThighLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_THIGH" Offset="0x8080" />
-        <Limb Name="gDs2nRightCalfLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_CALF" Offset="0x808C" />
+        <Limb Name="gDs2nRightShinLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_SHIN" Offset="0x808C" />
         <Limb Name="gDs2nRightFootLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_FOOT" Offset="0x8098" />
         <Limb Name="gDs2nLimb_008098" Type="Standard" EnumName="DS2N_LIMB_08" Offset="0x80A4" /> <!-- these three have no DL -->
         <Limb Name="gDs2nLimb_0080B0" Type="Standard" EnumName="DS2N_LIMB_09" Offset="0x80B0" />
@@ -86,7 +86,7 @@
         <Limb Name="gDs2nRightForearmLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_FOREARM" Offset="0x8104" />
         <Limb Name="gDs2nRightHandLimb" Type="Standard" EnumName="DS2N_LIMB_RIGHT_HAND" Offset="0x8110" />
         <Limb Name="gDs2nHeadLimb" Type="Standard" EnumName="DS2N_LIMB_HEAD" Offset="0x811C" />
-        <Skeleton Name="gDs2nSkeleton" Type="Flex" LimbType="Standard" LimbNone="DS2N_LIMB_NONE" LimbMax="DS2N_LIMB_MAX" EnumName="Ds2nLimb" Offset="0x8170" />
+        <Skeleton Name="gDs2nSkel" Type="Flex" LimbType="Standard" LimbNone="DS2N_LIMB_NONE" LimbMax="DS2N_LIMB_MAX" EnumName="Ds2nLimb" Offset="0x8170" />
 
         <!-- 8 bytes: 0x11 followed by zeros  <Blob Name="gDs2n_Blob_008178" Size="0x8" Offset="0x8178" /> -->
     </File>

--- a/assets/xml/objects/object_famos.xml
+++ b/assets/xml/objects/object_famos.xml
@@ -22,7 +22,7 @@
         <Limb Name="gFamosSwordLimb" Type="Standard" EnumName="FAMOS_LIMB_SWORD" Offset="0x3D00" />
         <Limb Name="gFamosShieldLimb" Type="Standard" EnumName="FAMOS_LIMB_SHIELD" Offset="0x3D0C" />
         <Limb Name="gFamosHeadLimb" Type="Standard" EnumName="FAMOS_LIMB_HEAD" Offset="0x3D18" />
-        <Skeleton Name="gFamosSkeleton" Type="Normal" LimbType="Standard" LimbNone="FAMOS_LIMB_NONE" LimbMax="FAMOS_LIMB_MAX" EnumName="FamosLimb" Offset="0x3D38" />
+        <Skeleton Name="gFamosSkel" Type="Normal" LimbType="Standard" LimbNone="FAMOS_LIMB_NONE" LimbMax="FAMOS_LIMB_MAX" EnumName="FamosLimb" Offset="0x3D38" />
 
         <Animation Name="gFamosIdleAnim" Offset="0x3DC8" /> <!-- Original name is "fam_dosun" -->
         <TextureAnimation Name="gFamosNormalGlowingEmblemTexAnim" Offset="0x3E30" />

--- a/assets/xml/objects/object_hs.xml
+++ b/assets/xml/objects/object_hs.xml
@@ -46,6 +46,6 @@
         <!-- shoulders down to toes plus box hes sitting on -->
         <Limb Name="gHsChestAndLowerBodyPlusBox" Type="Standard" EnumName="HS_LIMB_LOWER_BODY_PLUS_BOX" Offset="0x620C" />
         <Limb Name="gHsCuccoFeedBagsLimb" Type="Standard" EnumName="HS_LIMB_CUCCO_FEED_BAGS" Offset="0x6218" />
-        <Skeleton Name="gHsSkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_HS_LIMB_NONE" LimbMax="OBJECT_HS_LIMB_MAX" EnumName="ObjectHsLimb" Offset="0x6260" />
+        <Skeleton Name="gHsSkel" Type="Flex" LimbType="Standard" LimbNone="OBJECT_HS_LIMB_NONE" LimbMax="OBJECT_HS_LIMB_MAX" EnumName="ObjectHsLimb" Offset="0x6260" />
     </File>
 </Root>

--- a/assets/xml/objects/object_mnk.xml
+++ b/assets/xml/objects/object_mnk.xml
@@ -23,7 +23,7 @@
         <Limb Name="object_mnk_Standardlimb_00511C" Type="Standard" EnumName="OBJECT_MNK_1_LIMB_02" Offset="0x511C" />
         <Limb Name="object_mnk_Standardlimb_005128" Type="Standard" EnumName="OBJECT_MNK_1_LIMB_03" Offset="0x5128" />
         <Limb Name="object_mnk_Standardlimb_005134" Type="Standard" EnumName="OBJECT_MNK_1_LIMB_04" Offset="0x5134" />
-        <Skeleton Name="gMonkeyTiedUpPoleSkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_1_LIMB_NONE" LimbMax="OBJECT_MNK_1_LIMB_MAX" EnumName="ObjectMnk1Limb" Offset="0x5150" />
+        <Skeleton Name="gMonkeyTiedUpPoleSkel" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_1_LIMB_NONE" LimbMax="OBJECT_MNK_1_LIMB_MAX" EnumName="ObjectMnk1Limb" Offset="0x5150" />
         <Animation Name="object_mnk_Anim_005194" Offset="0x5194" /> <!-- Original name is "mnk_hashira_swing" -->
         <Animation Name="object_mnk_Anim_0052C4" Offset="0x52C4" /> <!-- Original name is "mnk_hashira_tiedNO" -->
         <Animation Name="object_mnk_Anim_005390" Offset="0x5390" /> <!-- Original name is "mnk_hashira_tiedtalk" -->
@@ -109,7 +109,7 @@
         <Limb Name="object_mnk_Standardlimb_019B0C" Type="Standard" EnumName="OBJECT_MNK_2_LIMB_14" Offset="0x19B0C" />
         <Limb Name="object_mnk_Standardlimb_019B18" Type="Standard" EnumName="OBJECT_MNK_2_LIMB_15" Offset="0x19B18" />
         <Limb Name="object_mnk_Standardlimb_019B24" Type="Standard" EnumName="OBJECT_MNK_2_LIMB_16" Offset="0x19B24" />
-        <Skeleton Name="gMonkeySkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_2_LIMB_NONE" LimbMax="OBJECT_MNK_2_LIMB_MAX" EnumName="ObjectMnk2Limb" Offset="0x19B88" />
+        <Skeleton Name="gMonkeySkel" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_2_LIMB_NONE" LimbMax="OBJECT_MNK_2_LIMB_MAX" EnumName="ObjectMnk2Limb" Offset="0x19B88" />
         <Animation Name="object_mnk_Anim_01A4F8" Offset="0x1A4F8" /> <!-- Original name is "mnk_onnikiruze" -->
         <Animation Name="object_mnk_Anim_01B468" Offset="0x1B468" /> <!-- Original name is "mnk_wakatte" -->
         <Animation Name="object_mnk_Anim_01BB0C" Offset="0x1BB0C" /> <!-- Original name is "mnk_wakatte_loop" -->
@@ -126,6 +126,6 @@
         <Limb Name="object_mnk_Standardlimb_01D4E8" Type="Standard" EnumName="OBJECT_MNK_3_LIMB_01" Offset="0x1D4E8" />
         <Limb Name="object_mnk_Standardlimb_01D4F4" Type="Standard" EnumName="OBJECT_MNK_3_LIMB_02" Offset="0x1D4F4" />
         <Limb Name="object_mnk_Standardlimb_01D500" Type="Standard" EnumName="OBJECT_MNK_3_LIMB_03" Offset="0x1D500" />
-        <Skeleton Name="gMonkeyHangingRopeSkeleton" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_3_LIMB_NONE" LimbMax="OBJECT_MNK_3_LIMB_MAX" EnumName="ObjectMnk3Limb" Offset="0x1D518" />
+        <Skeleton Name="gMonkeyHangingRopeSkel" Type="Flex" LimbType="Standard" LimbNone="OBJECT_MNK_3_LIMB_NONE" LimbMax="OBJECT_MNK_3_LIMB_MAX" EnumName="ObjectMnk3Limb" Offset="0x1D518" />
     </File>
 </Root>

--- a/assets/xml/objects/object_niw.xml
+++ b/assets/xml/objects/object_niw.xml
@@ -35,6 +35,6 @@
         <Limb Name="gNiwUpperBodyRootLimb" LimbType="Standard" EnumName="NIW_LIMB_UPPER_BODY" Offset="0x24D0"/>
         <Limb Name="gNiwNeckLimb" LimbType="Standard" EnumName="NIW_LIMB_NECK" Offset="0x24DC"/>
         <Limb Name="gNiwHeadLimb" LimbType="Standard" EnumName="NIW_LIMB_HEAD" Offset="0x24E8"/>
-        <Skeleton Name="gNiwSkeleton" Type="Flex" LimbType="Standard" LimbNone="NIW_LIMB_NONE" LimbMax="NIW_LIMB_MAX" EnumName="ObjectNiwLimb" Offset="0x2530" />
+        <Skeleton Name="gNiwSkel" Type="Flex" LimbType="Standard" LimbNone="NIW_LIMB_NONE" LimbMax="NIW_LIMB_MAX" EnumName="ObjectNiwLimb" Offset="0x2530" />
     </File>
 </Root>

--- a/assets/xml/objects/object_tro.xml
+++ b/assets/xml/objects/object_tro.xml
@@ -13,6 +13,6 @@
         <Texture Name="gKoumeKioskEyeHalfTex" OutName="koume_kiosk_eye_half" Format="rgba16" Width="32" Height="32" Offset="0x1940"/>
         <Texture Name="gKoumeKioskEyeClosedTex" OutName="koume_kiosk_eye_closed" Format="rgba16" Width="32" Height="32" Offset="0x2140"/>
         <Limb Name="gKoumeKioskHeadLimb" Type="Standard" EnumName="KOUME_KIOSK_LIMB_HEAD" Offset="0x2940" />
-        <Skeleton Name="gKoumeKioskSkeleton" Type="Normal" LimbType="Standard" LimbNone="KOUME_KIOSK_LIMB_NONE" LimbMax="KOUME_KIOSK_LIMB_MAX" EnumName="KoumeKioskLimb" Offset="0x2950" />
+        <Skeleton Name="gKoumeKioskSkel" Type="Normal" LimbType="Standard" LimbNone="KOUME_KIOSK_LIMB_NONE" LimbMax="KOUME_KIOSK_LIMB_MAX" EnumName="KoumeKioskLimb" Offset="0x2950" />
     </File>
 </Root>

--- a/assets/xml/objects/object_yb.xml
+++ b/assets/xml/objects/object_yb.xml
@@ -8,10 +8,10 @@
         <!-- <Blob Name="object_yb_Blob_002D50" Size="0x30" Offset="0x2D50" /> -->
         <DList Name="gYbPantsAndBellyButtonDL" Offset="0x3400" />
         <DList Name="gYbRightThighDL" Offset="0x3610" />
-        <DList Name="gYbRightCalfDL" Offset="0x37B0" />
+        <DList Name="gYbRightShinDL" Offset="0x37B0" />
         <DList Name="gYbRightFoodDL" Offset="0x3900" />
         <DList Name="gYbLeftThighDL" Offset="0x3BC8" />
-        <DList Name="gYbLeftCalfDL" Offset="0x3D68" />
+        <DList Name="gYbLeftShinDL" Offset="0x3D68" />
         <DList Name="gYbLeftFootDL" Offset="0x3EB8" />
         <DList Name="gYbEndDisplayList4108DL" Offset="0x4108" />
         <DList Name="gYbUpperTorsoDL" Offset="0x4110" />
@@ -39,10 +39,10 @@
         <Limb Name="gYbPantsLimb" Type="Standard" EnumName="YB_LIMB_PANTS" Offset="0x5E04" />
         <Limb Name="gYbLegsRootLimb" Type="Standard" EnumName="YB_LIMB_LEGS_ROOT" Offset="0x5E10" />
         <Limb Name="gYbRightThighLimb" Type="Standard" EnumName="YB_LIMB_RIGHT_THIGH" Offset="0x5E1C" />
-        <Limb Name="gYbRightCalfLimb" Type="Standard" EnumName="YB_LIMB_RIGHT_CALF" Offset="0x5E28" />
+        <Limb Name="gYbRightShinLimb" Type="Standard" EnumName="YB_LIMB_RIGHT_SHIN" Offset="0x5E28" />
         <Limb Name="gYbRightFootLimb" Type="Standard" EnumName="YB_LIMB_RIGHT_FOOT" Offset="0x5E34" />
         <Limb Name="gYbLeftThighLimb" Type="Standard" EnumName="YB_LIMB_LEFT_THIGH" Offset="0x5E40" />
-        <Limb Name="gYbLeftCalfLimb" Type="Standard" EnumName="YB_LIMB_LEFT_CALF" Offset="0x5E4C" />
+        <Limb Name="gYbLeftShinLimb" Type="Standard" EnumName="YB_LIMB_LEFT_SHIN" Offset="0x5E4C" />
         <Limb Name="gYbLeftFootLimb" Type="Standard" EnumName="YB_LIMB_LEFT_FOOT" Offset="0x5E58" />
         <Limb Name="gYbChestRootLimb" Type="Standard" EnumName="YB_LIMB_CHEST_ROOT" Offset="0x5E64" />
         <Limb Name="gYbHeadLimb" Type="Standard" EnumName="YB_LIMB_HEAD" Offset="0x5E70" />
@@ -57,6 +57,6 @@
         <Limb Name="gYbRightHandLimb" Type="Standard" EnumName="YB_LIMB_RIGHT_HAND" Offset="0x5ED0" />
         <Limb Name="gYbEmpty5EDCLimb" Type="Standard" EnumName="YB_LIMB_EMPTY_5EDC" Offset="0x5EDC" />
         <Limb Name="gYbUpperTorsoLimb" Type="Standard" EnumName="YB_LIMB_TORSO" Offset="0x5EE8" />
-        <Skeleton Name="gYbSkeleton" Type="Flex" LimbType="Standard" LimbNone="YB_LIMB_NONE" LimbMax="YB_LIMB_MAX" EnumName="ObjectYbLimb" Offset="0x5F48" />
+        <Skeleton Name="gYbSkel" Type="Flex" LimbType="Standard" LimbNone="YB_LIMB_NONE" LimbMax="YB_LIMB_MAX" EnumName="ObjectYbLimb" Offset="0x5F48" />
     </File>
 </Root>

--- a/assets/xml/objects/object_zl4.xml
+++ b/assets/xml/objects/object_zl4.xml
@@ -93,7 +93,7 @@
         <Limb Name="gDmZl4RightForearmLimb" Type="Standard" EnumName="ZL4_LIMB_RIGHT_FOREARM" Offset="0xDFD0" />
         <Limb Name="gDmZl4RightHandLimb" Type="Standard" EnumName="ZL4_LIMB_RIGHT_HAND" Offset="0xDFDC" />
         <Limb Name="gDmZl4HeadLimb" Type="Standard" EnumName="ZL4_LIMB_HEAD" Offset="0xDFE8" />
-        <Skeleton Name="gZl4Skeleton" Type="Flex" LimbType="Standard" LimbNone="ZL4_LIMB_NONE" LimbMax="ZL4_LIMB_MAX" EnumName="Zl4Limb" Offset="0xE038" />
+        <Skeleton Name="gZl4Skel" Type="Flex" LimbType="Standard" LimbNone="ZL4_LIMB_NONE" LimbMax="ZL4_LIMB_MAX" EnumName="Zl4Limb" Offset="0xE038" />
 
         
         <!-- Unused Flute Animations -->

--- a/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.c
+++ b/src/overlays/actors/ovl_Dm_Zl/z_dm_zl.c
@@ -119,7 +119,7 @@ void DmZl_Init(Actor* thisx, PlayState* play) {
     this->actor.targetArrowOffset = 1000.0f;
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 24.0f);
     // these three set to NULL should mean they are dynamically allocated
-    SkelAnime_InitFlex(play, &this->skelAnime, &gZl4Skeleton, NULL, NULL, NULL, 0);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gZl4Skel, NULL, NULL, NULL, 0);
     DmZl_ChangeAnim(&this->skelAnime, &sAnimationInfo[this->animIndex], 0);
     Actor_SetScale(&this->actor, 0.01f);
     this->actionFunc = DmZl_DoNothing;

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -117,8 +117,8 @@ void EnAni_Init(Actor* thisx, PlayState* play) {
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 24.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gAniSkeleton, &gAniStandingNormalAnim, this->jointTable,
-                       this->morphTable, ANI_LIMB_MAX);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gAniSkel, &gAniStandingNormalAnim, this->jointTable, this->morphTable,
+                       ANI_LIMB_MAX);
     Animation_PlayOnce(&this->skelAnime, &gAniStandingNormalAnim);
     Collider_InitAndSetCylinder(play, &this->collider1, &this->actor, &sCylinderInit);
     Collider_InitAndSetCylinder(play, &this->collider2, &this->actor, &sCylinderInit);

--- a/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
+++ b/src/overlays/actors/ovl_En_Attack_Niw/z_en_attack_niw.c
@@ -43,7 +43,7 @@ void EnAttackNiw_Init(Actor* thisx, PlayState* play) {
 
     Actor_ProcessInitChain(&this->actor, sInitChain);
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 25.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gNiwSkeleton, &gNiwIdleAnim, this->jointTable, this->morphTable,
+    SkelAnime_InitFlex(play, &this->skelAnime, &gNiwSkel, &gNiwIdleAnim, this->jointTable, this->morphTable,
                        NIW_LIMB_MAX);
 
     // probably copy pasted from EnNiw, which has this same code, but AttackNiw has no params

--- a/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
+++ b/src/overlays/actors/ovl_En_Bigpo/z_en_bigpo.c
@@ -201,7 +201,7 @@ void EnBigpo_Init(Actor* thisx, PlayState* play2) {
         return;
     }
 
-    SkelAnime_Init(play, &this->skelAnime, &gBigPoeSkeleton, &gBigPoeFloatAnim, this->jointTable, this->morphTable,
+    SkelAnime_Init(play, &this->skelAnime, &gBigPoeSkel, &gBigPoeFloatAnim, this->jointTable, this->morphTable,
                    BIG_POE_LIMB_MAX);
     Collider_InitAndSetCylinder(play, &this->collider, &this->actor, &sCylinderInit);
     CollisionCheck_SetInfo(&thisx->colChkInfo, &sDamageTable, &sColChkInfoInit);

--- a/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
+++ b/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
@@ -136,7 +136,7 @@ void EnDnh_Init(Actor* thisx, PlayState* play) {
     EnDnh* this = THIS;
 
     ActorShape_Init(&this->actor.shape, 0.0f, NULL, 0.0f);
-    SkelAnime_Init(play, &this->skelAnime, &gKoumeKioskSkeleton, NULL, this->jointTable, this->morphTable,
+    SkelAnime_Init(play, &this->skelAnime, &gKoumeKioskSkel, NULL, this->jointTable, this->morphTable,
                    KOUME_KIOSK_LIMB_MAX);
     SubS_ChangeAnimationByInfoS(&this->skelAnime, sAnimationInfo, ENDNH_ANIM_HEAD_MOVING);
     this->actor.shape.yOffset = 1100.0f;

--- a/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
+++ b/src/overlays/actors/ovl_En_Ds2n/z_en_ds2n.c
@@ -71,7 +71,7 @@ void EnDs2n_Init(Actor* thisx, PlayState* play) {
     EnDs2n* this = THIS;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 20.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gDs2nSkeleton, &gDs2nIdleAnim, NULL, NULL, 0);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gDs2nSkel, &gDs2nIdleAnim, NULL, NULL, 0);
     EnDs2n_SetupIdle(this);
 }
 

--- a/src/overlays/actors/ovl_En_Famos/z_en_famos.c
+++ b/src/overlays/actors/ovl_En_Famos/z_en_famos.c
@@ -173,7 +173,7 @@ void EnFamos_Init(Actor* thisx, PlayState* play) {
     }
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawSquare, 30.0f);
-    SkelAnime_Init(play, &this->skelAnime, &gFamosSkeleton, &gFamosIdleAnim, this->jointTable, this->morphTable,
+    SkelAnime_Init(play, &this->skelAnime, &gFamosSkel, &gFamosIdleAnim, this->jointTable, this->morphTable,
                    FAMOS_LIMB_MAX);
     Collider_InitAndSetCylinder(play, &this->collider1, &this->actor, &sCylinderInit1);
     Collider_InitAndSetCylinder(play, &this->collider2, &this->actor, &sCylinderInit2);

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -74,7 +74,7 @@ void EnHs_Init(Actor* thisx, PlayState* play) {
     EnHs* this = THIS;
 
     ActorShape_Init(&this->actor.shape, 0.0f, ActorShadow_DrawCircle, 36.0f);
-    SkelAnime_InitFlex(play, &this->skelAnime, &gHsSkeleton, &gHsIdleAnim, this->jointTable, this->morphTable,
+    SkelAnime_InitFlex(play, &this->skelAnime, &gHsSkel, &gHsIdleAnim, this->jointTable, this->morphTable,
                        OBJECT_HS_LIMB_MAX);
     Animation_PlayLoop(&this->skelAnime, &gHsIdleAnim);
     Collider_InitAndSetCylinder(play, &this->collider, &this->actor, &sCylinderInit);

--- a/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
+++ b/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
@@ -249,7 +249,7 @@ void EnMnk_MonkeyTiedUp_Init(Actor* thisx, PlayState* play) {
 
     this->actionFunc = EnMnk_MonkeyTiedUp_Wait;
     this->picto.actor.flags |= ACTOR_FLAG_2000000;
-    SkelAnime_InitFlex(play, &this->propSkelAnime, &gMonkeyTiedUpPoleSkeleton, &object_mnk_Anim_003584,
+    SkelAnime_InitFlex(play, &this->propSkelAnime, &gMonkeyTiedUpPoleSkel, &object_mnk_Anim_003584,
                        this->propJointTable, this->propMorphTable, OBJECT_MNK_1_LIMB_MAX);
     this->cueId = 4;
     this->animIndex = MONKEY_TIEDUP_ANIM_NONE;
@@ -277,7 +277,7 @@ void EnMnk_MonkeyHanging_Init(Actor* thisx, PlayState* play) {
     func_800BC154(play, &play->actorCtx, &this->picto.actor, ACTORCAT_PROP);
     this->actionFunc = EnMnk_MonkeyHanging_StruggleBeforeDunk;
     this->picto.actor.textId = 0x8E8;
-    SkelAnime_InitFlex(play, &this->propSkelAnime, &gMonkeyHangingRopeSkeleton, &gMonkeyHangingStruggleAnim,
+    SkelAnime_InitFlex(play, &this->propSkelAnime, &gMonkeyHangingRopeSkel, &gMonkeyHangingStruggleAnim,
                        this->propJointTable, this->propMorphTable, OBJECT_MNK_3_LIMB_MAX);
     EnMnk_MonkeyHanging_ChangeAnim(this, MONKEY_HANGING_ANIM_STRUGGLE, ANIMMODE_LOOP, 0.0f);
     this->unk_3E0 = 5;
@@ -297,7 +297,7 @@ void EnMnk_Init(Actor* thisx, PlayState* play) {
     Actor_SetScale(&this->picto.actor, 0.012f);
     ActorShape_Init(&this->picto.actor.shape, 0.0f, ActorShadow_DrawCircle, 12.0f);
     this->actionFunc = EnMnk_DoNothing;
-    SkelAnime_InitFlex(play, &this->skelAnime, &gMonkeySkeleton, &object_mnk_Anim_0105DC, this->jointTable,
+    SkelAnime_InitFlex(play, &this->skelAnime, &gMonkeySkel, &object_mnk_Anim_0105DC, this->jointTable,
                        this->morphTable, OBJECT_MNK_2_LIMB_MAX);
     Animation_PlayLoop(&this->skelAnime, &object_mnk_Anim_0105DC);
     this->flags = 0;

--- a/src/overlays/actors/ovl_En_Niw/z_en_niw.c
+++ b/src/overlays/actors/ovl_En_Niw/z_en_niw.c
@@ -108,7 +108,7 @@ void EnNiw_Init(Actor* thisx, PlayState* play) {
 
     ActorShape_Init(&thisx->shape, 0.0f, ActorShadow_DrawCircle, 25.0f);
 
-    SkelAnime_InitFlex(play, &this->skelAnime, &gNiwSkeleton, &gNiwIdleAnim, this->jointTable, this->morphTable,
+    SkelAnime_InitFlex(play, &this->skelAnime, &gNiwSkel, &gNiwIdleAnim, this->jointTable, this->morphTable,
                        NIW_LIMB_MAX);
     Math_Vec3f_Copy(&this->unk2A4, &this->actor.world.pos);
     Math_Vec3f_Copy(&this->unk2B0, &this->actor.world.pos);

--- a/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
+++ b/src/overlays/actors/ovl_En_Nwc/z_en_nwc.c
@@ -250,7 +250,7 @@ void EnNwc_LoadNiwSkeleton(EnNwc* this, PlayState* play) {
     if (Object_IsLoaded(&play->objectCtx, this->niwObjectIndex)) {
         gSegments[6] = VIRTUAL_TO_PHYSICAL(play->objectCtx.slots[this->niwObjectIndex].segment);
 
-        SkelAnime_InitFlex(play, &this->niwSkeleton, &gNiwSkeleton, &gNiwIdleAnim, this->jointTable, this->morphTable,
+        SkelAnime_InitFlex(play, &this->niwSkeleton, &gNiwSkel, &gNiwIdleAnim, this->jointTable, this->morphTable,
                            NIW_LIMB_MAX);
         Animation_Change(&this->niwSkeleton, &gNiwIdleAnim, 1.0f, 0.0f, Animation_GetLastFrame(&gNiwIdleAnim),
                          ANIMMODE_LOOP, 0.0f);

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -1395,8 +1395,8 @@ void EnOssan_CuriosityShopMan_Init(EnOssan* this, PlayState* play) {
 }
 
 void EnOssan_PartTimer_Init(EnOssan* this, PlayState* play) {
-    SkelAnime_InitFlex(play, &this->skelAnime, &gAniSkeleton, &gAniStandingNormalAnim, this->jointTable,
-                       this->morphTable, 16);
+    SkelAnime_InitFlex(play, &this->skelAnime, &gAniSkel, &gAniStandingNormalAnim, this->jointTable, this->morphTable,
+                       16);
     this->actor.draw = EnOssan_PartTimer_Draw;
 }
 

--- a/src/overlays/actors/ovl_En_Yb/z_en_yb.c
+++ b/src/overlays/actors/ovl_En_Yb/z_en_yb.c
@@ -88,7 +88,7 @@ void EnYb_Init(Actor* thisx, PlayState* play) {
     ActorShape_Init(&this->actor.shape, 0.0f, EnYb_ActorShadowFunc, 20.0f);
 
     // @bug this alignment is because of player animations, but should be using ALIGN16
-    SkelAnime_InitFlex(play, &this->skelAnime, &gYbSkeleton, &object_yb_Anim_000200, (uintptr_t)this->jointTable & ~0xF,
+    SkelAnime_InitFlex(play, &this->skelAnime, &gYbSkel, &object_yb_Anim_000200, (uintptr_t)this->jointTable & ~0xF,
                        (uintptr_t)this->morphTable & ~0xF, YB_LIMB_MAX);
 
     Animation_PlayLoop(&this->skelAnime, &object_yb_Anim_000200);


### PR DESCRIPTION
engineer pointed out to me that not all skeleton assets ended with `Skel` and that some humanoid lower legs were called "calf" instead of "shin". This PR addresses both of these inconsistencies.