### PR TITLE
Fix aliasing in Cutscene_SetActorCue

### DIFF
--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -1127,7 +1127,7 @@ void Cutscene_SetActorCue(CutsceneContext* csCtx, u8** script, s16 cueChannel) {
     *script += sizeof(numCues);
 
     for (i = 0; i < numCues; i++) {
-        CsCmdActorCue* cue = *(CsCmdActorCue**)script;
+        CsCmdActorCue* cue = (CsCmdActorCue*)(*script);
 
         if ((csCtx->curFrame >= cue->startFrame) && (csCtx->curFrame < cue->endFrame)) {
             csCtx->actorCues[cueChannel] = cue;


### PR DESCRIPTION
On gcc with strict-aliasing on (as is default) this could cause improper codegen sometimes due to breaking strict-aliasing rules. This fixes the issue and maintains matching.

Oddly, gcc seems to have trouble identifying when it should warn about strict-aliasing related issues, as this did not cause a warning.
