### PR TITLE
Fix most hardcoded pointers in extracted assets

### DIFF
--- a/assets/xml/objects/gameplay_field_keep.xml
+++ b/assets/xml/objects/gameplay_field_keep.xml
@@ -40,13 +40,18 @@
         <DList Name="gameplay_field_keep_DL_006760" Offset="0x6760" />
         <Texture Name="gameplay_field_keep_Tex_006810" OutName="tex_006810" Format="rgba16" Width="32" Height="32" Offset="0x6810" />
         <Texture Name="gameplay_field_keep_Tex_007010" OutName="tex_007010" Format="rgba16" Width="32" Height="32" Offset="0x7010" />
+
+        <Array Name="gameplay_field_keepVtx_007810" Count="9" Offset="0x7810">
+            <Vtx/>
+        </Array>
+
         <DList Name="gKusaBushType1DL" Offset="0x78A0" />
         <DList Name="gKusaBushType2DL" Offset="0x7938" />
 
         <Texture Name="gFieldSandstorm1Tex" OutName="sandstorm_1" Format="i8" Width="64" Height="32" Offset="0x79D0" />
         <Texture Name="gFieldSandstorm2Tex" OutName="sandstorm_2" Format="ia8" Width="64" Height="32" Offset="0x81D0" />
         <DList Name="gFieldSandstormDL" Offset="0x89D0" />
-    
+
         <Texture Name="gameplay_field_keep_Tex_008A90" OutName="tex_008A90" Format="rgba16" Width="32" Height="32" Offset="0x8A90" />
     </File>
 </Root>

--- a/assets/xml/objects/gameplay_keep.xml
+++ b/assets/xml/objects/gameplay_keep.xml
@@ -971,7 +971,8 @@
         <DList Name="gSwordBeamDL" Offset="0x27CA0" />
 
         <Blob Name="gameplay_keep_Blob_027DD0" Size="0x32C" Offset="0x27DD0" />
-        <Blob Name="gameplay_keep_Blob_0281DC" Size="0xF4" Offset="0x281DC" />
+        <Blob Name="gameplay_keep_Blob_0281DC" Size="0x14" Offset="0x281DC" />
+
         <DList Name="gameplay_keep_DL_0282D0" Offset="0x282D0" />
         <Texture Name="gameplay_keep_Tex_0283B8" OutName="tex_0283B8" Format="i4" Width="64" Height="64" Offset="0x283B8" />
         <Texture Name="gameplay_keep_Tex_028BB8" OutName="tex_028BB8" Format="i8" Width="32" Height="32" Offset="0x28BB8" />
@@ -1029,7 +1030,7 @@
         <Limb Name="gStrayFairyLeftFacingHeadLimb" Type="Standard" EnumName="STRAY_FAIRY_LIMB_LEFT_FACING_HEAD" Offset="0x2CA68" />
         <Skeleton Name="gStrayFairySkel" Type="Flex" LimbType="Standard" LimbNone="STRAY_FAIRY_LIMB_NONE" LimbMax="STRAY_FAIRY_LIMB_MAX" EnumName="StrayFairyLimb" Offset="0x2CA98" />
 
-        <Texture Name="gameplay_keep_Tex_02CAA8" OutName="tex_02CAA8" Format="i4" Width="16" Height="16" Offset="0x2CAA8" />
+        <Texture Name="gameplay_keep_Tex_02CAB0" OutName="tex_02CAB0" Format="i4" Width="16" Height="16" Offset="0x2CAB0" />
         <Texture Name="gameplay_keep_Tex_02CB30" OutName="tex_02CB30" Format="i8" Width="16" Height="16" Offset="0x2CB30" />
         <Texture Name="gameplay_keep_Tex_02CC30" OutName="tex_02CC30" Format="rgba16" Width="32" Height="32" Offset="0x2CC30" />
         <Texture Name="gameplay_keep_Tex_02D430" OutName="tex_02D430" Format="i8" Width="32" Height="64" Offset="0x2D430" />
@@ -1050,8 +1051,13 @@
         <Skeleton Name="gameplay_keep_Skel_02F028" Type="Flex" LimbType="Standard" LimbNone="FISH_LIMB_NONE" LimbMax="FISH_LIMB_MAX" EnumName="FishLimb" Offset="0x2F028" />
         <Animation Name="gameplay_keep_Anim_02F0EC" Offset="0x2F0EC" />
         <Texture Name="gEffShockwaveTex" OutName="eff_shockwave" Format="i8" Width="64" Height="64" Offset="0x2F100" />
