### PR TITLE
Add original asset names to all `object_n*` and `object_o*` files

### DIFF
--- a/assets/xml/objects/object_nb.xml
+++ b/assets/xml/objects/object_nb.xml
@@ -2,10 +2,10 @@
     <!-- Assets for Anju's Grandma -->
     <File Name="object_nb" Segment="6">
         <!-- Anju's Grandma Animations-->
-        <Animation Name="gNbTalkAnim" Offset="0x290" />
-        <Animation Name="gNbAngryAnim" Offset="0x52C" />
-        <Animation Name="gNbRelievedAnim" Offset="0x6D4" />
-        <Animation Name="gNbIdleAnim" Offset="0x990" />
+        <Animation Name="gNbTalkAnim" Offset="0x290" /> <!-- Original name is "nb_talk01" -->
+        <Animation Name="gNbAngryAnim" Offset="0x52C" /> <!-- Original name is "nb_talk02" -->
+        <Animation Name="gNbRelievedAnim" Offset="0x6D4" /> <!-- Original name is "nb_talk03" -->
+        <Animation Name="gNbIdleAnim" Offset="0x990" /> <!-- Original name is "nb_wait01" -->
 
         <!-- Anju's Grandma DisplayLists -->
         <DList Name="gNbWheelchairDL" Offset="0x4A70" /> <!-- Includes legs -->

--- a/assets/xml/objects/object_niw.xml
+++ b/assets/xml/objects/object_niw.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <!-- Cucco: zelda name for chicken, "Niw" likely short for "Niwatori" -->
     <File Name="object_niw" Segment="6">
-        <Animation Name="gNiwIdleAnim" Offset="0xE8" />
+        <Animation Name="gNiwIdleAnim" Offset="0xE8" /> <!-- Original name is "nw_wait" -->
         <DList Name="gNiwNeckDL" Offset="0x9C0" />
         <DList Name="gNiwHeadDL" Offset="0xA98" />
         <DList Name="gNiwTailDL" Offset="0xDF0" />
@@ -18,7 +18,7 @@
         <Texture Name="gNiwFootTex" OutName="foot" Format="rgba16" Width="8" Height="16" Offset="0x2080" />
         <Texture Name="gNiwFeatherTex" OutName="feather" Format="rgba16" Width="16" Height="16" Offset="0x2180" />
         <DList Name="gNiwFeatherMaterialDL" Offset="0x23B0" />
-        <DList Name="gNiwFeatherDL" Offset="0x2428" />
+        <DList Name="gNiwFeatherDL" Offset="0x2428" /> <!-- Original name is "nw_hane_model" -->
 
         <Limb Name="gNiwRootLimb" LimbType="Standard" EnumName="NIW_LIMB_ROOT" Offset="0x2440"/>
         <Limb Name="gNiwLimb_244C" LimbType="Standard" EnumName="NIW_LIMB_2" Offset="0x244C"/>

--- a/assets/xml/objects/object_nnh.xml
+++ b/assets/xml/objects/object_nnh.xml
@@ -2,7 +2,7 @@
     <!-- Son of the butler cursed into the corpse/body of a dead tree by Skullkid-->
     <!--    the player walks past before meeting the Happy Mask Salesman -->
     <File Name="object_nnh" Segment="6">
-        <DList Name="gButlerSonMainBodyDL" Offset="0x1510" />
+        <DList Name="gButlerSonMainBodyDL" Offset="0x1510" /> <!-- Original name is "nnh_body_model" -->
         <Texture Name="gButlerSonTLUT" OutName="tlut_001AA0" Format="rgba16" Width="16" Height="16" Offset="0x1AA0" />
 
         <!-- Similar to MainBodyTex but with dark green mold under the roots -->

--- a/assets/xml/objects/object_numa_obj.xml
+++ b/assets/xml/objects/object_numa_obj.xml
@@ -1,33 +1,33 @@
 ﻿<Root>
     <!-- Assets for actors in Woodfall Temple (doors, staircases, the wooden flower, poisoned/purified water) -->
     <File Name="object_numa_obj" Segment="6">
-        <DList Name="object_numa_obj_DL_0007A0" Offset="0x7A0" />
-        <DList Name="object_numa_obj_DL_0007A8" Offset="0x7A8" />
-        <DList Name="object_numa_obj_DL_0014C0" Offset="0x14C0" />
-        <DList Name="object_numa_obj_DL_0014C8" Offset="0x14C8" />
+        <DList Name="object_numa_obj_DL_0007A0" Offset="0x7A0" /> <!-- Original name is "m2_NumaRasenSita_modelT" -->
+        <DList Name="object_numa_obj_DL_0007A8" Offset="0x7A8" /> <!-- Original name is "m2_NumaRasenSita_model" -->
+        <DList Name="object_numa_obj_DL_0014C0" Offset="0x14C0" /> <!-- Original name is "m2_NumaRasenSita_PT_modelT" -->
+        <DList Name="object_numa_obj_DL_0014C8" Offset="0x14C8" /> <!-- Original name is "m2_NumaRasenSita_PT_model" -->
         <Texture Name="object_numa_obj_Tex_001D60" OutName="tex_001D60" Format="rgba16" Width="32" Height="64" Offset="0x1D60" />
         <Texture Name="object_numa_obj_Tex_002D60" OutName="tex_002D60" Format="rgba16" Width="32" Height="32" Offset="0x2D60" />
         <Texture Name="object_numa_obj_Tex_003560" OutName="tex_003560" Format="rgba16" Width="32" Height="32" Offset="0x3560" />
