### PR TITLE
add D_801D7E04 and D_801D7EA4 as labels to fix 2 missed pointers

### DIFF
--- a/tools/disasm/variables.txt
+++ b/tools/disasm/variables.txt
@@ -2269,6 +2269,8 @@
     0x801D703C:("sOcarinaMemoryGameEndPos","UNK_TYPE1","",0x1),
     0x801D7040:("sOcarinaMemoryGameNumNotes","UNK_TYPE1","",0x1),
     0x801D7044:("sOcarinaSongNotes","OcarinaNote","[24][20]",0xF00),
+    0x801D7E04:("D_801D7E04","UNK_TYPE1","",0x1),
+    0x801D7EA4:("D_801D7EA4","UNK_TYPE1","",0x1),
     0x801D7F44:("sOoTOcarinaSongNotes","OcarinaNote","[9][20]",0x5A0),
     0x801D84E4:("sOoTOcarinaSongsNumNotes","UNK_TYPE1","",0x1),
     0x801D84F0:("sPlaybackSong","UNK_PTR","",0x4),


### PR DESCRIPTION
Added these 2 variable definitions so it will catch their missing pointers in code_8019AF00.data.s.