+
         <DList Name="gEffShockwaveDL" Offset="0x30100" />
+        <Array Name="gEffShockwaveVtx" Count="4" Offset="0x30170">
+            <Vtx/>
+        </Array>
         <DList Name="gEffBubbleDL" Offset="0x301B0" />
+
         <Texture Name="gEffFireFootprint1Tex" OutName="eff_fire_footprint_1" Format="ia8" Width="32" Height="32" Offset="0x30270" />
         <Texture Name="gEffFireFootprint2Tex" OutName="eff_fire_footprint_2" Format="ia8" Width="32" Height="32" Offset="0x30670" />
         <Texture Name="gEffFireFootprint3Tex" OutName="eff_fire_footprint_3" Format="ia8" Width="32" Height="32" Offset="0x30A70" />
@@ -1315,20 +1321,22 @@
         <Texture Name="gameplay_keep_Tex_066BD0" OutName="tex_066BD0" Format="rgba16" Width="64" Height="32" Offset="0x66BD0" />
         <Texture Name="gameplay_keep_Tex_067BD0" OutName="tex_067BD0" Format="rgba16" Width="32" Height="32" Offset="0x67BD0" />
         <Texture Name="gameplay_keep_Tex_0683D0" OutName="tex_0683D0" Format="rgba16" Width="32" Height="32" Offset="0x683D0" />
-        
+
         <Texture Name="gSignRectangularSideTex" OutName="sign_rectangular_side" Format="rgba16" Width="32" Height="16" Offset="0x68BD0" />
         <Texture Name="gSignRectangularFrontTex" OutName="sign_rectangular_front" Format="rgba16" Width="32" Height="16" Offset="0x68FD0" />
         <Texture Name="gSignPostWoodTex" OutName="sign_post_wood" Format="rgba16" Width="64" Height="8" Offset="0x693D0" />
         <Texture Name="gSignLetteringTex" OutName="sign_lettering" Format="rgba16" Width="64" Height="32" Offset="0x697D0" />
-        
+
         <DList Name="gameplay_keep_DL_06A800" Offset="0x6A800" />
         <Texture Name="gameplay_keep_Tex_06A880" OutName="tex_06A880" Format="i8" Width="16" Height="16" Offset="0x6A880" />
         <DList Name="gameplay_keep_DL_06AB30" Offset="0x6AB30" />
         <Texture Name="gameplay_keep_Tex_06ABF8" OutName="tex_06ABF8" Format="rgba16" Width="36" Height="36" Offset="0x6ABF8" />
         <TextureAnimation Name="gameplay_keep_Matanimheader_06B6A0" Offset="0x6B6A0" />
         <TextureAnimation Name="gameplay_keep_Matanimheader_06B730" Offset="0x6B730" />
+
         <Blob Name="gameplay_keep_Blob_06B750" Size="0x3BC" Offset="0x6B750" />
-        <Blob Name="gameplay_keep_Blob_06BB0C" Size="0x4D4" Offset="0x6BB0C" />
+        <Blob Name="gameplay_keep_Blob_06BB0C" Size="0x14" Offset="0x6BB0C" />
+
         <DList Name="gameplay_keep_DL_06BFE0" Offset="0x6BFE0" />
         <DList Name="gameplay_keep_DL_06C098" Offset="0x6C098" />
         <DList Name="gameplay_keep_DL_06C1E8" Offset="0x6C1E8" />
@@ -1403,7 +1411,7 @@
         <Texture Name="gSunEvening1Tex" OutName="sun_evening_1" Format="i4" Width="64" Height="31" Offset="0x7A310" />
         <Texture Name="gSunEvening2Tex" OutName="sun_evening_2" Format="i4" Width="64" Height="16" Offset="0x7A6F0" />
         <Texture Name="gSunEvening3Tex" OutName="sun_evening_3" Format="i4" Width="64" Height="17" Offset="0x7A8F0" />