-        <DList Name="object_numa_obj_DL_004440" Offset="0x4440" />
-        <DList Name="object_numa_obj_DL_004448" Offset="0x4448" />
-        <DList Name="object_numa_obj_DL_0051B0" Offset="0x51B0" />
-        <DList Name="object_numa_obj_DL_0051B8" Offset="0x51B8" />
+        <DList Name="object_numa_obj_DL_004440" Offset="0x4440" /> <!-- Original name is "m2_NumaRasenUe_modelT" -->
+        <DList Name="object_numa_obj_DL_004448" Offset="0x4448" /> <!-- Original name is "m2_NumaRasenUe_model" -->
+        <DList Name="object_numa_obj_DL_0051B0" Offset="0x51B0" /> <!-- Original name is "m2_NumaRasenUe_PT_modelT" -->
+        <DList Name="object_numa_obj_DL_0051B8" Offset="0x51B8" /> <!-- Original name is "m2_NumaRasenUe_PT_model" -->
         <DList Name="gWoodfallDoorDL" Offset="0x5DF0" />
         <Texture Name="object_numa_obj_Tex_005FC0" OutName="tex_005FC0" Format="rgba16" Width="32" Height="64" Offset="0x5FC0" />
-        <DList Name="object_numa_obj_DL_007150" Offset="0x7150" />
+        <DList Name="object_numa_obj_DL_007150" Offset="0x7150" /> <!-- Original name is "m2_N_shutter1_model" -->
         <Texture Name="object_numa_obj_Tex_0072B0" OutName="tex_0072B0" Format="rgba16" Width="32" Height="64" Offset="0x72B0" />
-        <DList Name="object_numa_obj_DL_008440" Offset="0x8440" />
+        <DList Name="object_numa_obj_DL_008440" Offset="0x8440" /> <!-- Original name is "m2_N_shutter2_model" -->
         <Texture Name="object_numa_obj_Tex_0085A0" OutName="tex_0085A0" Format="rgba16" Width="32" Height="64" Offset="0x85A0" />
 
         <!-- Wooden Flower -->
-        <Collision Name="gWoodenFlowerOpenedFlowerCol" Offset="0x9FE0" />
-        <Collision Name="gWoodenFlowerClosedFlowerCol" Offset="0xA740" />
+        <Collision Name="gWoodenFlowerOpenedFlowerCol" Offset="0x9FE0" /> <!-- Original name is "m2_N_HANAafter_bgdatainfo" -->
+        <Collision Name="gWoodenFlowerClosedFlowerCol" Offset="0xA740" /> <!-- Original name is "m2_N_HANAdefault_bgdatainfo" -->
         <DList Name="gWoodenFlowerEmpty1DL" Offset="0xAB80" /> <!-- Original name might be "m2_N_HANAin_modelT", may have originally been for transparency? -->
-        <DList Name="gWoodenFlowerInnerPetalDL" Offset="0xAB88" />
+        <DList Name="gWoodenFlowerInnerPetalDL" Offset="0xAB88" /> <!-- Original name is "m2_N_HANAin_model" -->
         <DList Name="gWoodenFlowerEmpty2DL" Offset="0xB920" /> <!-- Original name might be "m2_N_HANAkuki_modelT", may have originally been for transparency? -->
-        <DList Name="gWoodenFlowerStalkDL" Offset="0xB928" />
+        <DList Name="gWoodenFlowerStalkDL" Offset="0xB928" /> <!-- Original name is "m2_N_HANAkuki_model" -->
         <DList Name="gWoodenFlowerEmpty3DL" Offset="0xBE50" /> <!-- Original name might be "m2_N_HANAout_modelT", may have originally been for transparency? -->
-        <DList Name="gWoodenFlowerOuterPetalDL" Offset="0xBE58" />
+        <DList Name="gWoodenFlowerOuterPetalDL" Offset="0xBE58" /> <!-- Original name is "m2_N_HANAout_model" -->
         <Texture Name="gWoodenFlowerPetalSidesTex" OutName="wooden_flower_petal_sides" Format="rgba16" Width="32" Height="32" Offset="0xBFD0" />
         <Texture Name="gWoodenFlowerInnerPetalTopTex" OutName="wooden_flower_inner_petal_top" Format="rgba16" Width="32" Height="64" Offset="0xC7D0" />
         <Texture Name="gWoodenFlowerInnerPetalBottomTex" OutName="wooden_flower_inner_petal_bottom" Format="rgba16" Width="32" Height="64" Offset="0xD7D0" />
@@ -36,22 +36,22 @@
         <Texture Name="gWoodenFlowerOuterPetalTopTex" OutName="wooden_flower_outer_petal_top" Format="rgba16" Width="32" Height="64" Offset="0x107D0" />
         <Texture Name="gWoodenFlowerOuterPetalBottomTex" OutName="wooden_flower_outer_petal_bottom" Format="rgba16" Width="32" Height="64" Offset="0x117D0" />
 
-        <Collision Name="object_numa_obj_Colheader_012818" Offset="0x12818" />
-        <DList Name="object_numa_obj_DL_0128E0" Offset="0x128E0" />
+        <Collision Name="object_numa_obj_Colheader_012818" Offset="0x12818" /> <!-- Original name is "m2_N_DOKUcode_bgdatainfo" -->
+        <DList Name="object_numa_obj_DL_0128E0" Offset="0x128E0" /> <!-- Original name is "m2_N_DOKUwater_modelT" -->
         <DList Name="object_numa_obj_DL_0129C0" Offset="0x129C0" />
-        <DList Name="object_numa_obj_DL_012A60" Offset="0x12A60" />
+        <DList Name="object_numa_obj_DL_012A60" Offset="0x12A60" /> <!-- Original name is "m2_N_DOKUwater03_modelT" -->
         <DList Name="object_numa_obj_DL_012B40" Offset="0x12B40" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_012B58" Offset="0x12B58" />
-        <DList Name="object_numa_obj_DL_012BF0" Offset="0x12BF0" />
+        <DList Name="object_numa_obj_DL_012BF0" Offset="0x12BF0" /> <!-- Original name is "m2_N_DOKUwater05_modelT" -->
         <DList Name="object_numa_obj_DL_012CD0" Offset="0x12CD0" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_012CE8" Offset="0x12CE8" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_012CF8" Offset="0x12CF8" />
