### PR TITLE
Document `object_jso` (Garo and Garo Master)

### DIFF
--- a/assets/xml/objects/object_jso.xml
+++ b/assets/xml/objects/object_jso.xml
@@ -2,8 +2,8 @@
     <!-- Assets for Garos and the Garo Master -->
     <File Name="object_jso" Segment="6">
         <!-- Unused Empty Texture Animations -->
-        <TextureAnimation Name="gGaroEmptyTexAnim1" Offset="0x0" />
-        <TextureAnimation Name="gGaroEmptyTexAnim2" Offset="0x10" />
+        <TextureAnimation Name="gGaroEmpty1TexAnim" Offset="0x0" />
+        <TextureAnimation Name="gGaroEmpty2TexAnim" Offset="0x10" />
 
         <!-- Garo Master Limb DisplayLists -->
         <DList Name="gGaroMasterLeftThighDL" Offset="0x1210" />

--- a/assets/xml/objects/object_jso.xml
+++ b/assets/xml/objects/object_jso.xml
@@ -1,122 +1,147 @@
 ﻿<Root>
+    <!-- Assets for Garos and the Garo Master -->
     <File Name="object_jso" Segment="6">
-        <!-- <Blob Name="object_jso_Blob_000000" Size="0x20" Offset="0x0" /> -->
-        <DList Name="object_jso_DL_001210" Offset="0x1210" />
-        <DList Name="object_jso_DL_001348" Offset="0x1348" />
-        <DList Name="object_jso_DL_0013F8" Offset="0x13F8" />
-        <DList Name="object_jso_DL_001508" Offset="0x1508" />
-        <DList Name="object_jso_DL_001640" Offset="0x1640" />
-        <DList Name="object_jso_DL_0016F0" Offset="0x16F0" />
-        <DList Name="object_jso_DL_001800" Offset="0x1800" />
-        <DList Name="object_jso_DL_001908" Offset="0x1908" />
-        <DList Name="object_jso_DL_001A18" Offset="0x1A18" />
-        <DList Name="object_jso_DL_001B00" Offset="0x1B00" />
-        <DList Name="object_jso_DL_001C48" Offset="0x1C48" />
-        <DList Name="object_jso_DL_001D78" Offset="0x1D78" />
-        <DList Name="object_jso_DL_001EA8" Offset="0x1EA8" />
-        <DList Name="object_jso_DL_001FA8" Offset="0x1FA8" />
-        <DList Name="object_jso_DL_001FF8" Offset="0x1FF8" />
-        <DList Name="object_jso_DL_0020B0" Offset="0x20B0" />
-        <DList Name="object_jso_DL_002100" Offset="0x2100" />
-        <!-- <Blob Name="object_jso_Blob_0021B8" Size="0x100" Offset="0x21B8" /> -->
-        <Texture Name="object_jso_Tex_0022B8" OutName="tex_0022B8" Format="rgba16" Width="16" Height="16" Offset="0x22B8" />
-        <Texture Name="object_jso_Tex_0024B8" OutName="tex_0024B8" Format="rgba16" Width="8" Height="16" Offset="0x24B8" />
-        <!-- <Blob Name="object_jso_Blob_0025B8" Size="0x80" Offset="0x25B8" /> -->
-        <Texture Name="object_jso_Tex_002638" OutName="tex_002638" Format="rgba16" Width="4" Height="4" Offset="0x2638" />
-        <Texture Name="object_jso_Tex_002658" OutName="tex_002658" Format="rgba16" Width="8" Height="32" Offset="0x2658" />
-        <Texture Name="object_jso_TLUT_002858" OutName="tlut_002858" Format="rgba16" Width="16" Height="16" Offset="0x2858" />
-        <Texture Name="object_jso_TLUT_002A58" OutName="tlut_002A58" Format="rgba16" Width="16" Height="16" Offset="0x2A58" />
-        <Texture Name="object_jso_Tex_002C58" OutName="tex_002C58" Format="ci8" Width="16" Height="16" Offset="0x2C58" />
-        <Texture Name="object_jso_Tex_002D58" OutName="tex_002D58" Format="ci8" Width="16" Height="16" Offset="0x2D58" />
-        <DList Name="object_jso_DL_002ED8" Offset="0x2ED8" />
-        <Texture Name="object_jso_Tex_002FB8" OutName="tex_002FB8" Format="rgba16" Width="8" Height="8" Offset="0x2FB8" />
-        <Limb Name="object_jso_Standardlimb_003038" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_01" Offset="0x3038" />
-        <Limb Name="object_jso_Standardlimb_003044" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_02" Offset="0x3044" />
-        <Limb Name="object_jso_Standardlimb_003050" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_03" Offset="0x3050" />
-        <Limb Name="object_jso_Standardlimb_00305C" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_04" Offset="0x305C" />
-        <Limb Name="object_jso_Standardlimb_003068" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_05" Offset="0x3068" />
-        <Limb Name="object_jso_Standardlimb_003074" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_06" Offset="0x3074" />
-        <Limb Name="object_jso_Standardlimb_003080" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_07" Offset="0x3080" />
-        <Limb Name="object_jso_Standardlimb_00308C" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_08" Offset="0x308C" />
-        <Limb Name="object_jso_Standardlimb_003098" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_09" Offset="0x3098" />
-        <Limb Name="object_jso_Standardlimb_0030A4" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0A" Offset="0x30A4" />
-        <Limb Name="object_jso_Standardlimb_0030B0" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0B" Offset="0x30B0" />
-        <Limb Name="object_jso_Standardlimb_0030BC" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0C" Offset="0x30BC" />
-        <Limb Name="object_jso_Standardlimb_0030C8" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0D" Offset="0x30C8" />
-        <Limb Name="object_jso_Standardlimb_0030D4" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0E" Offset="0x30D4" />
-        <Limb Name="object_jso_Standardlimb_0030E0" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_0F" Offset="0x30E0" />
-        <Limb Name="object_jso_Standardlimb_0030EC" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_10" Offset="0x30EC" />
-        <Limb Name="object_jso_Standardlimb_0030F8" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_11" Offset="0x30F8" />
-        <Limb Name="object_jso_Standardlimb_003104" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_12" Offset="0x3104" />
-        <Limb Name="object_jso_Standardlimb_003110" Type="Standard" EnumName="OBJECT_JSO_1_LIMB_13" Offset="0x3110" />
-        <Skeleton Name="object_jso_Skel_003168" Type="Flex" LimbType="Standard" LimbNone="OBJECT_JSO_1_LIMB_NONE" LimbMax="OBJECT_JSO_1_LIMB_MAX" EnumName="ObjectJso1Limb" Offset="0x3168" />
-        <Animation Name="object_jso_Anim_003238" Offset="0x3238" /> <!-- Original name is "jsk_pose" -->
-        <Animation Name="object_jso_Anim_003530" Offset="0x3530" /> <!-- Original name is "jso_attack1" -->
-        <Animation Name="object_jso_Anim_00378C" Offset="0x378C" /> <!-- Original name is "jso_attack2" -->
-        <Animation Name="object_jso_Anim_0038AC" Offset="0x38AC" /> <!-- Original name is "jso_attack_wait" -->
-        <Animation Name="object_jso_Anim_003D5C" Offset="0x3D5C" /> <!-- Original name is "jso_back" -->
-        <Animation Name="object_jso_Anim_004018" Offset="0x4018" /> <!-- Original name is "jso_bomb" -->
-        <Animation Name="object_jso_Anim_004384" Offset="0x4384" /> <!-- Original name is "jso_chakuchiD" -->
-        <Animation Name="object_jso_Anim_0044F8" Offset="0x44F8" /> <!-- Original name is "jso_damage" -->
-        <Animation Name="object_jso_Anim_004858" Offset="0x4858" /> <!-- Original name is "jso_defense" -->
-        <Animation Name="object_jso_Anim_005778" Offset="0x5778" /> <!-- Original name is "jso_demo_start" -->
-        <Animation Name="object_jso_Anim_005D5C" Offset="0x5D5C" /> <!-- Original name is "jso_down" -->
-        <Animation Name="object_jso_Anim_00603C" Offset="0x603C" /> <!-- Original name is "jso_hajiku" -->
-        <Animation Name="object_jso_Anim_0063A4" Offset="0x63A4" /> <!-- Original name is "jso_henahena" -->
-        <Animation Name="object_jso_Anim_0067F0" Offset="0x67F0" /> <!-- Original name is "jso_hetari" -->
-        <Animation Name="object_jso_Anim_0070BC" Offset="0x70BC" /> <!-- Original name is "jso_jakin" -->
-        <Animation Name="object_jso_Anim_0071E0" Offset="0x71E0" /> <!-- Original name is "jso_jumpD" -->
-        <Animation Name="object_jso_Anim_0072AC" Offset="0x72AC" /> <!-- Original name is "jso_kaiten" -->
-        <Animation Name="object_jso_Anim_00788C" Offset="0x788C" /> <!-- Original name is "jso_kyoro" -->
-        <Animation Name="object_jso_Anim_007B04" Offset="0x7B04" /> <!-- Original name is "jso_ororo" -->
-        <Animation Name="object_jso_Anim_0081F4" Offset="0x81F4" /> <!-- Original name is "jso_start" -->
-        <DList Name="object_jso_DL_008F50" Offset="0x8F50" />
-        <DList Name="object_jso_DL_009008" Offset="0x9008" />
-        <DList Name="object_jso_DL_0090C0" Offset="0x90C0" />
-        <DList Name="object_jso_DL_009190" Offset="0x9190" />
-        <DList Name="object_jso_DL_009248" Offset="0x9248" />
-        <DList Name="object_jso_DL_009300" Offset="0x9300" />
-        <DList Name="object_jso_DL_0093D0" Offset="0x93D0" />
-        <DList Name="object_jso_DL_009428" Offset="0x9428" />
-        <DList Name="object_jso_DL_0094E0" Offset="0x94E0" />
-        <DList Name="object_jso_DL_009758" Offset="0x9758" />
-        <DList Name="object_jso_DL_0098C8" Offset="0x98C8" />
-        <DList Name="object_jso_DL_0099B8" Offset="0x99B8" />
-        <DList Name="object_jso_DL_009AA8" Offset="0x9AA8" />
-        <DList Name="object_jso_DL_009B80" Offset="0x9B80" />
-        <DList Name="object_jso_DL_009BD8" Offset="0x9BD8" />
-        <DList Name="object_jso_DL_009C98" Offset="0x9C98" />
-        <DList Name="object_jso_DL_009CF0" Offset="0x9CF0" />
-        <Texture Name="object_jso_Tex_009DB0" OutName="tex_009DB0" Format="rgba16" Width="8" Height="16" Offset="0x9DB0" />
-        <Texture Name="object_jso_Tex_009EB0" OutName="tex_009EB0" Format="rgba16" Width="8" Height="8" Offset="0x9EB0" />
-        <Texture Name="object_jso_Tex_009F30" OutName="tex_009F30" Format="rgba16" Width="16" Height="32" Offset="0x9F30" />
-        <Texture Name="object_jso_Tex_00A330" OutName="tex_00A330" Format="rgba16" Width="16" Height="16" Offset="0xA330" />
-        <Texture Name="object_jso_Tex_00A530" OutName="tex_00A530" Format="rgba16" Width="16" Height="8" Offset="0xA530" />
-        <Texture Name="object_jso_Tex_00A630" OutName="tex_00A630" Format="rgba16" Width="8" Height="8" Offset="0xA630" />
-        <Texture Name="object_jso_Tex_00A6B0" OutName="tex_00A6B0" Format="rgba16" Width="16" Height="16" Offset="0xA6B0" />
-        <Texture Name="object_jso_Tex_00A8B0" OutName="tex_00A8B0" Format="rgba16" Width="4" Height="4" Offset="0xA8B0" />
-        <Limb Name="object_jso_Standardlimb_00A8D0" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_01" Offset="0xA8D0" />
-        <Limb Name="object_jso_Standardlimb_00A8DC" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_02" Offset="0xA8DC" />
-        <Limb Name="object_jso_Standardlimb_00A8E8" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_03" Offset="0xA8E8" />
-        <Limb Name="object_jso_Standardlimb_00A8F4" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_04" Offset="0xA8F4" />
-        <Limb Name="object_jso_Standardlimb_00A900" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_05" Offset="0xA900" />
-        <Limb Name="object_jso_Standardlimb_00A90C" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_06" Offset="0xA90C" />
-        <Limb Name="object_jso_Standardlimb_00A918" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_07" Offset="0xA918" />
-        <Limb Name="object_jso_Standardlimb_00A924" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_08" Offset="0xA924" />
-        <Limb Name="object_jso_Standardlimb_00A930" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_09" Offset="0xA930" />
-        <Limb Name="object_jso_Standardlimb_00A93C" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0A" Offset="0xA93C" />
-        <Limb Name="object_jso_Standardlimb_00A948" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0B" Offset="0xA948" />
-        <Limb Name="object_jso_Standardlimb_00A954" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0C" Offset="0xA954" />
-        <Limb Name="object_jso_Standardlimb_00A960" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0D" Offset="0xA960" />
-        <Limb Name="object_jso_Standardlimb_00A96C" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0E" Offset="0xA96C" />
-        <Limb Name="object_jso_Standardlimb_00A978" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_0F" Offset="0xA978" />
-        <Limb Name="object_jso_Standardlimb_00A984" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_10" Offset="0xA984" />
-        <Limb Name="object_jso_Standardlimb_00A990" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_11" Offset="0xA990" />
-        <Limb Name="object_jso_Standardlimb_00A99C" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_12" Offset="0xA99C" />
-        <Limb Name="object_jso_Standardlimb_00A9A8" Type="Standard" EnumName="OBJECT_JSO_2_LIMB_13" Offset="0xA9A8" />
-        <Skeleton Name="object_jso_Skel_00AA00" Type="Flex" LimbType="Standard" LimbNone="OBJECT_JSO_2_LIMB_NONE" LimbMax="OBJECT_JSO_2_LIMB_MAX" EnumName="ObjectJso2Limb" Offset="0xAA00" />
-        <Animation Name="object_jso_Anim_00AE80" Offset="0xAE80" /> <!-- Original name is "jso_wait" -->
-        <Animation Name="object_jso_Anim_00B1DC" Offset="0xB1DC" /> <!-- Original name is "jso_waitD" -->
-        <Animation Name="object_jso_Anim_00B5F0" Offset="0xB5F0" /> <!-- Original name is "jso_walk" -->
+        <!-- Unused Empty Texture Animations -->
+        <TextureAnimation Name="gGaroEmptyTexAnim1" Offset="0x0" />
+        <TextureAnimation Name="gGaroEmptyTexAnim2" Offset="0x10" />
+
+        <!-- Garo Master Limb DisplayLists -->
+        <DList Name="gGaroMasterLeftThighDL" Offset="0x1210" />
+        <DList Name="gGaroMasterLeftShinDL" Offset="0x1348" />
+        <DList Name="gGaroMasterLeftFootDL" Offset="0x13F8" />
+        <DList Name="gGaroMasterRightThighDL" Offset="0x1508" />
+        <DList Name="gGaroMasterRightShinDL" Offset="0x1640" />
+        <DList Name="gGaroMasterRightFootDL" Offset="0x16F0" />
+        <DList Name="gGaroMasterTorsoDL" Offset="0x1800" />
+        <DList Name="gGaroMasterHeadDL" Offset="0x1908" />
+        <DList Name="gGaroMasterRobeTopDL" Offset="0x1A18" />
+        <DList Name="gGaroMasterRobeFrontDL" Offset="0x1B00" />
+        <DList Name="gGaroMasterRobeRightDL" Offset="0x1C48" />
+        <DList Name="gGaroMasterRobeLeftDL" Offset="0x1D78" />
+        <DList Name="gGaroMasterRobeBackDL" Offset="0x1EA8" />
+        <DList Name="gGaroMasterRightArmDL" Offset="0x1FA8" />
+        <DList Name="gGaroMasterRightSwordDL" Offset="0x1FF8" />
+        <DList Name="gGaroMasterLeftArmDL" Offset="0x20B0" />
+        <DList Name="gGaroMasterLeftSwordDL" Offset="0x2100" />
+
+        <!-- Garo Master Textures -->
+        <Texture Name="gGaroMasterUnusedLegWrappingTex" OutName="garo_master_unused_leg_wrapping" Format="rgba16" Width="8" Height="16" Offset="0x21B8" /> <!-- unused duplicate of gGaroLegWrappingTex -->
+        <Texture Name="gGaroMasterRobeFrontTex" OutName="garo_master_robe_front" Format="rgba16" Width="16" Height="16" Offset="0x22B8" />
+        <Texture Name="gGaroMasterShinTex" OutName="garo_master_shin" Format="rgba16" Width="8" Height="16" Offset="0x24B8" />
+        <Texture Name="gGaroMasterDuplicateEyeTex" OutName="garo_master_duplicate_eye" Format="rgba16" Width="8" Height="8" Offset="0x25B8" /> <!-- unused duplicate of gGaroMasterEyeTex -->
+        <Texture Name="gGaroMasterSwordTex" OutName="garo_master_sword" Format="rgba16" Width="4" Height="4" Offset="0x2638" />
+        <Texture Name="gGaroMasterRobeTex" OutName="garo_master_robe" Format="rgba16" Width="8" Height="32" Offset="0x2658" />
+        <Texture Name="gGaroMasterClothingTLUT" OutName="garo_master_clothing_tlut" Format="rgba16" Width="16" Height="16" Offset="0x2858" />
+        <Texture Name="gGaroMasterMaskTLUT" OutName="garo_master_mask_tlut" Format="rgba16" Width="16" Height="16" Offset="0x2A58" />
+        <Texture Name="gGaroMasterClothingTex" OutName="garo_master_clothing" Format="ci8" Width="16" Height="16" Offset="0x2C58" />
+        <Texture Name="gGaroMasterMaskTex" OutName="garo_master_mask" Format="ci8" Width="16" Height="16" Offset="0x2D58" />
+
+        <!-- Garo Master Eyes Texture and DisplayList -->
+        <DList Name="gGaroMasterEyesDL" Offset="0x2ED8" />
+        <Texture Name="gGaroMasterEyeTex" OutName="garo_master_eye" Format="rgba16" Width="8" Height="8" Offset="0x2FB8" />
+
+        <!-- Garo Master Limbs -->
+        <Limb Name="gGaroMasterRootLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROOT" Offset="0x3038" />
+        <Limb Name="gGaroMasterTorsoLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_TORSO" Offset="0x3044" />
+        <Limb Name="gGaroMasterLeftArmLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LEFT_ARM" Offset="0x3050" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <Limb Name="gGaroMasterLeftSwordLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LEFT_SWORD" Offset="0x305C" />
+        <Limb Name="gGaroMasterRightArmLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_RIGHT_ARM" Offset="0x3068" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <Limb Name="gGaroMasterRightSwordLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_RIGHT_SWORD" Offset="0x3074" />
+        <Limb Name="gGaroMasterRobeTopLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROBE_TOP" Offset="0x3080" />
+        <Limb Name="gGaroMasterRobeBackLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROBE_BACK" Offset="0x308C" />
+        <Limb Name="gGaroMasterRobeLeftLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROBE_LEFT" Offset="0x3098" />
+        <Limb Name="gGaroMasterRobeRightLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROBE_RIGHT" Offset="0x30A4" />
+        <Limb Name="gGaroMasterRobeFrontLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_ROBE_FRONT" Offset="0x30B0" />
+        <Limb Name="gGaroMasterHeadLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_HEAD" Offset="0x30BC" />
+        <Limb Name="gGaroMasterLowerBodyRootLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LOWER_BODY_ROOT" Offset="0x30C8" />
+        <Limb Name="gGaroMasterRightThighLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_RIGHT_THIGH" Offset="0x30D4" />
+        <Limb Name="gGaroMasterRightShinLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_RIGHT_SHIN" Offset="0x30E0" />
+        <Limb Name="gGaroMasterRightFootLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_RIGHT_FOOT" Offset="0x30EC" />
+        <Limb Name="gGaroMasterLeftThighLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LEFT_THIGH" Offset="0x30F8" />
+        <Limb Name="gGaroMasterLeftShinLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LEFT_SHIN" Offset="0x3104" />
+        <Limb Name="gGaroMasterLeftFootLimb" Type="Standard" EnumName="GARO_MASTER_LIMB_LEFT_FOOT" Offset="0x3110" />
+
+        <!-- Garo Master Skeleton -->
+        <Skeleton Name="gGaroMasterSkel" Type="Flex" LimbType="Standard" LimbNone="GARO_MASTER_LIMB_NONE" LimbMax="GARO_MASTER_LIMB_MAX" EnumName="GaroMasterLimb" Offset="0x3168" />
+
+        <!-- Garo and Garo Master Animations -->
+        <Animation Name="gGaroStaticJumpPoseAnim" Offset="0x3238" /> <!-- Unused, one-frame long animation of the Garo jumping or falling. Original name is "jsk_pose" -->
+        <Animation Name="gGaroDashAttackAnim" Offset="0x3530" /> <!-- Original name is "jso_attack1" -->
+        <Animation Name="gGaroSlashStartAnim" Offset="0x378C" /> <!-- Original name is "jso_attack2" -->
+        <Animation Name="gGaroSlashLoopAnim" Offset="0x38AC" /> <!-- Original name is "jso_attack_wait" -->
+        <Animation Name="gGaroJumpBackAnim" Offset="0x3D5C" /> <!-- Original name is "jso_back" -->
+        <Animation Name="gGaroTakeOutBombAnim" Offset="0x4018" /> <!-- Original name is "jso_bomb" -->
+        <Animation Name="gGaroLandAnim" Offset="0x4384" /> <!-- Original name is "jso_chakuchiD" ("chakuchi" = "landing", "D" is probably short for "demo") -->
+        <Animation Name="gGaroDamagedAnim" Offset="0x44F8" /> <!-- Original name is "jso_damage" -->
+        <Animation Name="gGaroGuardAnim" Offset="0x4858" /> <!-- Original name is "jso_defense" -->
+        <Animation Name="gGaroAppearAndDrawSwordsAnim" Offset="0x5778" /> <!-- Original name is "jso_demo_start" -->
+        <Animation Name="gGaroFallDownAnim" Offset="0x5D5C" /> <!-- Original name is "jso_down" -->
+        <Animation Name="gGaroKnockedBackAnim" Offset="0x603C" /> <!-- Original name is "jso_hajiku" ("repelled" or "bounced back") -->
+        <Animation Name="gGaroTrembleAnim" Offset="0x63A4" /> <!-- Original name is "jso_henahena" (onomatopoeic for "weakly; helplessly​") -->
+        <Animation Name="gGaroCollapseAnim" Offset="0x67F0" /> <!-- Original name is "jso_hetari" ("to sink down to the floor") -->
+        <Animation Name="gGaroDrawSwordsAnim" Offset="0x70BC" /> <!-- Original name is "jso_jakin" (possibly onomatopoeic for drawing a sword from a sheath) -->
+        <Animation Name="gGaroJumpDownAnim" Offset="0x71E0" /> <!-- Original name is "jso_jumpD" -->
+        <Animation Name="gGaroSpinAttackAnim" Offset="0x72AC" /> <!-- Original name is "jso_kaiten" ("rotation; turn; spin") -->
+        <Animation Name="gGaroLookAroundAnim" Offset="0x788C" /> <!-- Original name is "jso_kyoro" (onomatopoeic for "looking around restlessly") -->
+        <Animation Name="gGaroCowerAnim" Offset="0x7B04" /> <!-- Original name is "jso_ororo" (possibly onomatopoeic for "in a panic; helplessly" or "sobbing; tearfully") -->
+        <Animation Name="gGaroAppearAnim" Offset="0x81F4" /> <!-- Original name is "jso_start" -->
+
+        <!-- Garo Limb DisplayLists -->
+        <DList Name="gGaroLeftThighDL" Offset="0x8F50" />
+        <DList Name="gGaroLeftShinDL" Offset="0x9008" />
+        <DList Name="gGaroLeftFootDL" Offset="0x90C0" />
+        <DList Name="gGaroRightThighDL" Offset="0x9190" />
+        <DList Name="gGaroRightShinDL" Offset="0x9248" />
+        <DList Name="gGaroRightFootDL" Offset="0x9300" />
+        <DList Name="gGaroTorsoDL" Offset="0x93D0" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <DList Name="gGaroHeadDL" Offset="0x9428" />
+        <DList Name="gGaroRobeTopDL" Offset="0x94E0" />
+        <DList Name="gGaroRobeFrontDL" Offset="0x9758" />
+        <DList Name="gGaroRobeRightDL" Offset="0x98C8" />
+        <DList Name="gGaroRobeLeftDL" Offset="0x99B8" />
+        <DList Name="gGaroRobeBackDL" Offset="0x9AA8" />
+        <DList Name="gGaroRightArmDL" Offset="0x9B80" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <DList Name="gGaroRightSwordDL" Offset="0x9BD8" />
+        <DList Name="gGaroLeftArmDL" Offset="0x9C98" /> <!-- Renders a single triangle instead of a normal-looking limb -->
+        <DList Name="gGaroLeftSwordDL" Offset="0x9CF0" />
+
+        <!-- Garo Textures -->
+        <Texture Name="gGaroLegWrappingTex" OutName="garo_leg_wrapping" Format="rgba16" Width="8" Height="16" Offset="0x9DB0" />
+        <Texture Name="gGaroThighTex" OutName="garo_thigh" Format="rgba16" Width="8" Height="8" Offset="0x9EB0" />
+        <Texture Name="gGaroRobeFrontTex" OutName="garo_robe_front" Format="rgba16" Width="16" Height="32" Offset="0x9F30" />
+        <Texture Name="gGaroRobeTex" OutName="garo_robe" Format="rgba16" Width="16" Height="16" Offset="0xA330" />
+        <Texture Name="gGaroRobeStitchingTex" OutName="garo_robe_stitching" Format="rgba16" Width="16" Height="8" Offset="0xA530" />
+        <Texture Name="gGaroRobeTopTex" OutName="garo_robe_top" Format="rgba16" Width="8" Height="8" Offset="0xA630" />
+        <Texture Name="gGaroEyesTex" OutName="garo_eyes" Format="rgba16" Width="16" Height="16" Offset="0xA6B0" />
+        <Texture Name="gGaroSwordTex" OutName="garo_sword" Format="rgba16" Width="4" Height="4" Offset="0xA8B0" />
+
+        <!-- Garo Limbs -->
+        <Limb Name="gGaroRootLimb" Type="Standard" EnumName="GARO_LIMB_ROOT" Offset="0xA8D0" />
+        <Limb Name="gGaroTorsoLimb" Type="Standard" EnumName="GARO_LIMB_TORSO" Offset="0xA8DC" />
+        <Limb Name="gGaroLeftArmLimb" Type="Standard" EnumName="GARO_LIMB_LEFT_ARM" Offset="0xA8E8" />
+        <Limb Name="gGaroLeftSwordLimb" Type="Standard" EnumName="GARO_LIMB_LEFT_SWORD" Offset="0xA8F4" />
+        <Limb Name="gGaroRightArmLimb" Type="Standard" EnumName="GARO_LIMB_RIGHT_ARM" Offset="0xA900" />
+        <Limb Name="gGaroRightSwordLimb" Type="Standard" EnumName="GARO_LIMB_RIGHT_SWORD" Offset="0xA90C" />
+        <Limb Name="gGaroRobeTopLimb" Type="Standard" EnumName="GARO_LIMB_ROBE_TOP" Offset="0xA918" />
+        <Limb Name="gGaroRobeBackLimb" Type="Standard" EnumName="GARO_LIMB_ROBE_BACK" Offset="0xA924" />
+        <Limb Name="gGaroRobeLeftLimb" Type="Standard" EnumName="GARO_LIMB_ROBE_LEFT" Offset="0xA930" />
+        <Limb Name="gGaroRobeRightLimb" Type="Standard" EnumName="GARO_LIMB_ROBE_RIGHT" Offset="0xA93C" />
+        <Limb Name="gGaroRobeFrontLimb" Type="Standard" EnumName="GARO_LIMB_ROBE_FRONT" Offset="0xA948" />
+        <Limb Name="gGaroHeadLimb" Type="Standard" EnumName="GARO_LIMB_HEAD" Offset="0xA954" />
+        <Limb Name="gGaroLowerBodyRootLimb" Type="Standard" EnumName="GARO_LIMB_LOWER_BODY_ROOT" Offset="0xA960" />
+        <Limb Name="gGaroRightThighLimb" Type="Standard" EnumName="GARO_LIMB_RIGHT_THIGH" Offset="0xA96C" />
+        <Limb Name="gGaroRightShinLimb" Type="Standard" EnumName="GARO_LIMB_RIGHT_SHIN" Offset="0xA978" />
+        <Limb Name="gGaroRightFootLimb" Type="Standard" EnumName="GARO_LIMB_RIGHT_FOOT" Offset="0xA984" />
+        <Limb Name="gGaroLeftThighLimb" Type="Standard" EnumName="GARO_LIMB_LEFT_THIGH" Offset="0xA990" />
+        <Limb Name="gGaroLeftShinLimb" Type="Standard" EnumName="GARO_LIMB_LEFT_SHIN" Offset="0xA99C" />
+        <Limb Name="gGaroLeftFootLimb" Type="Standard" EnumName="GARO_LIMB_LEFT_FOOT" Offset="0xA9A8" />
+
+        <!-- Garo Skeleton -->
+        <Skeleton Name="gGaroSkel" Type="Flex" LimbType="Standard" LimbNone="GARO_LIMB_NONE" LimbMax="GARO_LIMB_MAX" EnumName="GaroLimb" Offset="0xAA00" />
+
+        <!-- Garo and Garo Master Animations -->
+        <Animation Name="gGaroIdleAnim" Offset="0xAE80" /> <!-- Original name is "jso_wait" -->
+        <Animation Name="gGaroLaughAnim" Offset="0xB1DC" /> <!-- Original name is "jso_waitD" -->
+        <Animation Name="gGaroBounceAnim" Offset="0xB5F0" /> <!-- Original name is "jso_walk" -->
     </File>
 </Root>


### PR DESCRIPTION
I had already done this in my branch that matches the `EnJso` actor, but I figured I should PR it separately to slim down the eventual PR for that actor. Most of these names I'm pretty confident in bar this limb:
![image](https://github.com/zeldaret/mm/assets/12245827/205994a7-7a2d-4f08-8faa-7572e10a16ec)

I call it "RobeTop", since it goes above the top of the Garo's head. There are narrow bits that go all the way down the robe, but the more important thing is that this is where the top of the robe comes from. I didn't call it "hood" because Garo Master has this same limb, and it's not really a hood on him. I'm open to suggestions, though.