-        
+
         <DList Name="gSunSparkleMaterialDL" Offset="0x7AB10" /> <!-- sun (sparkles when small) displaylist -->
         <DList Name="gSunSparkleModelDL" Offset="0x7AB58" />
         <DList Name="gSunDL" Offset="0x7AB70" />
@@ -1418,6 +1426,11 @@
         <DList Name="gameplay_keep_DL_07D260" Offset="0x7D260" />
         <DList Name="gameplay_keep_DL_07D348" Offset="0x7D348" />
         <Texture Name="gameplay_keep_Tex_07D350" OutName="tex_07D350" Format="i8" Width="16" Height="32" Offset="0x7D350" />
+
+        <Array Name="gameplay_keepVtx_07D550" Count="4" Offset="0x7D550">
+            <Vtx/>
+        </Array>
+
         <DList Name="gEffFire1DL" Offset="0x7D590" />
         <DList Name="gEffFire2DL" Offset="0x7D650" />
         <Texture Name="gEffFireMask1Tex" OutName="eff_fire_mask_1" Format="i4" Width="32" Height="64" Offset="0x7D710" />
@@ -1435,8 +1448,10 @@
         <DList Name="gameplay_keep_DL_081620" Offset="0x81620" />
         <DList Name="gameplay_keep_DL_081628" Offset="0x81628" />
         <Texture Name="gameplay_keep_Tex_0816C0" OutName="tex_0816C0" Format="rgba16" Width="16" Height="32" Offset="0x816C0" />
+
         <Blob Name="gameplay_keep_Blob_081AC0" Size="0x1A74" Offset="0x81AC0" />
-        <Blob Name="gameplay_keep_Blob_083534" Size="0x125C" Offset="0x83534" />
+        <Blob Name="gameplay_keep_Blob_083534" Size="0x1C" Offset="0x83534" />
+
         <DList Name="gameplay_keep_DL_084790" Offset="0x84790" />
         <DList Name="gameplay_keep_DL_0847E0" Offset="0x847E0" />
         <DList Name="gameplay_keep_DL_084850" Offset="0x84850" />
@@ -1468,7 +1483,7 @@
         <DList Name="gameplay_keep_DL_085418" Offset="0x85418" />
         <DList Name="gameplay_keep_DL_085490" Offset="0x85490" />
         <Blob Name="gameplay_keep_Blob_085510" Size="0x130" Offset="0x85510" />
-        <Blob Name="gameplay_keep_Blob_085640" Size="0x3A30" Offset="0x85640" />
+        <Blob Name="gameplay_keep_Blob_085640" Size="0x10" Offset="0x85640" />
 
         <!-- Zora Elegy of Emptiness Shell -->
         <DList Name="gElegyShellZoraDL" Offset="0x89070" /> <!-- Original name is "pzs_zo_model" -->

--- a/assets/xml/objects/object_hana.xml
+++ b/assets/xml/objects/object_hana.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <ExternalFile XmlPath="objects/gameplay_field_keep.xml" OutPath="assets/objects/gameplay_field_keep/"/>
     <!-- Assets for the orange graveyard flowers -->
     <File Name="object_hana" Segment="6">
         <!-- Each of these is a single flower out of the 3 -->

--- a/assets/xml/objects/object_moonend.xml
+++ b/assets/xml/objects/object_moonend.xml
@@ -1,7 +1,8 @@
 ﻿<Root>
     <File Name="object_moonend" Segment="6">
-        <!-- <Blob Name="object_moonend_Blob_000000" Size="0x1214" Offset="0x0" /> -->
-        <Blob Name="object_moonend_Blob_001214" Size="0x43DC" Offset="0x1214" />
+        <Blob Name="object_moonend_Blob_000000" Size="0x1214" Offset="0x0" />
+        <Blob Name="object_moonend_Blob_001214" Size="0x1C" Offset="0x1214" />
+
         <DList Name="object_moonend_DL_0055F0" Offset="0x55F0" />
         <DList Name="object_moonend_DL_0061F8" Offset="0x61F8" />
         <DList Name="object_moonend_DL_006460" Offset="0x6460" />
@@ -20,8 +21,10 @@
         <Texture Name="object_moonend_Tex_009530" OutName="tex_009530" Format="i8" Width="64" Height="64" Offset="0x9530" />
         <Texture Name="object_moonend_Tex_00A530" OutName="tex_00A530" Format="i8" Width="64" Height="64" Offset="0xA530" />
         <TextureAnimation Name="object_moonend_Matanimheader_00B540" Offset="0xB540" />