-        <DList Name="object_numa_obj_DL_012D90" Offset="0x12D90" />
+        <DList Name="object_numa_obj_DL_012D90" Offset="0x12D90" /> <!-- Original name is "m2_N_water_modelT" -->
         <DList Name="object_numa_obj_DL_012E70" Offset="0x12E70" />
-        <DList Name="object_numa_obj_DL_012F10" Offset="0x12F10" />
+        <DList Name="object_numa_obj_DL_012F10" Offset="0x12F10" /> <!-- Original name is "m2_N_water03_modelT" -->
         <DList Name="object_numa_obj_DL_012FF0" Offset="0x12FF0" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_013008" Offset="0x13008" />
-        <DList Name="object_numa_obj_DL_0130A0" Offset="0x130A0" />
+        <DList Name="object_numa_obj_DL_0130A0" Offset="0x130A0" /> <!-- Original name is "m2_N_water05_modelT" -->
         <DList Name="object_numa_obj_DL_013180" Offset="0x13180" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_013198" Offset="0x13198" />
         <TextureAnimation Name="object_numa_obj_Matanimheader_0131A8" Offset="0x131A8" />

--- a/assets/xml/objects/object_ny.xml
+++ b/assets/xml/objects/object_ny.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_ny" Segment="6">
-        <DList Name="object_ny_DL_000030" Offset="0x30" />
+        <DList Name="object_ny_DL_000030" Offset="0x30" /> <!-- Original name is "ksl_kusari_modelT" -->
         <DList Name="object_ny_DL_0000B8" Offset="0xB8" />
         <Texture Name="object_ny_Tex_0000C0" OutName="tex_0000C0" Format="rgba16" Width="8" Height="16" Offset="0xC0" />
         <Texture Name="object_ny_Tex_0001C0" OutName="tex_0001C0" Format="rgba16" Width="16" Height="16" Offset="0x1C0" />

--- a/assets/xml/objects/object_oF1d_map.xml
+++ b/assets/xml/objects/object_oF1d_map.xml
@@ -14,7 +14,7 @@
         <DList Name="gGoronSmallSnowballFragmentMaterialDL" Offset="0xD50" />
         <DList Name="gGoronSmallSnowballFragmentModelDL" Offset="0xDD8" />
 
-        <DList Name="gGoronSnowballDL" Offset="0x1560" />
+        <DList Name="gGoronSnowballDL" Offset="0x1560" /> <!-- Original name is "of1_snowgoroniwa_model" -->
         <Blob Name="object_oF1d_map_Blob_001750" Size="0x20" Offset="0x1750" />
         <Texture Name="gGoronSnowBallTex" OutName="goron_snow" Format="rgba16" Width="32" Height="64" Offset="0x1770" />
         <Blob Name="object_oF1d_map_Blob_002770" Size="0x800" Offset="0x2770" />
@@ -32,9 +32,9 @@
         <DList Name="object_oF1d_map_DL_003340" Offset="0x3340" />
 
         <!-- Animations -->
-        <Animation Name="gGoronCoverEarsAnim" Offset="0x3650" />
-        <Animation Name="gGoronDropKegAnim" Offset="0x39D8" />
-        <Animation Name="gGoronShiverAnim" Offset="0x3E28" />
+        <Animation Name="gGoronCoverEarsAnim" Offset="0x3650" /> <!-- Original name is "goron_urusaina" -->
+        <Animation Name="gGoronDropKegAnim" Offset="0x39D8" /> <!-- Original name is "gr_gift_bom" -->
+        <Animation Name="gGoronShiverAnim" Offset="0x3E28" /> <!-- Original name is "gr_samui" -->
 
         <!-- Don Gero's Mask -->
         <DList Name="gGoronDonGeroMaskDL" Offset="0x4DB0" />
@@ -60,7 +60,7 @@
 
         <!-- Rolled Up -->
         <DList Name="gGoronEmpty2DL" Offset="0x91A0" />
-        <DList Name="gGoronRolledUpDL" Offset="0x91A8" />
+        <DList Name="gGoronRolledUpDL" Offset="0x91A8" /> <!-- Original name is "oF1d_iwa2_model" -->
         <Texture Name="gGoronRolledUpTLUT" OutName="goron_rolled_up_tlut" Format="rgba16" Width="16" Height="16" Offset="0x94E0" />
         <Texture Name="gGoronRolledUpSkinTex" OutName="goron_rolled_up_skin" Format="ci8" Width="16" Height="16" Offset="0x96E0" />
         <Texture Name="gGoronRolledUpBellyButtonTex" OutName="goron_rolled_up_belly_button" Format="ci8" Width="8" Height="8" Offset="0x97E0" />
@@ -68,7 +68,7 @@
         <Texture Name="gGoronRolledUpRocksTex" OutName="goron_rolled_up_rocks" Format="ci8" Width="32" Height="64" Offset="0x98A0" />
 
         <!-- Animation -->
-        <Animation Name="gGoronTPoseAnim" Offset="0xA118" />
+        <Animation Name="gGoronTPoseAnim" Offset="0xA118" /> <!-- Original name is "ng_kihon" -->
 
         <!-- DLists -->
         <DList Name="gGoronBodyDL" Offset="0xCC50" />
@@ -128,15 +128,15 @@
         <Skeleton Name="gGoronSkel" Type="Flex" LimbType="Standard" LimbNone="GORON_LIMB_NONE" LimbMax="GORON_LIMB_MAX" EnumName="GoronLimb" Offset="0x11AC8" />
 
         <!-- Animations -->
-        <Animation Name="gGoronLyingDownIdleAnim" Offset="0x11D98" />
-        <Animation Name="gGoronUnrollAnim" Offset="0x12DE0" />
-        <Animation Name="gGoronShiveringSurprisedAnim" Offset="0x135E8" />
-        <Animation Name="gGoronStandingHandTappingAnim" Offset="0x13DB0" />
-        <Animation Name="gGoronSleepyAnim" Offset="0x143AC" />
-        <Animation Name="gGoronStandingIdleAnim" Offset="0x14CE0" />
+        <Animation Name="gGoronLyingDownIdleAnim" Offset="0x11D98" /> <!-- Original name is "oF1d_chyu_goron" -->
+        <Animation Name="gGoronUnrollAnim" Offset="0x12DE0" /> <!-- Original name is "oF1d_konnnichiwa" -->
+        <Animation Name="gGoronShiveringSurprisedAnim" Offset="0x135E8" /> <!-- Original name is "ofx_odoroku" -->
+        <Animation Name="gGoronStandingHandTappingAnim" Offset="0x13DB0" /> <!-- Original name is "ofx_uri" -->
+        <Animation Name="gGoronSleepyAnim" Offset="0x143AC" /> <!-- Original name is "ofx_wabi" -->
+        <Animation Name="gGoronStandingIdleAnim" Offset="0x14CE0" /> <!-- Original name is "ofx_wait01" -->
 
         <!-- Dust -->
         <DList Name="gGoronDustMaterialDL" Offset="0x14CF0" />
-        <DList Name="gGoronDustModelDL" Offset="0x14D00" />
+        <DList Name="gGoronDustModelDL" Offset="0x14D00" /> <!-- Original name might be "snowgoron_effct_set" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_ob.xml
+++ b/assets/xml/objects/object_ob.xml
@@ -7,8 +7,8 @@
         <DList Name="gMoonChildGyorgsMaskDL" Offset="0x1D80" />
         <DList Name="gMoonChildGohtsMaskDL" Offset="0x3AD0" />
         <DList Name="gMoonChildTwinmoldsMaskDL" Offset="0x5020" />
-        <DList Name="gMoonChildMajorasMaskDL" Offset="0x6380" />
-        <DList Name="gMoonChildMajorasMaskEyesDL" Offset="0x6730" />
+        <DList Name="gMoonChildMajorasMaskDL" Offset="0x6380" /> <!-- Original name is "mjk_evilmask_model" -->
+        <DList Name="gMoonChildMajorasMaskEyesDL" Offset="0x6730" /> <!-- Original name is "mjk_evLIGHTeye_model" -->
 
         <!-- Moonchild Mask Textures -->
         <Texture Name="gMoonChildMajorasMaskTex" OutName="moonchild_majoras_mask" Format="rgba16" Width="32" Height="64" Offset="0x67E0" />
@@ -40,8 +40,8 @@
         <Texture Name="gMoonChildTwinmoldsMaskSnoutTex" OutName="moonchild_twinmolds_mask_snout" Format="ci4" Width="64" Height="64" Offset="0xFB40" />
 
         <!-- Moonchild Moving Animations -->
-        <Animation Name="gMoonChildWalkingAnim" Offset="0x10880" />
-        <Animation Name="gMoonChildRunningAnim" Offset="0x10CD8" />
+        <Animation Name="gMoonChildWalkingAnim" Offset="0x10880" /> <!-- Original name is "mjk_run" -->
+        <Animation Name="gMoonChildRunningAnim" Offset="0x10CD8" /> <!-- Original name is "mjk_run2" -->
 
         <!-- Moonchild DisplayLists -->
         <DList Name="gMoonChildPelvisDL" Offset="0x14190" />
@@ -94,8 +94,8 @@
         <Skeleton Name="gMoonChildSkel" Type="Flex" LimbType="Standard" LimbNone="MOONCHILD_LIMB_NONE" LimbMax="MOONCHILD_LIMB_MAX" EnumName="MoonchildLimb" Offset="0x164B8" />
 
         <!-- Moonchild Mask Still Animations -->
-        <Animation Name="gMoonChildGettingUpAnim" Offset="0x16F58" />
-        <Animation Name="gMoonChildSittingAnim" Offset="0x1764C" />
-        <Animation Name="gMoonChildStandingAnim" Offset="0x17E98" />
+        <Animation Name="gMoonChildGettingUpAnim" Offset="0x16F58" /> <!-- Original name is "mjk_suwari2wait" -->
+        <Animation Name="gMoonChildSittingAnim" Offset="0x1764C" /> <!-- Original name is "mjk_suwariloop" -->
+        <Animation Name="gMoonChildStandingAnim" Offset="0x17E98" /> <!-- Original name is "mjk_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_obj_chan.xml
+++ b/assets/xml/objects/object_obj_chan.xml
@@ -1,14 +1,14 @@
 ﻿<Root>
     <!-- Object for the Goron Shrine Chandelier -->
     <File Name="object_obj_chan" Segment="6">
-        <DList Name="gChandelierPotHolderDL" Offset="0xA10" />
-        <DList Name="gChandelierCenterDL" Offset="0xAF0" />
+        <DList Name="gChandelierPotHolderDL" Offset="0xA10" /> <!-- Original name is "z2_16_tubo01_modelT" -->
+        <DList Name="gChandelierCenterDL" Offset="0xAF0" /> <!-- Original name is "z2_16_tubo01_model" -->
         <Texture Name="gChandelierCenterBottomTex" OutName="chandelier_center_bottom" Format="rgba16" Width="32" Height="32" Offset="0xD80" />
         <Texture Name="gChandelierCenterTopTex" OutName="chandelier_center_top" Format="rgba16" Width="32" Height="32" Offset="0x1580" />
         <Texture Name="gChandelierChainTex" OutName="chandelier_chain" Format="ia4" Width="16" Height="32" Offset="0x1D80" />
         <Texture Name="gChandelierPotHolderTex" OutName="chandelier_pot_holder" Format="i8" Width="32" Height="8" Offset="0x1E80" />