-        <!-- <Blob Name="object_moonend_Blob_00B550" Size="0x50" Offset="0xB550" /> -->
-        <Blob Name="object_moonend_Blob_00B5A0" Size="0x1750" Offset="0xB5A0" />
+
+        <Blob Name="object_moonend_Blob_00B550" Size="0x50" Offset="0xB550" />
+        <Blob Name="object_moonend_Blob_00B5A0" Size="0x170" Offset="0xB5A0" />
+
         <DList Name="object_moonend_DL_00CCF0" Offset="0xCCF0" />
         <DList Name="object_moonend_DL_00CF58" Offset="0xCF58" />
         <DList Name="object_moonend_DL_00D080" Offset="0xD080" />

--- a/assets/xml/objects/object_ssh.xml
+++ b/assets/xml/objects/object_ssh.xml
@@ -15,7 +15,6 @@
         <Texture Name="object_ssh_Tex_001D70" OutName="tex_001D70" Format="ci8" Width="8" Height="16" Offset="0x1D70" />
         <Texture Name="object_ssh_Tex_001DF0" OutName="tex_001DF0" Format="ci8" Width="32" Height="32" Offset="0x1DF0" />
         <Texture Name="object_ssh_Tex_0021F0" OutName="tex_0021F0" Format="ci8" Width="32" Height="32" Offset="0x21F0" />
-        <Blob Name="object_ssh_Blob_0025F0" Size="0x2870" Offset="0x25F0" />
         <DList Name="object_ssh_DL_004E60" Offset="0x4E60" />
         <DList Name="object_ssh_DL_005210" Offset="0x5210" />
         <DList Name="object_ssh_DL_0056A0" Offset="0x56A0" />

--- a/assets/xml/objects/object_syokudai.xml
+++ b/assets/xml/objects/object_syokudai.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <ExternalFile XmlPath="objects/gameplay_dangeon_keep.xml" OutPath="assets/objects/gameplay_dangeon_keep/"/>
     <File Name="object_syokudai" Segment="6">
         <DList Name="gObjectSyokudaiTypeSwitchCausesFlameDL" Offset="0x3A0" />
         <DList Name="gObjectSyokudaiTypeNoSwitchDL" Offset="0x870" />

--- a/assets/xml/objects/object_syoten.xml
+++ b/assets/xml/objects/object_syoten.xml
@@ -1,7 +1,8 @@
 ﻿<Root>
     <File Name="object_syoten" Segment="6">
-        <!-- <Blob Name="object_syoten_Blob_000000" Size="0x23C" Offset="0x0" /> -->
-        <Blob Name="object_syoten_Blob_00023C" Size="0x214" Offset="0x23C" />
+        <Blob Name="object_syoten_Blob_000000" Size="0x23C" Offset="0x0" />
+        <Blob Name="object_syoten_Blob_00023C" Size="0x14" Offset="0x23C" />
+
         <DList Name="object_syoten_DL_000450" Offset="0x450" />
         <DList Name="object_syoten_DL_000518" Offset="0x518" />
         <DList Name="object_syoten_DL_0005E0" Offset="0x5E0" />
@@ -13,8 +14,10 @@
         <Texture Name="object_syoten_Tex_000A90" OutName="tex_000A90" Format="i8" Width="32" Height="32" Offset="0xA90" />
         <Texture Name="object_syoten_Tex_000E90" OutName="tex_000E90" Format="i8" Width="32" Height="32" Offset="0xE90" />
         <TextureAnimation Name="object_syoten_Matanimheader_001298" Offset="0x1298" />
+
         <!-- <Blob Name="object_syoten_Blob_0012A0" Size="0x88" Offset="0x12A0" /> -->
-        <Blob Name="object_syoten_Blob_001328" Size="0x48" Offset="0x1328" />
+        <Blob Name="object_syoten_Blob_001328" Size="0x8" Offset="0x1328" />
+
         <DList Name="object_syoten_DL_001370" Offset="0x1370" />
         <TextureAnimation Name="object_syoten_Matanimheader_001448" Offset="0x1448" />
         <DList Name="object_syoten_DL_001730" Offset="0x1730" />