-        <DList Name="gChandelierEmptyDL" Offset="0x2350" />
-        <DList Name="gChandelierPotDL" Offset="0x2358" />
+        <DList Name="gChandelierEmptyDL" Offset="0x2350" /> <!-- Original name is "z2_16_tubo02_modelT" -->
+        <DList Name="gChandelierPotDL" Offset="0x2358" /> <!-- Original name is "z2_16_tubo02_model" -->
         <Texture Name="gChandelierPotTex" OutName="chandelier_pot" Format="rgba16" Width="32" Height="64" Offset="0x24F0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_obj_danpeilift.xml
+++ b/assets/xml/objects/object_obj_danpeilift.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_obj_danpeilift" Segment="6">
-        <DList Name="object_obj_danpeilift_DL_000180" Offset="0x180" />
+        <DList Name="object_obj_danpeilift_DL_000180" Offset="0x180" /> <!-- Original name is "Y2_DANPEI_lift_model2" -->
         <Texture Name="object_obj_danpeilift_Tex_000298" OutName="tex_000298" Format="rgba16" Width="32" Height="32" Offset="0x298" />
-        <Collision Name="object_obj_danpeilift_Colheader_000BA0" Offset="0xBA0" />
+        <Collision Name="object_obj_danpeilift_Colheader_000BA0" Offset="0xBA0" /> <!-- Original name is "Y2_DANPEI_lift_bgdatainfo2" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_obj_dinner.xml
+++ b/assets/xml/objects/object_obj_dinner.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_obj_dinner" Segment="6">
-        <DList Name="object_obj_dinner_DL_0011E0" Offset="0x11E0" />
-        <DList Name="object_obj_dinner_DL_001AA0" Offset="0x1AA0" />
+        <DList Name="object_obj_dinner_DL_0011E0" Offset="0x11E0" /> <!-- Original name is "obj_dinner_model" -->
+        <DList Name="object_obj_dinner_DL_001AA0" Offset="0x1AA0" /> <!-- Original name might be "objT_model" -->
         <Texture Name="object_obj_dinner_Tex_001B38" OutName="tex_001B38" Format="rgba16" Width="4" Height="32" Offset="0x1B38" />
         <Texture Name="object_obj_dinner_Tex_001C38" OutName="tex_001C38" Format="rgba16" Width="16" Height="16" Offset="0x1C38" />
         <Texture Name="object_obj_dinner_Tex_001E38" OutName="tex_001E38" Format="rgba16" Width="16" Height="16" Offset="0x1E38" />

--- a/assets/xml/objects/object_obj_milk_bin.xml
+++ b/assets/xml/objects/object_obj_milk_bin.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_obj_milk_bin" Segment="6">
-        <DList Name="gMilkBinMilkJarDL" Offset="0x4B0" />
+        <DList Name="gMilkBinMilkJarDL" Offset="0x4B0" /> <!-- Original name is "obj_mlk_simplebin_model" -->
         <Texture Name="object_obj_milk_bin_TLUT_0007C0" OutName="tlut_0007C0" Format="rgba16" Width="16" Height="16" Offset="0x7C0" />
         <Texture Name="object_obj_milk_bin_Tex_0009C0" OutName="tex_0009C0" Format="ci8" Width="8" Height="8" Offset="0x9C0" />
         <Texture Name="object_obj_milk_bin_Tex_000A00" OutName="tex_000A00" Format="ci8" Width="32" Height="64" Offset="0xA00" />

--- a/assets/xml/objects/object_obj_tokeidai.xml
+++ b/assets/xml/objects/object_obj_tokeidai.xml
@@ -32,47 +32,39 @@
         <Texture Name="gClockTowerUnusedTowerWallMaskTex" OutName="clock_tower_unused_tower_wall_mask" Format="i4" Width="64" Height="64" Offset="0x86C0" />
         <Texture Name="gClockTowerStaircaseToRooftopMaskTex" OutName="clock_tower_staircase_to_rooftop_mask" Format="i4" Width="64" Height="64" Offset="0x8EC0" />
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Termina Field Walls -->
-        <DList Name="gClockTowerUnusedEmpty1DL" Offset="0x9A00" />
-        <DList Name="gClockTowerTerminaFieldWallsDL" Offset="0x9A08" />
+        <DList Name="gClockTowerUnusedEmpty1DL" Offset="0x9A00" /> <!-- Not present in MM3D, but it was probably named "z2_00_tokeitou_modelT" -->
+        <DList Name="gClockTowerTerminaFieldWallsDL" Offset="0x9A08" /> <!-- Original name is "z2_00_tokeitou_model" ("clock tower") -->
         <Texture Name="gClockTowerTerminaFieldWallsBrickTex" OutName="clock_tower_termina_field_walls_brick" Format="rgba16" Width="32" Height="32" Offset="0x9B48" />
         <Texture Name="gClockTowerTerminaFieldWallsMaskTex" OutName="clock_tower_termina_field_walls_mask" Format="i4" Width="64" Height="64" Offset="0xA348" />
-        <DList Name="gClockTowerSpotlightDL" Offset="0xB0C0" />
-        <DList Name="gClockTowerCounterweightDL" Offset="0xB208" />
+        <DList Name="gClockTowerSpotlightDL" Offset="0xB0C0" /> <!-- Original name is "z2_atama_modelT" -->
+        <DList Name="gClockTowerCounterweightDL" Offset="0xB208" /> <!-- Original name is "z2_atama_model" -->
         <TextureAnimation Name="gClockTowerUnusedTexAnim" Offset="0xB4E4" />
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Exterior Gear -->
-        <DList Name="gClockTowerUnusedEmpty2DL" Offset="0xBA70" />
-        <DList Name="gClockTowerExteriorGearDL" Offset="0xBA78" />
+        <DList Name="gClockTowerUnusedEmpty2DL" Offset="0xBA70" /> <!-- Not present in MM3D, but it was probably named "z2_hagu_modelT" -->
+        <DList Name="gClockTowerExteriorGearDL" Offset="0xBA78" /> <!-- Original name is "z2_hagu_model" ("gear; cogwheel​") -->
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Center and Hand -->
-        <DList Name="gClockTowerUnusedEmpty3DL" Offset="0xBEE0" />
-        <DList Name="gClockTowerClockCenterAndHandDL" Offset="0xBEE8" />
+        <DList Name="gClockTowerUnusedEmpty3DL" Offset="0xBEE0" /> <!-- Not present in MM3D, but it was probably named "z2_hari_modelT" -->
+        <DList Name="gClockTowerClockCenterAndHandDL" Offset="0xBEE8" /> <!-- Original name is "z2_hari_model" ("hand (e.g. clock, etc.); pointer​") -->
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Sun and Moon Panel -->
-        <DList Name="gClockTowerUnusedEmpty4DL" Offset="0xC360" />
-        <DList Name="gClockTowerSunAndMoonPanelDL" Offset="0xC368" />
+        <DList Name="gClockTowerUnusedEmpty4DL" Offset="0xC360" /> <!-- Not present in MM3D, but it was probably named "z2_paneru_modelT" -->
+        <DList Name="gClockTowerSunAndMoonPanelDL" Offset="0xC368" /> <!-- Original name is "z2_paneru_model" (probably just literally "panel") -->
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Minute Ring -->
-        <DList Name="gClockTowerUnusedEmpty5DL" Offset="0xCF20" />
-        <DList Name="gClockTowerMinuteRingDL" Offset="0xCF28" />
+        <DList Name="gClockTowerUnusedEmpty5DL" Offset="0xCF20" /> <!-- Not present in MM3D, but it was probably named "z2_tannsin_modelT" -->
+        <DList Name="gClockTowerMinuteRingDL" Offset="0xCF28" /> <!-- Original name is "z2_tannsin_model" ("short hand; hour hand") -->
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Unused Tower Wall -->
-        <DList Name="gClockTowerUnusedEmpty6DL" Offset="0xD380" />
-        <DList Name="gClockTowerUnusedTowerWallDL" Offset="0xD388" />
+        <DList Name="gClockTowerUnusedEmpty6DL" Offset="0xD380" /> <!-- Not present in MM3D, but it was probably named "z2_tou_modelT" -->
+        <DList Name="gClockTowerUnusedTowerWallDL" Offset="0xD388" /> <!-- Original name might be "z2_tou_model" ("tower; steeple; spire​") -->
 
         <!-- Used as the xluDList for Staircase to Rooftop -->
-        <DList Name="gClockTowerEmptyDL" Offset="0xD8E0" />
-        <DList Name="gClockTowerStaircaseToRooftopDL" Offset="0xD8E8" />
+        <DList Name="gClockTowerEmptyDL" Offset="0xD8E0" /> <!-- Not present in MM3D, but it was probably named "z2_towerkaidan_modelT" -->
+        <DList Name="gClockTowerStaircaseToRooftopDL" Offset="0xD8E8" /> <!-- Original name is "z2_towerkaidan_model" ("kaiden" = "stairs; stairway; staircase​") -->
         <Texture Name="gClockTowerClockFaceBackTex" OutName="clock_tower_clock_face_back" Format="rgba16" Width="16" Height="32" Offset="0xDAC0" />
 
-        <!-- Probably intended to be used as the xluDList for Clock Tower Clock Face -->
-        <DList Name="gClockTowerUnusedEmpty7DL" Offset="0xE810" />
-        <DList Name="gClockTowerClockFaceDL" Offset="0xE818" />
+        <DList Name="gClockTowerUnusedEmpty7DL" Offset="0xE810" /> <!-- Not present in MM3D, but it was probably named "z2_tyousin_modelT" -->
+        <DList Name="gClockTowerClockFaceDL" Offset="0xE818" /> <!-- Original name is "z2_tyousin_model" ("long hand; minute hand​") -->
 
-        <!-- Probably intended to be used as the xluDList for Wall Clock Clock Face -->
-        <DList Name="gClockTowerUnusedEmpty8DL" Offset="0xF510" />
-        <DList Name="gWallClockClockFaceDL" Offset="0xF518" />
+        <DList Name="gClockTowerUnusedEmpty8DL" Offset="0xF510" /> <!-- Not present in MM3D, but it was probably named "z2_tyousin_room_modelT" -->
+        <DList Name="gWallClockClockFaceDL" Offset="0xF518" /> <!-- Original name is "z2_tyousin_room_model" -->
         <Texture Name="gWallClockClockFaceBackTex" OutName="wall_clock_clock_face_back" Format="rgba16" Width="16" Height="32" Offset="0xF7F8" />
         <Texture Name="gWallClockClockFaceBottomTex" OutName="wall_clock_clock_face_bottom" Format="rgba16" Width="64" Height="32" Offset="0xFBF8" />
         <Texture Name="gWallClockClockFaceTopTex" OutName="wall_clock_clock_face_top" Format="rgba16" Width="64" Height="32" Offset="0x10BF8" />

--- a/assets/xml/objects/object_obj_usiyane.xml
+++ b/assets/xml/objects/object_obj_usiyane.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_obj_usiyane" Segment="6">
-        <DList Name="object_obj_usiyane_DL_000090" Offset="0x90" />
-        <DList Name="object_obj_usiyane_DL_000098" Offset="0x98" />
+        <DList Name="object_obj_usiyane_DL_000090" Offset="0x90" /> <!-- Original name is "z2_usiwara_modelT" -->
+        <DList Name="object_obj_usiyane_DL_000098" Offset="0x98" /> <!-- Original name is "z2_usiwara_model" -->
         <Texture Name="object_obj_usiyane_Tex_000130" OutName="tex_000130" Format="rgba16" Width="32" Height="16" Offset="0x130" />