--- a/assets/xml/objects/object_wood02.xml
+++ b/assets/xml/objects/object_wood02.xml
@@ -1,4 +1,5 @@
 ﻿<Root>
+    <ExternalFile XmlPath="objects/gameplay_field_keep.xml" OutPath="assets/objects/gameplay_field_keep/"/>
     <File Name="object_wood02" Segment="6">
         <DList Name="object_wood02_DL_000090" Offset="0x90" />
         <DList Name="object_wood02_DL_000160" Offset="0x160" />

--- a/assets/xml/objects/object_zog.xml
+++ b/assets/xml/objects/object_zog.xml
@@ -79,7 +79,7 @@
         <Texture Name="object_zog_Tex_025750" OutName="tex_025750" Format="rgba16" Width="32" Height="32" Offset="0x25750" />
         <Texture Name="object_zog_Tex_025F50" OutName="tex_025F50" Format="rgba16" Width="32" Height="32" Offset="0x25F50" />
         <Texture Name="object_zog_Tex_026750" OutName="tex_026750" Format="rgba16" Width="32" Height="32" Offset="0x26750" />
-        <Blob Name="object_zog_Blob_026F50" Size="0x1150" Offset="0x26F50" />
+
         <DList Name="object_zog_DL_0280A0" Offset="0x280A0" />
         <DList Name="object_zog_DL_0280A8" Offset="0x280A8" />
         <Texture Name="object_zog_Tex_028610" OutName="tex_028610" Format="rgba16" Width="16" Height="16" Offset="0x28610" />

--- a/assets/xml/overlays/ovl_Obj_Grass.xml
+++ b/assets/xml/overlays/ovl_Obj_Grass.xml
@@ -1,4 +1,5 @@
 <Root>
+    <ExternalFile XmlPath="objects/gameplay_field_keep.xml" OutPath="assets/objects/gameplay_field_keep/"/>
     <File Name="ovl_Obj_Grass" BaseAddress="0x809A9110" RangeStart="0x18E0" RangeEnd="0x19F0">
         <DList Name="gObjGrass_D_809AA9F0" Offset="0x18E0"/>
         <DList Name="gObjGrass_D_809AAA68" Offset="0x1958"/>

--- a/assets/xml/overlays/ovl_Obj_Jgame_Light.xml
+++ b/assets/xml/overlays/ovl_Obj_Jgame_Light.xml
@@ -1,12 +1,11 @@
-
 <Root>
     <File Name="ovl_Obj_Jgame_Light" BaseAddress="0x80C152F0" RangeStart="0x8FC" RangeEnd="0xE40">
         <!-- @bug: Based on the DList, this should be an invalid i16 -->
-        <Texture Name="sObjJgameLightIncorrectTex" OutName="obj_jgamelight_incorrect" Static="On" Format="ia16" Width="16" Height="16" Offset="0x8FC"/>
+        <Texture Name="sObjJgameLightIncorrectTex" OutName="obj_jgamelight_incorrect" Format="ia16" Width="16" Height="16" Offset="0x8FC"/>
         <!-- @bug: Based on the DList, this should be an invalid i16 -->
-        <Texture Name="sObjJgameLightCorrectTex" OutName="obj_jgamelight_correct" Static="On" Format="ia16" Width="16" Height="16" Offset="0xAFC"/>
+        <Texture Name="sObjJgameLightCorrectTex" OutName="obj_jgamelight_correct" Format="ia16" Width="16" Height="16" Offset="0xAFC"/>
+
         <DList Name="gObjJgameLightIncorrectDL" Offset="0xD40"/>
         <DList Name="gObjJgameLightCorrectDL" Offset="0xDC0"/>
-        
     </File>
 </Root>


### PR DESCRIPTION
Fixes most assets from using hardcoded pointers.
Many of the issues were caused by blobs being too big so ZAPD couldn't create the corresponding symbol automatically. Some others where gameplay_keep symbols not present in the xml, so ZAPD couldn't see them when crossreferencing.

The remaining hardcoded symbols are the ones from Z2_SEA (Great Bay Temple) which are handled by `Scene_DrawConfigGreatBayTemple` and a few limbs from object_osn and object_dmask that reference dlists from gameplay keep but for some ZAPD doesn't symbolize them