-        <DList Name="object_obj_usiyane_DL_000830" Offset="0x830" />
-        <DList Name="object_obj_usiyane_DL_000838" Offset="0x838" />
+        <DList Name="object_obj_usiyane_DL_000830" Offset="0x830" /> <!-- Original name is "z2_usiyane_modelT" -->
+        <DList Name="object_obj_usiyane_DL_000838" Offset="0x838" /> <!-- Original name is "z2_usiyane_model" -->
         <Texture Name="object_obj_usiyane_TLUT_0009C8" OutName="tlut_0009C8" Format="rgba16" Width="4" Height="4" Offset="0x9C8" />
         <Texture Name="object_obj_usiyane_Tex_0009E8" OutName="tex_0009E8" Format="ci4" Width="64" Height="64" Offset="0x9E8" />
         <Texture Name="object_obj_usiyane_Tex_0011E8" OutName="tex_0011E8" Format="rgba16" Width="64" Height="32" Offset="0x11E8" />
-        <Collision Name="object_obj_usiyane_Colheader_0022AC" Offset="0x22AC" />
+        <Collision Name="object_obj_usiyane_Colheader_0022AC" Offset="0x22AC" /> <!-- Original name is "z2_usiyane_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_obj_yasi.xml
+++ b/assets/xml/objects/object_obj_yasi.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <!-- Object for the Palm Tree(s) found at the Great Bay Coast -->
     <File Name="object_obj_yasi" Segment="6">
-        <DList Name="gPalmTreeDL" Offset="0x360" />
+        <DList Name="gPalmTreeDL" Offset="0x360" /> <!-- Original name is "z2_yasi_model" -->
         <Texture Name="gPalmTreeTLUT" OutName="palm_tree_tlut" Format="rgba16" Width="4" Height="4" Offset="0x630" />
         <Texture Name="gPalmTreeFrondTex" OutName="palm_tree_frond" Format="ci4" Width="32" Height="128" Offset="0x650" />
         <Texture Name="gPalmTreeDekuNutTex" OutName="palm_tree_deku_nut" Format="rgba16" Width="16" Height="16" Offset="0xE50" />
         <Texture Name="gPalmTreeScarredWoodTex" OutName="palm_tree_scarred_wood" Format="rgba16" Width="16" Height="16" Offset="0x1050" />
         <Texture Name="gPalmTreeWoodTex" OutName="palm_tree_wood" Format="rgba16" Width="8" Height="8" Offset="0x1250" />
-        <Collision Name="gPalmTreeCol" Offset="0x1428" />
+        <Collision Name="gPalmTreeCol" Offset="0x1428" /> <!-- Original name is "z2_yasi_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_omoya_obj.xml
+++ b/assets/xml/objects/object_omoya_obj.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_omoya_obj" Segment="6">
-        <DList Name="object_omoya_obj_DL_0001A0" Offset="0x1A0" />
+        <DList Name="object_omoya_obj_DL_0001A0" Offset="0x1A0" /> <!-- Original name is "yane_model" -->
         <Texture Name="object_omoya_obj_TLUT_0002D8" OutName="tlut_0002D8" Format="rgba16" Width="4" Height="4" Offset="0x2D8" />
         <Texture Name="object_omoya_obj_Tex_0002F8" OutName="tex_0002F8" Format="rgba16" Width="64" Height="32" Offset="0x2F8" />
         <Texture Name="object_omoya_obj_Tex_0012F8" OutName="tex_0012F8" Format="ci4" Width="64" Height="64" Offset="0x12F8" />

--- a/assets/xml/objects/object_open_obj.xml
+++ b/assets/xml/objects/object_open_obj.xml
@@ -1,15 +1,15 @@
 ﻿<Root>
     <File Name="object_open_obj" Segment="6">
-        <DList Name="object_open_obj_DL_0003E0" Offset="0x3E0" />
-        <DList Name="object_open_obj_DL_0003E8" Offset="0x3E8" />
+        <DList Name="object_open_obj_DL_0003E0" Offset="0x3E0" /> <!-- Original name is "m2_OPNshutter_modelT" -->
+        <DList Name="object_open_obj_DL_0003E8" Offset="0x3E8" /> <!-- Original name is "m2_OPNshutter_model" -->
         <Texture Name="object_open_obj_Tex_000558" OutName="tex_000558" Format="rgba16" Width="32" Height="64" Offset="0x558" />
-        <Collision Name="object_open_obj_Colheader_001640" Offset="0x1640" />
-        <DList Name="gSpotlightLeftDL" Offset="0x1A60" />
-        <DList Name="gSpotlightRightDL" Offset="0x1B40" />
+        <Collision Name="object_open_obj_Colheader_001640" Offset="0x1640" /> <!-- Original name is "m2_OPNshutter_bgdatainfo" -->
+        <DList Name="gSpotlightLeftDL" Offset="0x1A60" /> <!-- Original name is "m2_SPOT_modelT" -->
+        <DList Name="gSpotlightRightDL" Offset="0x1B40" /> <!-- Original name is "m2_SPOT_model" -->
         <Texture Name="gSpotlightShapesTex" OutName="spotlight_shapes" Format="rgba16" Width="32" Height="32" Offset="0x1CD0" />
         <Texture Name="gSpotlightFloorTex" OutName="spotlight_floor" Format="ia8" Width="32" Height="64" Offset="0x24D0" />
         <TextureAnimation Name="gSpotlightTexAnim" Offset="0x2CE0" />
-        <DList Name="object_open_obj_DL_002D30" Offset="0x2D30" />
+        <DList Name="object_open_obj_DL_002D30" Offset="0x2D30" /> <!-- Original name is "rakugaki_modelT" -->
         <DList Name="object_open_obj_DL_002DC0" Offset="0x2DC0" />
         <!-- <Blob Name="object_open_obj_Blob_002DC8" Size="0xE608" Offset="0x2DC8" /> -->
         <Texture Name="object_open_obj_Tex_00DDC8" OutName="tex_00DDC8" Format="i4" Width="32" Height="32" Offset="0xDDC8" />

--- a/assets/xml/objects/object_ot.xml
+++ b/assets/xml/objects/object_ot.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_ot" Segment="6">
         <DList Name="object_ot_DL_000040" Offset="0x40" />
-        <DList Name="object_ot_DL_000078" Offset="0x78" />
-        <Animation Name="object_ot_Anim_000420" Offset="0x420" />
-        <DList Name="object_ot_DL_0004A0" Offset="0x4A0" />
+        <DList Name="object_ot_DL_000078" Offset="0x78" /> <!-- Original name is "ot_item_model" -->
+        <Animation Name="object_ot_Anim_000420" Offset="0x420" /> <!-- Original name is "ot_kissing" -->
+        <DList Name="object_ot_DL_0004A0" Offset="0x4A0" /> <!-- Original name is "ot_light_model" -->
         <Texture Name="object_ot_Tex_000550" OutName="tex_000550" Format="ia16" Width="8" Height="8" Offset="0x550" />
         <TextureAnimation Name="object_ot_Matanimheader_0005F8" Offset="0x5F8" />
-        <Animation Name="object_ot_Anim_0008D8" Offset="0x8D8" />
+        <Animation Name="object_ot_Anim_0008D8" Offset="0x8D8" /> <!-- Original name is "ot_swim" -->
         <DList Name="object_ot_DL_001800" Offset="0x1800" />
         <DList Name="object_ot_DL_0018D0" Offset="0x18D0" />
         <DList Name="object_ot_DL_001988" Offset="0x1988" />
@@ -49,6 +49,6 @@
         <Limb Name="object_ot_Standardlimb_0047A0" Type="Standard" EnumName="OBJECT_OT_LIMB_11" Offset="0x47A0" />
         <Limb Name="object_ot_Standardlimb_0047AC" Type="Standard" EnumName="OBJECT_OT_LIMB_12" Offset="0x47AC" />
         <Skeleton Name="object_ot_Skel_004800" Type="Flex" LimbType="Standard" LimbNone="OBJECT_OT_LIMB_NONE" LimbMax="OBJECT_OT_LIMB_MAX" EnumName="ObjectOtLimb" Offset="0x4800" />
-        <Animation Name="object_ot_Anim_004B30" Offset="0x4B30" />
+        <Animation Name="object_ot_Anim_004B30" Offset="0x4B30" /> <!-- Original name is "ot_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_owl.xml
+++ b/assets/xml/objects/object_owl.xml
@@ -2,14 +2,14 @@
     <!-- Object for Kaepora Gaebora (Owl) -->
     <File Name="object_owl" Segment="6">
         <!-- Animation -->
-        <Animation Name="gOwlTakeoffAnim" Offset="0x1168" />
+        <Animation Name="gOwlTakeoffAnim" Offset="0x1168" /> <!-- Original name is "hovering" -->
         
         <!-- Single feather -->
-        <DList Name="gOwlFeatherDL" Offset="0x1200" />
+        <DList Name="gOwlFeatherDL" Offset="0x1200" /> <!-- Original name is "owl_feather_model" -->
         <Texture Name="gOwlFeatherTex" OutName="owl_feather" Format="rgba16" Width="16" Height="32" Offset="0x1290" />
         
         <!-- Animation -->
-        <Animation Name="gOwlFlyAnim" Offset="0x1ADC" />
+        <Animation Name="gOwlFlyAnim" Offset="0x1ADC" /> <!-- Original name is "owl_fly" -->
         
         <!-- Owl Flying DList -->
         <DList Name="gOwlFlyingLowerBodyDL" Offset="0x5050" />
@@ -78,9 +78,9 @@
         <Skeleton Name="gOwlFlyingSkel" Type="Flex" LimbType="Standard" LimbNone="OWL_FLYING_LIMB_NONE" LimbMax="OWL_FLYING_LIMB_MAX" EnumName="OwlFlyingLimb" Offset="0xC5F8" />
         
         <!-- Animations -->
-        <Animation Name="gOwlGlideAnim" Offset="0xC6D4" />
-        <Animation Name="gOwlUnfoldWingsAnim" Offset="0xCB94" />
-        <Animation Name="gOwlPerchAnim" Offset="0xCDB0" />
+        <Animation Name="gOwlGlideAnim" Offset="0xC6D4" /> <!-- Original name is "owl_kakku" -->
+        <Animation Name="gOwlUnfoldWingsAnim" Offset="0xCB94" /> <!-- Original name is "owl_openwing" -->
+        <Animation Name="gOwlPerchAnim" Offset="0xCDB0" /> <!-- Original name is "owl_wait" -->
         
         <!-- Owl Perching DList -->
         <DList Name="gOwlPerchingLeftWingDL" Offset="0xF220" />

--- a/assets/xml/objects/object_oyu.xml
+++ b/assets/xml/objects/object_oyu.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <!-- Hot Spring Water found in the Goron Graveyard -->
     <File Name="object_oyu" Segment="6">
-        <DList Name="gGoronGraveyardHotSpringWaterDL" Offset="0x80" />
+        <DList Name="gGoronGraveyardHotSpringWaterDL" Offset="0x80" /> <!-- Original name is "z2_goron_haka_oyu_modelT" -->
         <DList Name="gGoronGraveyardHotSpringWaterEmptyDL" Offset="0x158" />
         <Texture Name="gGoronGraveyardHotSpringWaterTex" OutName="hot_spring_water" Format="rgba16" Width="32" Height="32" Offset="0x160" />
         <TextureAnimation Name="gGoronGraveyardHotSpringWaterTexAnim" Offset="0x968" />
-        <Collision Name="gGoronGraveyardHotSpringWaterCol" Offset="0x988" />
+        <Collision Name="gGoronGraveyardHotSpringWaterCol" Offset="0x988" /> <!-- Original name is "z2_goron_haka_oyu_bgdatainfo" -->
     </File>
 </Root>


### PR DESCRIPTION
I should note that I skipped `object_os_anime` in this one. This is because this object isn't in the 3DS games; the animations were moved to the constituent objects. This is why `object_os_anime` has some `Cne_*` animations labelled right now; because I could get them from `zelda_cne`. However, I didn't want to bother with trying to chase down where any other animations came from until OoT's EnHy was documented.