### PR TITLE
Document `Actor_TalkOfferAccepted`

### DIFF
--- a/docs/tutorial/advanced_control_flow.md
+++ b/docs/tutorial/advanced_control_flow.md
@@ -87,7 +87,7 @@ void func_80952734(EnMs* this, PlayState* play) {
         this->actor.textId = 0x932;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) != 0) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) != 0) {
         this->actionFunc = func_809527F8;
         return;
     }
@@ -112,7 +112,7 @@ void func_809529AC(EnMs* this, PlayState* play) {
 }
 
 void func_80952A1C(EnMs* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_ContinueTextbox(play, 0x936U);
         this->actionFunc = func_809527F8;
     } else {

--- a/docs/tutorial/documenting.md
+++ b/docs/tutorial/documenting.md
@@ -134,7 +134,7 @@ void func_80C1019C(EnRecepgirl* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) != 0) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) != 0) {
         func_80C10290(this);
     } else if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
         Actor_OfferTalk(&this->actor, play, 60.0f);
@@ -470,7 +470,7 @@ void func_80C1019C(EnRecepgirl* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) != 0) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) != 0) {
         func_80C10290(this);
     } else if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
         Actor_OfferTalk(&this->actor, play, 60.0f);
@@ -540,7 +540,7 @@ void func_80C102D4(EnRecepgirl* this, PlayState* play) {
     }
 }
 ```
-All this branching is to make the conversation look more diverse and interesting. Notably, though, `func_80C1019C` is set to start with, and is only changed when `Actor_ProcessTalkRequest(&this->actor, &play->state) != 0`. This is something to do with talking. The other function handles the rest of the conversation, and hands back to the first if `Message_GetState(&play->msgCtx) == 2`. This function is *something* to do with the text state, which will require `z_message` to be decomped. However, observation in-game will reveal this is something to do with ending dialogue. So we can conclude that the action functions are `EnRecepgirl_Wait` and `EnRecepgirl_Talk`. The setup functions are thus `EnRecepgirl_SetupWait` and `EnRecepgirl_SetupTalk`.
+All this branching is to make the conversation look more diverse and interesting. Notably, though, `func_80C1019C` is set to start with, and is only changed when `Actor_TalkOfferAccepted(&this->actor, &play->state) != 0`. This is something to do with talking. The other function handles the rest of the conversation, and hands back to the first if `Message_GetState(&play->msgCtx) == 2`. This function is *something* to do with the text state, which will require `z_message` to be decomped. However, observation in-game will reveal this is something to do with ending dialogue. So we can conclude that the action functions are `EnRecepgirl_Wait` and `EnRecepgirl_Talk`. The setup functions are thus `EnRecepgirl_SetupWait` and `EnRecepgirl_SetupTalk`.
 
 For more complex actors, we have a tool called `graphovl.py` that can produce function flow graphs for actors: running
 

--- a/docs/tutorial/other_functions.md
+++ b/docs/tutorial/other_functions.md
@@ -130,7 +130,7 @@ void func_80C1019C(EnRecepgirl* this, PlayState* play) {
             Animation_ChangeTransitionRepeat(temp_a0, &D_06009890, -4.0f);
         }
     }
-    if (Actor_ProcessTalkRequest((Actor *) this, play) != 0) {
+    if (Actor_TalkOfferAccepted((Actor *) this, play) != 0) {
         func_80C10290(this);
         return;
     }
@@ -185,7 +185,7 @@ void func_80C1019C(EnRecepgirl* this, PlayState* play) {
             Animation_ChangeTransitionRepeat(&this->skelAnime, &D_06009890, -4.0f);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) != 0) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) != 0) {
         func_80C10290(this);
         return;
     }
@@ -223,7 +223,7 @@ void func_80C1019C(EnRecepgirl* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) != 0) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) != 0) {
         func_80C10290(this);
     } else if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
         Actor_OfferTalk(&this->actor, play, 60.0f);

--- a/include/functions.h
+++ b/include/functions.h
@@ -324,7 +324,7 @@ PosRot Actor_GetWorld(Actor* actor);
 PosRot Actor_GetWorldPosShapeRot(Actor* actor);
 
 s32 Target_OutsideLeashRange(Actor* actor, Player* player, s32 ignoreLeash);
-s32 Actor_ProcessTalkRequest(Actor* actor, GameState* gameState);
+s32 Actor_TalkOfferAccepted(Actor* actor, GameState* gameState);
 s32 Actor_OfferTalkExchange(Actor* actor, PlayState* play, f32 xzRange, f32 yRange, PlayerItemAction exchangeItemAction);
 s32 Actor_OfferTalkExchangeEquiCylinder(Actor* actor, PlayState* play, f32 radius, PlayerItemAction exchangeItemAction);
 s32 Actor_OfferTalk(Actor* actor, PlayState* play, f32 radius);

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -486,8 +486,10 @@ typedef enum {
 #define ACTOR_FLAG_40            (1 << 6)
 // hidden or revealed by Lens of Truth (depending on room lensMode)
 #define ACTOR_FLAG_REACT_TO_LENS (1 << 7)
-// Player has requested to talk to the actor; Player uses this flag differently than every other actor
-#define ACTOR_FLAG_TALK_REQUESTED (1 << 8)
+// Signals that player has accepted an offer to talk to an actor
+// Player will retain this flag until the player is finished talking
+// Actor will retain this flag until `Actor_TalkOfferAccepted` is called or manually turned off by the actor
+#define ACTOR_FLAG_TALK (1 << 8)
 // 
 #define ACTOR_FLAG_200           (1 << 9)
 // 

--- a/src/code/z_en_a_keep.c
+++ b/src/code/z_en_a_keep.c
@@ -71,7 +71,7 @@ void EnAObj_Destroy(Actor* thisx, PlayState* play) {
 void EnAObj_Idle(EnAObj* this, PlayState* play) {
     s32 yawDiff;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnAObj_Talk;
     } else {
         yawDiff = ABS_ALT((s16)(this->actor.yawTowardsPlayer - this->actor.shape.rot.y));

--- a/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
+++ b/src/overlays/actors/ovl_Arms_Hook/z_arms_hook.c
@@ -109,7 +109,7 @@ s32 ArmsHook_CheckForCancel(ArmsHook* this) {
     Player* player = (Player*)this->actor.parent;
 
     if (Player_IsHoldingHookshot(player)) {
-        if ((player->itemAction != player->heldItemAction) || (player->actor.flags & ACTOR_FLAG_TALK_REQUESTED) ||
+        if ((player->itemAction != player->heldItemAction) || (player->actor.flags & ACTOR_FLAG_TALK) ||
             (player->stateFlags1 & (PLAYER_STATE1_80 | PLAYER_STATE1_4000000))) {
             this->timer = 0;
             ArmsHook_DetachHookFromActor(this);

--- a/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
+++ b/src/overlays/actors/ovl_Dm_Char08/z_dm_char08.c
@@ -1024,7 +1024,7 @@ void DmChar08_Update(Actor* thisx, PlayState* play) {
     this->dyna.actor.focus.rot.y = this->dyna.actor.world.rot.y;
     this->dyna.actor.focus.rot.z = this->dyna.actor.world.rot.z;
 
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         this->unk_206 = 1;
     }
 

--- a/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.c
+++ b/src/overlays/actors/ovl_Dm_Tag/z_dm_tag.c
@@ -211,7 +211,7 @@ s32 func_80C2291C(DmTag* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_18C & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_18C |= 8;
         SubS_SetOfferMode(&this->unk_18C, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->msgEventScript = func_80C22880(this, play);

--- a/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
+++ b/src/overlays/actors/ovl_Elf_Msg/z_elf_msg.c
@@ -135,7 +135,7 @@ void ElfMsg_Update(Actor* thisx, PlayState* play) {
     ElfMsg* this = THIS;
 
     if (func_8092DF9C(this, play) == 0) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             if (ELFMSG_GET_SWITCH_FLAG(thisx) != 0x7F) {
                 Flags_SetSwitch(play, ELFMSG_GET_SWITCH_FLAG(thisx));
             }

--- a/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
+++ b/src/overlays/actors/ovl_Elf_Msg2/z_elf_msg2.c
@@ -128,7 +128,7 @@ void func_8096EE64(ElfMsg2* this, PlayState* play) {
 }
 
 void func_8096EF98(ElfMsg2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         ElfMsg2_SetupAction(this, func_8096EE64);
     }
 }

--- a/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
+++ b/src/overlays/actors/ovl_Elf_Msg3/z_elf_msg3.c
@@ -133,7 +133,7 @@ void ElfMsg3_Update(Actor* thisx, PlayState* play) {
     ElfMsg3* this = THIS;
 
     if (!func_80A2CD1C(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             if (ELFMSG3_GET_SWITCH_FLAG(thisx) != 0x7F) {
                 Flags_SetSwitch(play, ELFMSG3_GET_SWITCH_FLAG(thisx));
             }

--- a/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
+++ b/src/overlays/actors/ovl_Elf_Msg4/z_elf_msg4.c
@@ -159,7 +159,7 @@ void ElfMsg4_Update(Actor* thisx, PlayState* play) {
             return;
         }
 
-        if ((bgActor != NULL) && Actor_ProcessTalkRequest(bgActor, &play->state)) {
+        if ((bgActor != NULL) && Actor_TalkOfferAccepted(bgActor, &play->state)) {
             if (ELFMSG4_GET_SWITCH_FLAG(thisx) != 0x7F) {
                 Flags_SetSwitch(play, ELFMSG4_GET_SWITCH_FLAG(thisx));
             }

--- a/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
+++ b/src/overlays/actors/ovl_Elf_Msg6/z_elf_msg6.c
@@ -262,7 +262,7 @@ void func_80BA1CF8(ElfMsg6* this, PlayState* play) {
         return;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         switch (this->actor.textId) {
             case 0x224:
                 SET_WEEKEVENTREG(WEEKEVENTREG_79_10);
@@ -296,7 +296,7 @@ void func_80BA1E30(ElfMsg6* this, PlayState* play) {
         return;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         switch (this->actor.textId) {
             case 0x216:
                 SET_WEEKEVENTREG(WEEKEVENTREG_31_04);
@@ -351,7 +351,7 @@ void func_80BA2038(ElfMsg6* this, PlayState* play) {
 }
 
 void func_80BA2048(ElfMsg6* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnElf* sp20 = (EnElf*)GET_PLAYER(play)->tatlActor;
 
         sp20->unk_264 |= 0x20;
@@ -375,7 +375,7 @@ void func_80BA2048(ElfMsg6* this, PlayState* play) {
 }
 
 void func_80BA215C(ElfMsg6* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Actor_Kill(&this->actor);
         return;
     }
@@ -386,7 +386,7 @@ void func_80BA215C(ElfMsg6* this, PlayState* play) {
 }
 
 void func_80BA21C4(ElfMsg6* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnElf* sp20 = (EnElf*)GET_PLAYER(play)->tatlActor;
 
         sp20->unk_264 |= 0x20;

--- a/src/overlays/actors/ovl_En_Ah/z_en_ah.c
+++ b/src/overlays/actors/ovl_En_Ah/z_en_ah.c
@@ -172,7 +172,7 @@ s32 func_80BD2BE8(EnAh* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_2D8 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_2D8, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         ret = true;
         this->unk_2D8 |= 8;

--- a/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
+++ b/src/overlays/actors/ovl_En_Akindonuts/z_en_akindonuts.c
@@ -1313,7 +1313,7 @@ void func_80BEEE10(EnAkindonuts* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 2000, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2DC(this, play);
         this->actionFunc = func_80BEEFA8;
     } else if (((this->actor.xzDistToPlayer < 100.0f) &&
@@ -1440,7 +1440,7 @@ void func_80BEF450(EnAkindonuts* this, PlayState* play) {
 }
 
 void func_80BEF4B8(EnAkindonuts* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2DC(this, play);
         this->actionFunc = func_80BEEFA8;
     } else {

--- a/src/overlays/actors/ovl_En_Al/z_en_al.c
+++ b/src/overlays/actors/ovl_En_Al/z_en_al.c
@@ -503,7 +503,7 @@ s32 func_80BDEC2C(EnAl* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_4C2 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_4C2 &= ~0x1800;
         if (player->exchangeItemAction == PLAYER_IA_LETTER_MAMA) {
             this->unk_4C2 |= 0x800;

--- a/src/overlays/actors/ovl_En_An/z_en_an.c
+++ b/src/overlays/actors/ovl_En_An/z_en_an.c
@@ -1746,7 +1746,7 @@ s32* EnAn_GetMsgEventScript(EnAn* this, PlayState* play) {
 s32 EnAn_CheckTalk(EnAn* this, PlayState* play) {
     s32 ret = false;
 
-    if ((this->stateFlags & SUBS_OFFER_MODE_MASK) && Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if ((this->stateFlags & SUBS_OFFER_MODE_MASK) && Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->stateFlags, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_3C4 = 0;
         this->msgEventState = 0;

--- a/src/overlays/actors/ovl_En_An/z_en_an.c
+++ b/src/overlays/actors/ovl_En_An/z_en_an.c
@@ -1746,7 +1746,8 @@ s32* EnAn_GetMsgEventScript(EnAn* this, PlayState* play) {
 s32 EnAn_CheckTalk(EnAn* this, PlayState* play) {
     s32 ret = false;
 
-    if ((this->stateFlags & SUBS_OFFER_MODE_MASK) && Actor_TalkOfferAccepted(&this->actor, &play->state)) {
+    if (((this->stateFlags & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->stateFlags, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_3C4 = 0;
         this->msgEventState = 0;

--- a/src/overlays/actors/ovl_En_Ani/z_en_ani.c
+++ b/src/overlays/actors/ovl_En_Ani/z_en_ani.c
@@ -182,7 +182,7 @@ void EnAni_Talk(EnAni* this, PlayState* play) {
 
 void EnAni_IdleInPain(EnAni* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnAni_Talk;
     } else {
         // telling you not to take his rupees you knocked from the tree

--- a/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
+++ b/src/overlays/actors/ovl_En_Aob_01/z_en_aob_01.c
@@ -580,7 +580,7 @@ void EnAob01_BeforeRace_Idle(EnAob01* this, PlayState* play) {
                 this->stateFlags |= ENAOB01_FLAG_TALKING_TO_PLAYER_HOLDING_DOG;
                 this->actionFunc = EnAob01_BeforeRace_Talk;
             }
-        } else if (Actor_ProcessTalkRequest(&this->actor, &play->state) &&
+        } else if (Actor_TalkOfferAccepted(&this->actor, &play->state) &&
                    (this->stateFlags & ENAOB01_FLAG_PLAYER_CAN_TALK)) {
             this->stateFlags &= ~ENAOB01_FLAG_PLAYER_CAN_TALK;
             this->prevTrackTarget = this->trackTarget;
@@ -634,7 +634,7 @@ void EnAob01_BeforeRace_Talk(EnAob01* this, PlayState* play) {
     }
 
     if (this->stateFlags & ENAOB01_FLAG_TALKING_TO_PLAYER_HOLDING_DOG) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actor.flags &= ~ACTOR_FLAG_10000;
             func_80123E90(play, &this->actor);
             if (this->stateFlags & ENAOB01_FLAG_PLAYER_TOLD_TO_PICK_A_DOG) {
@@ -844,7 +844,7 @@ void EnAob01_Race_StartCutscene(EnAob01* this, PlayState* play) {
  * receive the same number of rupees they bet.
  */
 void EnAob01_AfterRace_GiveRaceResult(EnAob01* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         func_80123E90(play, &this->actor);
         this->rupeesBet = gSaveContext.unk_3F5C;
@@ -951,7 +951,7 @@ void EnAob01_AfterRace_AfterGivingReward(EnAob01* this, PlayState* play) {
  * the player has won the 150 rupee reward.
  */
 void EnAob01_AfterRace_AskToPlayAgain(EnAob01* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->textId = 0x354C; // Want to play again?
         Message_ContinueTextbox(play, this->textId);
         this->actionFunc = EnAob01_BeforeRace_RespondToPlayAgainQuestion;

--- a/src/overlays/actors/ovl_En_Az/z_en_az.c
+++ b/src/overlays/actors/ovl_En_Az/z_en_az.c
@@ -1431,7 +1431,7 @@ void func_80A97410(EnAz* this, PlayState* play) {
             }
         } else if (((this->unk_378 == 0) || (this->unk_378 == 1)) && (this->unk_374 & 0x20)) {
             if (this->unk_378 == 1) {
-                if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+                if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                     func_80A97114(this, play);
                     this->unk_378 = 2;
                 } else if (Actor_OfferTalkExchange(&this->actor, play, this->actor.xzDistToPlayer,
@@ -1459,7 +1459,7 @@ void func_80A97410(EnAz* this, PlayState* play) {
                         Math_SmoothStepToS(&this->unk_3D6, 0, 3, 0x71C, 0);
                     }
                 }
-                if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+                if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                     func_80A97114(this, play);
                     this->unk_378 = 2;
                     if ((this->unk_3D2 == 0x10CE) || (this->unk_3D2 == 0x10D4)) {

--- a/src/overlays/actors/ovl_En_Baba/z_en_baba.c
+++ b/src/overlays/actors/ovl_En_Baba/z_en_baba.c
@@ -577,7 +577,7 @@ void EnBaba_FinishInit(EnBaba* this, PlayState* play) {
 void EnBaba_Idle(EnBaba* this, PlayState* play) {
     if ((this->stateFlags & BOMB_SHOP_LADY_STATE_AUTOTALK) || (this->bombShopkeeper != NULL) ||
         EnBaba_FindBombShopkeeper(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             EnBaba_HandleConversation(this, play);
             if (this->stateFlags & BOMB_SHOP_LADY_STATE_AUTOTALK) {
                 this->actor.flags &= ~ACTOR_FLAG_10000;
@@ -655,7 +655,7 @@ void EnBaba_GiveBlastMask(EnBaba* this, PlayState* play) {
 }
 
 void EnBaba_GaveBlastMask(EnBaba* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnBaba_HandleConversation(this, play);
         this->actionFunc = EnBaba_Talk;
     } else {
@@ -683,7 +683,7 @@ void EnBaba_FollowSchedule(EnBaba* this, PlayState* play) {
     EnBaba_HandleSchedule(this, play);
 
     if (this->stateFlags & BOMB_SHOP_LADY_STATE_VISIBLE) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             Message_StartTextbox(play, 0x2A39, &this->actor); // "I'm sorry"
             this->actionFunc = EnBaba_FollowSchedule_Talk;
         } else if ((this->actor.xzDistToPlayer < 100.0f) || this->actor.isLockedOn) {

--- a/src/overlays/actors/ovl_En_Baisen/z_en_baisen.c
+++ b/src/overlays/actors/ovl_En_Baisen/z_en_baisen.c
@@ -163,7 +163,7 @@ void func_80BE87FC(EnBaisen* this) {
 }
 
 void func_80BE887C(EnBaisen* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BE895C(this, play);
     } else {
         if (this->paramCopy != 0) {

--- a/src/overlays/actors/ovl_En_Bal/z_en_bal.c
+++ b/src/overlays/actors/ovl_En_Bal/z_en_bal.c
@@ -507,7 +507,7 @@ void EnBal_GroundIdle(EnBal* this, PlayState* play) {
         this->timer++;
     }
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->forceEyesShut = false;
         this->eyeTexIndex = TINGLE_EYETEX_OPEN;
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_TALKED_TINGLE)) {
@@ -1036,7 +1036,7 @@ void EnBal_SetupThankYou(EnBal* this) {
 void EnBal_ThankYou(EnBal* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         player->stateFlags1 &= ~PLAYER_STATE1_20;
         Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, TINGLE_ANIM_TWIST);
         this->forceEyesShut = false;

--- a/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
+++ b/src/overlays/actors/ovl_En_Bba_01/z_en_bba_01.c
@@ -130,7 +130,7 @@ void EnBba01_UpdateModel(EnBba01* this, PlayState* play) {
 s32 EnBba01_TestIsTalking(EnBba01* this, PlayState* play) {
     s32 isTalking = false;
 
-    if (Actor_ProcessTalkRequest(&this->enHy.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->enHy.actor, &play->state)) {
         isTalking = true;
         this->enHy.textId = 0x10B9; // Invalid textId, produces empty textbox
         this->enHy.prevTrackTarget = this->enHy.trackTarget;

--- a/src/overlays/actors/ovl_En_Bji_01/z_en_bji_01.c
+++ b/src/overlays/actors/ovl_En_Bji_01/z_en_bji_01.c
@@ -100,7 +100,7 @@ void func_809CCEE8(EnBji01* this, PlayState* play) {
             this->actor.flags &= ~ACTOR_FLAG_10000;
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         play->msgCtx.msgMode = MSGMODE_NONE;
         play->msgCtx.msgLength = 0;
         func_809CD028(this, play);

--- a/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
+++ b/src/overlays/actors/ovl_En_Bjt/z_en_bjt.c
@@ -321,7 +321,7 @@ s32 EnBjt_CheckTalk(EnBjt* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->stateFlags & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->stateFlags |= TOILET_HAND_STATE_TALKING;
         SubS_SetOfferMode(&this->stateFlags, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->msgEventCallback = EnBjt_ChooseBehaviour;
@@ -365,7 +365,7 @@ void EnBjt_Talk(EnBjt* this, PlayState* play) {
     s16 yaw = this->actor.yawTowardsPlayer;
 
     if (func_8010BF58(&this->actor, play, sMsgEventScript, this->msgEventCallback, &this->msgEventArg4)) {
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         SubS_SetOfferMode(&this->stateFlags, SUBS_OFFER_MODE_ONSCREEN, SUBS_OFFER_MODE_MASK);
         this->stateFlags &= ~TOILET_HAND_STATE_TALKING;
         this->msgEventArg4 = 0;

--- a/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
+++ b/src/overlays/actors/ovl_En_Bom_Bowl_Man/z_en_bom_bowl_man.c
@@ -580,7 +580,7 @@ void func_809C59F0(EnBomBowlMan* this, PlayState* play) {
 }
 
 void func_809C5AA4(EnBomBowlMan* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->unk_2F6 == ENBOMBOWLMAN_F0_0) {
             this->actionFunc = func_809C4DA4;
         } else {

--- a/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
+++ b/src/overlays/actors/ovl_En_Bombers/z_en_bombers.c
@@ -355,7 +355,7 @@ void func_80C03AF4(EnBombers* this, PlayState* play) {
         this->actor.textId = Text_GetFaceReaction(play, FACE_REACTION_SET_BOMBERS);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2A4 = this->actor.yawTowardsPlayer;
         this->collider.dim.radius = 20;
         this->collider.dim.height = 60;
@@ -500,7 +500,7 @@ void func_80C042F8(EnBombers* this) {
 
 void func_80C04354(EnBombers* this, PlayState* play) {
     Math_SmoothStepToS(&this->unk_288, this->unk_28E, 1, 0x3E8, 0);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_28E = 0;
         this->actionFunc = func_80C043C8;
     } else {

--- a/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
+++ b/src/overlays/actors/ovl_En_Bombers2/z_en_bombers2.c
@@ -189,7 +189,7 @@ void func_80C04BA0(EnBombers2* this, PlayState* play) {
         this->actor.textId = Text_GetFaceReaction(play, FACE_REACTION_SET_BOMBERS_HIDEOUT_GUARD);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2B6 = this->actor.world.rot.y;
         SET_WEEKEVENTREG(WEEKEVENTREG_86_02);
         func_80C04D00(this);

--- a/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
+++ b/src/overlays/actors/ovl_En_Bomjima/z_en_bomjima.c
@@ -442,7 +442,7 @@ void func_80BFEB64(EnBomjima* this, PlayState* play) {
         this->actor.textId = Text_GetFaceReaction(play, FACE_REACTION_SET_JIM);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2DC = this->actor.yawTowardsPlayer;
         func_80C00234(this);
         return;
@@ -561,7 +561,7 @@ void func_80BFF174(EnBomjima* this, PlayState* play) {
         this->actor.textId = Text_GetFaceReaction(play, FACE_REACTION_SET_JIM);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2DC = this->actor.yawTowardsPlayer;
         func_80C00234(this);
         return;
@@ -944,7 +944,7 @@ void func_80C00168(EnBomjima* this, PlayState* play) {
         this->actor.textId = Text_GetFaceReaction(play, FACE_REACTION_SET_JIM);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2DC = this->actor.yawTowardsPlayer;
         func_80C00234(this);
     } else {

--- a/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
+++ b/src/overlays/actors/ovl_En_Bomjimb/z_en_bomjimb.c
@@ -571,7 +571,7 @@ void func_80C0201C(EnBomjimb* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2CA = 10;
         this->actionFunc = func_80C02A14;
     } else {

--- a/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
+++ b/src/overlays/actors/ovl_En_Cne_01/z_en_cne_01.c
@@ -122,7 +122,7 @@ void EnCne01_UpdateModel(EnCne01* this, PlayState* play) {
 s32 EnCne01_TestIsTalking(EnCne01* this, PlayState* play) {
     s32 isTalking = false;
 
-    if (Actor_ProcessTalkRequest(&this->enHy.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->enHy.actor, &play->state)) {
         isTalking = true;
         this->enHy.textId = 0x10B9; // Invalid textId, produces empty textbox
         this->enHy.prevTrackTarget = this->enHy.trackTarget;

--- a/src/overlays/actors/ovl_En_Cow/z_en_cow.c
+++ b/src/overlays/actors/ovl_En_Cow/z_en_cow.c
@@ -251,7 +251,7 @@ void EnCow_CheckForEmptyBottle(EnCow* this, PlayState* play) {
 }
 
 void EnCow_Talk(EnCow* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->actor.textId == 0x32C8) { // Text to give milk after playing Epona's Song.
             this->actionFunc = EnCow_CheckForEmptyBottle;
         } else if (this->actor.textId == 0x32C9) { // Text to give milk.

--- a/src/overlays/actors/ovl_En_Dai/z_en_dai.c
+++ b/src/overlays/actors/ovl_En_Dai/z_en_dai.c
@@ -216,7 +216,7 @@ s32 func_80B3E7C8(EnDai* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_1CE & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_1CE, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->actionFunc = func_80B3EF90;
         ret = true;

--- a/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
+++ b/src/overlays/actors/ovl_En_Daiku/z_en_daiku.c
@@ -216,7 +216,7 @@ void func_809438F8(EnDaiku* this, PlayState* play) {
         this->actor.textId = sTextIds[this->unk_28C];
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80943BC0(this);
         return;
     }

--- a/src/overlays/actors/ovl_En_Daiku2/z_en_daiku2.c
+++ b/src/overlays/actors/ovl_En_Daiku2/z_en_daiku2.c
@@ -261,7 +261,7 @@ void func_80BE66E4(EnDaiku2* this, PlayState* play) {
 
     this->actor.textId = sTextIds[this->unk_28A];
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BE6B40(this, play);
         return;
     }
@@ -374,7 +374,7 @@ void func_80BE6D40(EnDaiku2* this, PlayState* play) {
     s32 pad[3];
     s16 sp3A = Math_Vec3f_Yaw(&this->actor.world.pos, &this->unk_268);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BE6BC0;
         return;
     }
@@ -408,7 +408,7 @@ void func_80BE6EF0(EnDaiku2* this, PlayState* play) {
     Vec3f sp40;
     s16 var;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BE6BC0;
         return;
     }

--- a/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
+++ b/src/overlays/actors/ovl_En_Demo_heishi/z_en_demo_heishi.c
@@ -136,7 +136,7 @@ void EnDemoheishi_Idle(EnDemoheishi* this, PlayState* play) {
     yawDiff = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
     absYawDiff = ABS_ALT(yawDiff);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnDemoheishi_SetupTalk(this);
     } else if (absYawDiff <= 0x4BB8) {
         Actor_OfferTalk(&this->actor, play, 70.0f);

--- a/src/overlays/actors/ovl_En_Dg/z_en_dg.c
+++ b/src/overlays/actors/ovl_En_Dg/z_en_dg.c
@@ -1283,7 +1283,7 @@ void EnDg_Thrown(EnDg* this, PlayState* play) {
 }
 
 void EnDg_SetupTalk(EnDg* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         EnDg_StartTextBox(this, play);
         this->actionFunc = EnDg_Talk;

--- a/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
+++ b/src/overlays/actors/ovl_En_Dnh/z_en_dnh.c
@@ -101,7 +101,7 @@ void* func_80A50DF8(EnDnh* this, PlayState* play) {
 
 s32 func_80A50E40(EnDnh* this, PlayState* play) {
     if (((this->unk18C & SUBS_OFFER_MODE_MASK) == SUBS_OFFER_MODE_NONE) ||
-        !Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        !Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         return 0;
     }
     SubS_SetOfferMode(&this->unk18C, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);

--- a/src/overlays/actors/ovl_En_Dno/z_en_dno.c
+++ b/src/overlays/actors/ovl_En_Dno/z_en_dno.c
@@ -371,7 +371,7 @@ void func_80A71C3C(EnDno* this, PlayState* play) {
         Math_ScaledStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 0x222);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         play->msgCtx.msgMode = MSGMODE_NONE;
         play->msgCtx.msgLength = 0;
         func_80A71E54(this, play);
@@ -589,7 +589,7 @@ void func_80A724B8(EnDno* this, PlayState* play) {
         func_80A71424(&this->unk_466, 0, this->actor.yawTowardsPlayer, this->actor.home.rot.y, 0x2000, 0x2D8);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80A725E0(this, play);
     } else if (this->actor.xzDistToPlayer < 60.0f) {
         Actor_OfferTalk(&this->actor, play, 60.0f);
@@ -602,7 +602,7 @@ void func_80A7256C(EnDno* this, PlayState* play) {
 }
 
 void func_80A72598(EnDno* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80A725E0(this, play);
     } else {
         func_80A7256C(this, play);

--- a/src/overlays/actors/ovl_En_Dnp/z_en_dnp.c
+++ b/src/overlays/actors/ovl_En_Dnp/z_en_dnp.c
@@ -248,7 +248,7 @@ s32 func_80B3CF60(EnDnp* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_322 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_322, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_322 |= 8;
         this->actionFunc = func_80B3D3F8;
@@ -356,7 +356,7 @@ void func_80B3D338(EnDnp* this, PlayState* play) {
     }
 
     if (this->unk_32E == 0) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->unk_32E = 1;
         } else {
             this->actor.textId = 0x971;

--- a/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
+++ b/src/overlays/actors/ovl_En_Dnq/z_en_dnq.c
@@ -356,7 +356,7 @@ s32 func_80A52D44(EnDnq* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_37C & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_37C, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_380 = func_80A52CF8(this, play);
         this->actionFunc = func_80A52FB8;

--- a/src/overlays/actors/ovl_En_Dns/z_en_dns.c
+++ b/src/overlays/actors/ovl_En_Dns/z_en_dns.c
@@ -230,7 +230,7 @@ s32 func_8092CAD0(EnDns* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_2C6 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_2C6, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_2C6 &= ~0x10;
         if (ENDNS_GET_4000(&this->actor)) {

--- a/src/overlays/actors/ovl_En_Door/z_en_door.c
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.c
@@ -501,7 +501,7 @@ void func_80866B20(EnDoor* this, PlayState* play) {
     static s32 D_80867BC0;
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->knobDoor.dyna.actor, &play->state) &&
+    if (Actor_TalkOfferAccepted(&this->knobDoor.dyna.actor, &play->state) &&
         (this->knobDoor.dyna.actor.textId == 0x1821)) {
         D_80867BC0 = true;
     }

--- a/src/overlays/actors/ovl_En_Elf/z_en_elf.c
+++ b/src/overlays/actors/ovl_En_Elf/z_en_elf.c
@@ -1473,7 +1473,7 @@ void func_8089010C(Actor* thisx, PlayState* play) {
         thisx->flags |= ACTOR_FLAG_10000;
     }
 
-    if (Actor_ProcessTalkRequest(thisx, &play->state)) {
+    if (Actor_TalkOfferAccepted(thisx, &play->state)) {
         Audio_PlaySfx_AtPosWithReverb(&gSfxDefaultPos, NA_SE_VO_NA_LISTEN, 0x20);
         thisx->focus.pos = thisx->world.pos;
 
@@ -1487,7 +1487,7 @@ void func_8089010C(Actor* thisx, PlayState* play) {
         thisx->update = func_8088FE64;
         func_8088C51C(this, 3);
         if (this->elfMsg != NULL) {
-            this->elfMsg->flags |= ACTOR_FLAG_TALK_REQUESTED;
+            this->elfMsg->flags |= ACTOR_FLAG_TALK;
             thisx->csId = this->elfMsg->csId;
             if (thisx->csId != CS_ID_NONE) {
                 func_8088FD04(this);

--- a/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.c
+++ b/src/overlays/actors/ovl_En_Elfgrp/z_en_elfgrp.c
@@ -589,7 +589,7 @@ void func_80A3A77C(EnElfgrp* this, PlayState* play) {
 void func_80A3A7FC(EnElfgrp* this, PlayState* play) {
     s32 curTotalFairies;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         gSaveContext.save.saveInfo.weekEventReg[9] |= this->talkedOnceFlag;
         this->actionFunc = func_80A3A6F4;
 
@@ -611,7 +611,7 @@ void func_80A3A8F8(EnElfgrp* this, PlayState* play) {
     s32 pad;
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         gSaveContext.save.saveInfo.weekEventReg[9] |= this->talkedOnceFlag;
         this->actionFunc = func_80A3A6F4;
         return;

--- a/src/overlays/actors/ovl_En_Fish2/z_en_fish2.c
+++ b/src/overlays/actors/ovl_En_Fish2/z_en_fish2.c
@@ -350,7 +350,7 @@ void func_80B28C14(EnFish2* this, PlayState* play) {
     Actor* itemAction = play->actorCtx.actorLists[ACTORCAT_ITEMACTION].first;
     WaterBox* waterbox;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80B29128(this);
         return;
     }

--- a/src/overlays/actors/ovl_En_Fishing/z_en_fishing.c
+++ b/src/overlays/actors/ovl_En_Fishing/z_en_fishing.c
@@ -2820,7 +2820,7 @@ void EnFishing_HandleAquariumDialog(EnFishing* this, PlayState* play) {
         if (this->unk_1CC == 0) {
             this->actor.flags |= ACTOR_FLAG_TARGETABLE;
 
-            if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+            if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                 D_8090CCF8 = D_809171CC;
                 this->unk_1CB = 1;
             } else {
@@ -4707,7 +4707,7 @@ void EnFishing_HandleOwnerDialog(EnFishing* this, PlayState* play) {
                 this->actor.textId = 0x4097;
             }
 
-            if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+            if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                 if (D_809171FC == 0) {
                     this->unk_154 = 1;
                     if (sLinkAge != 1) {

--- a/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
+++ b/src/overlays/actors/ovl_En_Fsn/z_en_fsn.c
@@ -223,7 +223,7 @@ void EnFsn_HandleConversationBackroom(EnFsn* this, PlayState* play) {
 void EnFsn_HandleSetupResumeInteraction(EnFsn* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_DONE) && Message_ShouldAdvance(play) &&
         (this->cutsceneState == ENFSN_CUTSCENESTATE_STOPPED)) {
-        Actor_ProcessTalkRequest(&this->actor, &play->state);
+        Actor_TalkOfferAccepted(&this->actor, &play->state);
         Actor_OfferTalkExchangeEquiCylinder(&this->actor, play, 400.0f, PLAYER_IA_MINUS1);
         if (ENFSN_IS_SHOP(&this->actor)) {
             this->actor.textId = 0;
@@ -409,7 +409,7 @@ void EnFsn_EndInteraction(EnFsn* this, PlayState* play) {
         CutsceneManager_Stop(this->csId);
         this->cutsceneState = ENFSN_CUTSCENESTATE_STOPPED;
     }
-    Actor_ProcessTalkRequest(&this->actor, &play->state);
+    Actor_TalkOfferAccepted(&this->actor, &play->state);
     play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     play->msgCtx.stateTimer = 4;
     Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
@@ -759,7 +759,7 @@ void EnFsn_Idle(EnFsn* this, PlayState* play) {
         return;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->cutsceneState == ENFSN_CUTSCENESTATE_STOPPED) {
             if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
                 CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
@@ -946,7 +946,7 @@ void EnFsn_AskBuyOrSell(EnFsn* this, PlayState* play) {
 }
 
 void EnFsn_SetupDeterminePrice(EnFsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.textId = 0xFF;
         Message_StartTextbox(play, this->actor.textId, &this->actor);
         this->actionFunc = EnFsn_DeterminePrice;
@@ -1066,7 +1066,7 @@ void EnFsn_SetupResumeInteraction(EnFsn* this, PlayState* play) {
 }
 
 void EnFsn_ResumeInteraction(EnFsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (ENFSN_IS_SHOP(&this->actor)) {
             if (!this->isSelling) {
                 this->csId = this->lookToShopkeeperBuyingCsId;
@@ -1420,7 +1420,7 @@ void EnFsn_SetupEndInteractionImmediately(EnFsn* this, PlayState* play) {
 }
 
 void EnFsn_IdleBackroom(EnFsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->textId = 0;
         EnFsn_HandleConversationBackroom(this, play);
         this->actionFunc = EnFsn_ConverseBackroom;

--- a/src/overlays/actors/ovl_En_Fu/z_en_fu.c
+++ b/src/overlays/actors/ovl_En_Fu/z_en_fu.c
@@ -400,7 +400,7 @@ void func_80962340(EnFu* this, PlayState* play) {
         this->actor.flags |= ACTOR_FLAG_10000;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->unk_54A == 2) {
             if (this->unk_552 == 0x287D) {
                 if (GET_PLAYER_FORM == PLAYER_FORM_DEKU) {
@@ -919,7 +919,7 @@ void func_80963610(EnFu* this) {
 void func_80963630(EnFu* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_22_10) && CHECK_WEEKEVENTREG(WEEKEVENTREG_22_20) && (CURRENT_DAY == 3) &&
             (GET_PLAYER_FORM == PLAYER_FORM_HUMAN)) {
             if (CHECK_WEEKEVENTREG(WEEKEVENTREG_22_40)) {

--- a/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
+++ b/src/overlays/actors/ovl_En_Gb2/z_en_gb2.c
@@ -386,7 +386,7 @@ void func_80B0FEBC(EnGb2* this, PlayState* play) {
         this->unk_288 = 10;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->unk_26E, &this->actor);
         this->actionFunc = func_80B0FFA8;
     } else if ((this->actor.xzDistToPlayer < 300.0f) || this->actor.isLockedOn) {
@@ -552,7 +552,7 @@ void func_80B10344(EnGb2* this, PlayState* play) {
 }
 
 void func_80B10584(EnGb2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->unk_26E, &this->actor);
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = func_80B10634;
@@ -655,7 +655,7 @@ void func_80B10924(EnGb2* this, PlayState* play) {
 }
 
 void func_80B109DC(EnGb2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->unk_26E, &this->actor);
         this->actionFunc = func_80B10634;
     } else {
@@ -710,7 +710,7 @@ void func_80B10B5C(EnGb2* this, PlayState* play) {
 
     if (func_80B0FA48(this, play)) {
         this->unk_26C &= ~0x20;
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state) && (this->unk_26C & 0x40)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state) && (this->unk_26C & 0x40)) {
             if ((this->unk_26E == 0x14EE) || (this->unk_26E == 0x14F4)) {
                 this->unk_26C |= 2;
             }
@@ -724,7 +724,7 @@ void func_80B10B5C(EnGb2* this, PlayState* play) {
         }
     } else {
         this->unk_26C &= ~0x40;
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state) && (this->unk_26C & 0x20)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state) && (this->unk_26C & 0x20)) {
             this->actor.flags &= ~ACTOR_FLAG_10000;
             Message_StartTextbox(play, this->unk_26E, &this->actor);
             if (this->unk_26E == 0x14EB) {
@@ -801,7 +801,7 @@ void func_80B10E98(EnGb2* this, PlayState* play) {
 }
 
 void func_80B11048(EnGb2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         Message_StartTextbox(play, this->unk_26E, &this->actor);
         this->actionFunc = func_80B10DAC;

--- a/src/overlays/actors/ovl_En_Geg/z_en_geg.c
+++ b/src/overlays/actors/ovl_En_Geg/z_en_geg.c
@@ -472,7 +472,7 @@ void func_80BB221C(EnGeg* this, PlayState* play) {
 
     if (sp27 != 0) {
         this->unk_230 &= ~8;
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state) && (this->unk_230 & 4)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state) && (this->unk_230 & 4)) {
             if (sp27 == 1) {
                 this->unk_496 = 0xD66;
                 this->nextCsId = this->csIdList[3];
@@ -497,7 +497,7 @@ void func_80BB221C(EnGeg* this, PlayState* play) {
     } else {
         this->unk_230 &= ~4;
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_35_40)) {
-            if (Actor_ProcessTalkRequest(&this->actor, &play->state) && (this->unk_230 & 8)) {
+            if (Actor_TalkOfferAccepted(&this->actor, &play->state) && (this->unk_230 & 8)) {
                 this->unk_496 = 0xD62;
                 Message_StartTextbox(play, this->unk_496, &this->actor);
                 this->unk_230 &= ~8;
@@ -506,7 +506,7 @@ void func_80BB221C(EnGeg* this, PlayState* play) {
                 Actor_OfferTalk(&this->actor, play, 300.0f);
                 this->unk_230 |= 8;
             }
-        } else if (Actor_ProcessTalkRequest(&this->actor, &play->state) && (this->unk_230 & 8)) {
+        } else if (Actor_TalkOfferAccepted(&this->actor, &play->state) && (this->unk_230 & 8)) {
             SET_WEEKEVENTREG(WEEKEVENTREG_35_40);
             this->unk_496 = 0xD5E;
             this->nextCsId = this->csIdList[0];
@@ -813,7 +813,7 @@ void func_80BB2F7C(EnGeg* this, PlayState* play) {
 void func_80BB30B4(EnGeg* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (player->transformation == PLAYER_FORM_GORON) {
             this->unk_496 = 0xD6A;
         } else if (Player_GetMask(play) == PLAYER_MASK_DON_GERO) {
@@ -858,7 +858,7 @@ void func_80BB31B8(EnGeg* this, PlayState* play) {
 }
 
 void func_80BB32AC(EnGeg* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->unk_496, &this->actor);
         this->actionFunc = func_80BB27D4;
     } else {

--- a/src/overlays/actors/ovl_En_Gg/z_en_gg.c
+++ b/src/overlays/actors/ovl_En_Gg/z_en_gg.c
@@ -258,7 +258,7 @@ void func_80B35450(EnGg* this, PlayState* play) {
         func_80B359DC(this, play);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_REACT_TO_LENS)) {
             Actor_DeactivateLens(play);
         }

--- a/src/overlays/actors/ovl_En_Gg2/z_en_gg2.c
+++ b/src/overlays/actors/ovl_En_Gg2/z_en_gg2.c
@@ -183,7 +183,7 @@ void func_80B3AE60(EnGg2* this, PlayState* play) {
 }
 
 void func_80B3AFB0(EnGg2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2F0 = 1;
         this->actionFunc = func_80B3AE60;
     } else if ((this->actor.xzDistToPlayer < 100.0f) && (this->actor.xzDistToPlayer > 50.0f) &&

--- a/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
+++ b/src/overlays/actors/ovl_En_Ginko_Man/z_en_ginko_man.c
@@ -88,7 +88,7 @@ void EnGinkoMan_Idle(EnGinkoMan* this, PlayState* play) {
     s32 yaw = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
 
     EnGinkoMan_SwitchAnimation(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (HS_GET_BANK_RUPEES() == 0) {
             Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, GINKO_ANIM_LEGSMACKING);
             Message_StartTextbox(play, 0x44C, &this->actor);
@@ -565,7 +565,7 @@ void EnGinkoMan_SetupBankAward2(EnGinkoMan* this) {
 
 // separate function to handle bank rewards... called while the player is receiving the award
 void EnGinkoMan_BankAward2(EnGinkoMan* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_10_08) && (this->curTextId == 0x45B)) {
             SET_WEEKEVENTREG(WEEKEVENTREG_10_08);
             Message_StartTextbox(play, 0x47A, &this->actor);

--- a/src/overlays/actors/ovl_En_Gk/z_en_gk.c
+++ b/src/overlays/actors/ovl_En_Gk/z_en_gk.c
@@ -679,7 +679,7 @@ void func_80B51760(EnGk* this, PlayState* play) {
             return;
         }
 
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->unk_1E4 |= 4;
             this->unk_31C = func_80B50410(this, play);
             Message_StartTextbox(play, this->unk_31C, &this->actor);
@@ -893,7 +893,7 @@ void func_80B5202C(EnGk* this, PlayState* play) {
     }
 
     if (!func_80B50854(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             SET_WEEKEVENTREG(WEEKEVENTREG_24_80);
             this->actionFunc = func_80B51698;
         } else if ((this->actor.xzDistToPlayer < 100.0f) || this->actor.isLockedOn) {
@@ -952,7 +952,7 @@ void func_80B5227C(EnGk* this, PlayState* play) {
 }
 
 void func_80B52340(EnGk* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_1E4 |= 4;
         if (CHECK_EVENTINF(EVENTINF_11)) {
             this->unk_31C = 0xE90;
@@ -1024,7 +1024,7 @@ void func_80B5253C(EnGk* this, PlayState* play) {
 }
 
 void func_80B525E0(EnGk* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_31C = 0xE92;
         Message_StartTextbox(play, this->unk_31C, &this->actor);
         this->actionFunc = func_80B52430;

--- a/src/overlays/actors/ovl_En_Gm/z_en_gm.c
+++ b/src/overlays/actors/ovl_En_Gm/z_en_gm.c
@@ -757,7 +757,7 @@ s32 func_8094EE84(EnGm* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_3A4 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_3A4, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_3E0 = 0;
         this->unk_3E4 = NULL;

--- a/src/overlays/actors/ovl_En_Go/z_en_go.c
+++ b/src/overlays/actors/ovl_En_Go/z_en_go.c
@@ -891,7 +891,7 @@ void EnGo_UpdateCollider(EnGo* this, PlayState* play) {
  */
 s32 EnGo_UpdateTalking(EnGo* this, PlayState* play) {
     if (((this->actionFlags & SUBS_OFFER_MODE_MASK) == SUBS_OFFER_MODE_NONE) ||
-        !Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        !Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         return false;
     }
 

--- a/src/overlays/actors/ovl_En_Gs/z_en_gs.c
+++ b/src/overlays/actors/ovl_En_Gs/z_en_gs.c
@@ -1030,7 +1030,7 @@ void EnGs_Update(Actor* thisx, PlayState* play) {
     s32 pad;
     EnGs* this = THIS;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         play->msgCtx.msgMode = MSGMODE_NONE;
         play->msgCtx.msgLength = 0;
         this->collider.base.acFlags &= ~AC_HIT;

--- a/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.c
+++ b/src/overlays/actors/ovl_En_Guard_Nuts/z_en_guard_nuts.c
@@ -155,7 +155,7 @@ void EnGuardNuts_Wait(EnGuardNuts* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     yawDiff = ABS_ALT(BINANG_SUB(this->actor.yawTowardsPlayer, this->actor.home.rot.y));
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80ABB540(this);
         return;
     }

--- a/src/overlays/actors/ovl_En_Guruguru/z_en_guruguru.c
+++ b/src/overlays/actors/ovl_En_Guruguru/z_en_guruguru.c
@@ -181,7 +181,7 @@ void func_80BC6F14(EnGuruguru* this, PlayState* play) {
     yawTemp = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
     yaw = ABS_ALT(yawTemp);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BC701C(this, play);
     } else if (yaw <= 0x2890) {
         Actor_OfferTalk(&this->actor, play, 60.0f);
@@ -323,7 +323,7 @@ void func_80BC7440(EnGuruguru* this, PlayState* play) {
 
 void func_80BC7520(EnGuruguru* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BC7068;
     } else {
         Actor_OfferTalkExchange(&this->actor, play, 400.0f, 400.0f, PLAYER_IA_MINUS1);

--- a/src/overlays/actors/ovl_En_Hg/z_en_hg.c
+++ b/src/overlays/actors/ovl_En_Hg/z_en_hg.c
@@ -233,7 +233,7 @@ void EnHg_ReactToHit(EnHg* this, PlayState* play) {
 
 void EnHg_HandleTatlDialog(EnHg* this, PlayState* play) {
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_NONE) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             Message_StartTextbox(play, 0x24F, &this->actor);
         } else {
             Actor_OfferTalk(&this->actor, play, 80.0f);

--- a/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
+++ b/src/overlays/actors/ovl_En_Hgo/z_en_hgo.c
@@ -150,7 +150,7 @@ void EnHgo_SetupTalk(EnHgo* this) {
 }
 
 void EnHgo_Talk(EnHgo* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (Player_GetMask(play) == PLAYER_MASK_GIBDO) {
             if (!(this->talkFlags & TALK_FLAG_HAS_SPOKEN_WITH_GIBDO_MASK)) {
                 this->talkFlags |= TALK_FLAG_HAS_SPOKEN_WITH_GIBDO_MASK;

--- a/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.c
+++ b/src/overlays/actors/ovl_En_Hidden_Nuts/z_en_hidden_nuts.c
@@ -184,7 +184,7 @@ void func_80BDB2B8(EnHiddenNuts* this, PlayState* play) {
         this->unk_20A = false;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BDB580(this);
         return;
     }

--- a/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.c
+++ b/src/overlays/actors/ovl_En_Hint_Skb/z_en_hint_skb.c
@@ -411,7 +411,7 @@ void func_80C2075C(EnHintSkb* this) {
 }
 
 void func_80C2077C(EnHintSkb* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_3E0 = 1;
         if (this->unk_3DC == 0) {
             this->unk_3DC = 1;

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -691,7 +691,7 @@ s32 EnHorse_PlayerCanMove(EnHorse* this, PlayState* play) {
     if ((player->stateFlags1 & PLAYER_STATE1_1) || (func_800B7128(GET_PLAYER(play)) == true) ||
         (player->stateFlags1 & PLAYER_STATE1_100000) ||
         (((this->stateFlags & ENHORSE_FLAG_19) || (this->stateFlags & ENHORSE_FLAG_29)) && !this->inRace) ||
-        (this->action == ENHORSE_ACTION_HBA) || (player->actor.flags & ACTOR_FLAG_TALK_REQUESTED) ||
+        (this->action == ENHORSE_ACTION_HBA) || (player->actor.flags & ACTOR_FLAG_TALK) ||
         (play->csCtx.state != CS_STATE_IDLE) || (CutsceneManager_GetCurrentCsId() != CS_ID_NONE) ||
         (player->stateFlags1 & PLAYER_STATE1_20) || (player->csAction != PLAYER_CSACTION_NONE)) {
         return false;
@@ -1662,7 +1662,7 @@ void EnHorse_Reverse(EnHorse* this, PlayState* play) {
         } else if (stickMag < 10.0f) {
             stickAngle = -0x7FFF;
         }
-    } else if ((player->actor.flags & ACTOR_FLAG_TALK_REQUESTED) || (play->csCtx.state != CS_STATE_IDLE) ||
+    } else if ((player->actor.flags & ACTOR_FLAG_TALK) || (play->csCtx.state != CS_STATE_IDLE) ||
                (CutsceneManager_GetCurrentCsId() != CS_ID_NONE) || (player->stateFlags1 & PLAYER_STATE1_20)) {
         EnHorse_StartMountedIdleResetAnim(this);
         this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_Hs/z_en_hs.c
+++ b/src/overlays/actors/ovl_En_Hs/z_en_hs.c
@@ -253,7 +253,7 @@ void func_809533A0(EnHs* this, PlayState* play) {
 }
 
 void func_8095345C(EnHs* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80953180;
         func_809533A0(this, play);
         if (this->stateFlags & 8) {

--- a/src/overlays/actors/ovl_En_Ig/z_en_ig.c
+++ b/src/overlays/actors/ovl_En_Ig/z_en_ig.c
@@ -440,7 +440,7 @@ s32 func_80BF19A0(EnIg* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_3D0 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_3D0, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_3F6 = 0;
         this->unk_3F8 = NULL;

--- a/src/overlays/actors/ovl_En_In/z_en_in.c
+++ b/src/overlays/actors/ovl_En_In/z_en_in.c
@@ -348,7 +348,7 @@ void func_808F395C(EnIn* this, PlayState* play) {
     if (this->unk4B0 == WEEKEVENTREG_HORSE_RACE_STATE_END) {
         this->actionFunc = func_808F5A94;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = func_808F5A34;
         this->unk48C = 1;
@@ -400,7 +400,7 @@ void func_808F39DC(EnIn* this, PlayState* play) {
 }
 
 void func_808F3AD4(EnIn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->unk48C = 1;
         this->actionFunc = func_808F5A94;
@@ -424,7 +424,7 @@ void func_808F3B40(EnIn* this, PlayState* play) {
 }
 
 void func_808F3BD4(EnIn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->unk48C = 1;
         this->actionFunc = func_808F5A94;
@@ -448,7 +448,7 @@ void func_808F3C40(EnIn* this, PlayState* play) {
 }
 
 void func_808F3CD4(EnIn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->unk48C = 1;
         this->actionFunc = func_808F5A94;
@@ -1352,7 +1352,7 @@ s32 func_808F5728(PlayState* play, EnIn* this, s32 arg2, s32* arg3) {
         *arg3 = 1;
         return 0;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         *arg3 = 1;
         return 1;
     }

--- a/src/overlays/actors/ovl_En_Ja/z_en_ja.c
+++ b/src/overlays/actors/ovl_En_Ja/z_en_ja.c
@@ -137,7 +137,7 @@ s32 func_80BC19FC(EnJa* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_340 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_340, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->actionFunc = func_80BC22F4;
         ret = true;

--- a/src/overlays/actors/ovl_En_Jg/z_en_jg.c
+++ b/src/overlays/actors/ovl_En_Jg/z_en_jg.c
@@ -351,7 +351,7 @@ void EnJg_Idle(EnJg* this, PlayState* play) {
 }
 
 void EnJg_GoronShrineIdle(EnJg* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->flags |= FLAG_LOOKING_AT_PLAYER;
         Message_StartTextbox(play, this->textId, &this->actor);
         this->actionFunc = EnJg_GoronShrineTalk;
@@ -594,7 +594,7 @@ void EnJg_FrozenIdle(EnJg* this, PlayState* play) {
             }
         }
     } else {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             Message_StartTextbox(play, 0x236, &this->actor); // The old Goron is frozen solid!
             this->actionFunc = EnJg_EndFrozenInteraction;
         } else if (this->actor.isLockedOn) {
@@ -904,7 +904,7 @@ void EnJg_CheckIfTalkingToPlayerAndHandleFreezeTimer(EnJg* this, PlayState* play
     s16 curFrame = this->skelAnime.curFrame;
     s16 endFrame = Animation_GetLastFrame(sAnimationInfo[this->animIndex].animation);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->flags |= FLAG_LOOKING_AT_PLAYER;
         this->actor.speed = 0.0f;
 

--- a/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
+++ b/src/overlays/actors/ovl_En_Jgame_Tsn/z_en_jgame_tsn.c
@@ -160,7 +160,7 @@ void func_80C13B74(EnJgameTsn* this) {
 void func_80C13BB8(EnJgameTsn* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->actor.flags & ACTOR_FLAG_10000) {
             this->actor.flags &= ~ACTOR_FLAG_10000;
             if (gSaveContext.timerCurTimes[TIMER_ID_MINIGAME_2] > SECONDS_TO_TIMER(0)) {
@@ -215,7 +215,7 @@ void func_80C13E6C(EnJgameTsn* this) {
 }
 
 void func_80C13E90(EnJgameTsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         if (((gSaveContext.save.time > CLOCK_TIME(4, 0)) && (gSaveContext.save.time < CLOCK_TIME(7, 0))) ||
             ((gSaveContext.save.time > CLOCK_TIME(16, 0)) && (gSaveContext.save.time < CLOCK_TIME(19, 0)))) {
@@ -407,7 +407,7 @@ void func_80C145FC(EnJgameTsn* this) {
 }
 
 void func_80C14610(EnJgameTsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x10A4, &this->actor);
         this->unk_300 = 0x10A4;
         func_80C14030(this);

--- a/src/overlays/actors/ovl_En_Js/z_en_js.c
+++ b/src/overlays/actors/ovl_En_Js/z_en_js.c
@@ -485,19 +485,19 @@ void func_80969400(s32 arg0) {
 void func_80969494(EnJs* this, PlayState* play) {
     func_80968A5C(this);
     Message_CloseTextbox(play);
-    this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+    this->actor.flags &= ~ACTOR_FLAG_TALK;
     this->actionFunc = func_80969B5C;
 }
 
 void func_809694E8(EnJs* this, PlayState* play) {
     Message_CloseTextbox(play);
-    this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+    this->actor.flags &= ~ACTOR_FLAG_TALK;
     this->actionFunc = func_8096A104;
 }
 
 void func_80969530(EnJs* this, PlayState* play) {
     Message_CloseTextbox(play);
-    this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+    this->actor.flags &= ~ACTOR_FLAG_TALK;
     this->actionFunc = func_8096A6F4;
     if ((this->actor.home.rot.y == this->actor.shape.rot.y) && (this->unk_2B8 & 0x10)) {
         Animation_Change(&this->skelAnime, &gMoonChildGettingUpAnim, -1.0f,
@@ -686,7 +686,7 @@ void func_80969B5C(EnJs* this, PlayState* play) {
             }
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80969898;
         this->actor.speed = 0.0f;
         this->unk_2B4 = 0.0f;
@@ -865,7 +865,7 @@ void func_8096A080(EnJs* this, PlayState* play) {
 
 void func_8096A104(EnJs* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80969DA4;
         func_8096A080(this, play);
     } else if (func_80968DD0(this, play)) {
@@ -890,7 +890,7 @@ void func_8096A1E8(EnJs* this, PlayState* play) {
     if (SkelAnime_Update(&this->skelAnime)) {
         Animation_MorphToLoop(&this->skelAnime, &gMoonChildStandingAnim, 0.0f);
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = func_8096A38C;
         Message_StartTextbox(play, 0x2208, &this->actor);
@@ -1055,7 +1055,7 @@ void func_8096A6F4(EnJs* this, PlayState* play) {
         Animation_MorphToLoop(&this->skelAnime, &gMoonChildSittingAnim, -10.0f);
         this->unk_2B8 &= ~8;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_8096A38C;
         this->unk_2B8 &= ~2;
         func_8096A184(this, play);

--- a/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
+++ b/src/overlays/actors/ovl_En_Kakasi/z_en_kakasi.c
@@ -327,7 +327,7 @@ void EnKakasi_TimeSkipDialogue(EnKakasi* this, PlayState* play) {
                 this->picto.actor.flags |= ACTOR_FLAG_10000;
             }
 
-            if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+            if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
                 player->stateFlags1 &= ~PLAYER_STATE1_20;
                 this->unkState196 = 2;
                 this->picto.actor.flags &= ~ACTOR_FLAG_10000;
@@ -356,7 +356,7 @@ void EnKakasi_IdleStanding(EnKakasi* this, PlayState* play) {
         EnKakasi_SetupSongTeach(this, play);
         return;
     }
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->skelAnime.playSpeed = 1.0f;
         EnKakasi_SetupDialogue(this);
         return;
@@ -1111,7 +1111,7 @@ void EnKakasi_SetupIdleRisen(EnKakasi* this) {
 
 void EnKakasi_IdleRisen(EnKakasi* this, PlayState* play) {
     Math_SmoothStepToS(&this->picto.actor.shape.rot.y, this->picto.actor.yawTowardsPlayer, 5, 1000, 0);
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnKakasi_RisenDialogue;
     } else {
         Actor_OfferTalk(&this->picto.actor, play, 70.0f);

--- a/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
+++ b/src/overlays/actors/ovl_En_Kanban/z_en_kanban.c
@@ -184,7 +184,7 @@ void func_80954BE8(EnKanban* this, PlayState* play) {
         if (this->msgTimer == 0) {
             yaw = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
             if (ABS_ALT(yaw) < 0x2800) {
-                if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+                if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                     this->msgFlag = true;
                 } else {
                     Actor_OfferTalk(&this->actor, play, 68.0f);

--- a/src/overlays/actors/ovl_En_Kbt/z_en_kbt.c
+++ b/src/overlays/actors/ovl_En_Kbt/z_en_kbt.c
@@ -281,7 +281,7 @@ void func_80B3415C(EnKbt* this) {
 void func_80B34314(EnKbt* this, PlayState* play) {
     func_80B34078(this);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B34598;
         Actor_ChangeFocus(&this->actor, play, this->unk_278);
         this->unk_278->textId = this->actor.textId;

--- a/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.c
+++ b/src/overlays/actors/ovl_En_Kendo_Js/z_en_kendo_js.c
@@ -168,7 +168,7 @@ void func_80B2654C(EnKendoJs* this, PlayState* play) {
     s32 phi_v0;
     s32 sp30;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (CURRENT_DAY != 0) {
             sp30 = CURRENT_DAY - 1;
         } else {
@@ -514,7 +514,7 @@ void func_80B27030(EnKendoJs* this, PlayState* play) {
 
     if (EnKendoJs_MovePlayerToPos(play, sp20)) {
         this->actor.flags |= ACTOR_FLAG_10000;
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actor.flags &= ~ACTOR_FLAG_10000;
             player->stateFlags1 &= ~PLAYER_STATE1_20;
             func_80B279F0(this, play, 0);
@@ -686,7 +686,7 @@ void func_80B27760(EnKendoJs* this) {
 void func_80B27774(EnKendoJs* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_63_20)) {
             SET_WEEKEVENTREG(WEEKEVENTREG_63_20);
             Message_StartTextbox(play, 0x272F, &this->actor);

--- a/src/overlays/actors/ovl_En_Kgy/z_en_kgy.c
+++ b/src/overlays/actors/ovl_En_Kgy/z_en_kgy.c
@@ -489,7 +489,7 @@ void func_80B417B8(EnKgy* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_5) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
         func_80B413C8(this);
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         this->actionFunc = func_80B419B0;
         func_80B40E18(this, 7);
     }
@@ -517,7 +517,7 @@ void func_80B418C4(EnKgy* this, PlayState* play) {
         func_80B413C8(this);
         CutsceneManager_Queue(this->csIdList[5]);
         this->actionFunc = func_80B41858;
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
     }
     func_80B40EE8(this, play);
 }
@@ -527,7 +527,7 @@ void func_80B419B0(EnKgy* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     func_80B4163C(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
         func_80B411DC(this, play, 4);
         func_80B40E18(this, this->actor.textId);
         if (this->actor.textId == 0xC37) {
@@ -604,14 +604,14 @@ void func_80B41C54(EnKgy* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     if (Actor_TextboxIsClosing(&this->actor, play)) {
         this->actionFunc = func_80B41C30;
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
     }
     func_80B40EE8(this, play);
 }
 
 void func_80B41CBC(EnKgy* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         func_80B40E18(this, this->actor.textId);
         this->actionFunc = func_80B41E18;
@@ -877,7 +877,7 @@ void func_80B42508(EnKgy* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     this->actor.focus.pos = this->unk_2A8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
         this->actionFunc = func_80B41E18;
         func_80B411DC(this, play, 4);
         func_80B40E18(this, this->actor.textId);
@@ -887,7 +887,7 @@ void func_80B42508(EnKgy* this, PlayState* play) {
 void func_80B425A0(EnKgy* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     this->actor.focus.pos = this->unk_2A8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B41E18;
         EnKgy_ChangeAnimLoopMorph(this, ENKGY_ANIM_1);
         func_80B411DC(this, play, 0);
@@ -903,7 +903,7 @@ void func_80B42660(EnKgy* this, PlayState* play) {
     if ((Message_GetState(&play->msgCtx) == TEXT_STATE_5) && Message_ShouldAdvance(play)) {
         Message_CloseTextbox(play);
         func_80B413C8(this);
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         this->actionFunc = func_80B42714;
         func_80B40E18(this, 7);
     }
@@ -916,7 +916,7 @@ void func_80B42714(EnKgy* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
     this->actor.focus.pos = this->unk_2A8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state) || (&this->actor == player->talkActor)) {
         func_80B411DC(this, play, 4);
         func_80B40E18(this, this->actor.textId);
         if (this->actor.textId == 0xC37) {
@@ -985,7 +985,7 @@ void func_80B4296C(EnKgy* this, PlayState* play) {
     }
 
     this->actor.focus.pos = this->unk_2A8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B427C8;
         if (this->animIndex == ENKGY_ANIM_4) {
             EnKgy_ChangeAnimLoopMorph(this, ENKGY_ANIM_7);
@@ -1100,7 +1100,7 @@ void func_80B42D28(EnKgy* this, PlayState* play) {
     }
 
     this->actor.focus.pos = this->unk_2A8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B42A8C;
         if (this->actor.textId == 0xC2D) {
             EnKgy_ChangeAnimLoopMorph(this, ENKGY_ANIM_1);

--- a/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.c
+++ b/src/overlays/actors/ovl_En_Kujiya/z_en_kujiya.c
@@ -82,7 +82,7 @@ void EnKujiya_SetupWait(EnKujiya* this) {
 }
 
 void EnKujiya_Wait(EnKujiya* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if ((gSaveContext.save.time >= CLOCK_TIME(6, 0)) && (gSaveContext.save.time < CLOCK_TIME(18, 0))) {
             if (EnKujiya_CheckBoughtTicket()) {
                 Message_StartTextbox(play, 0x2B61, &this->actor);

--- a/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.c
+++ b/src/overlays/actors/ovl_En_Lift_Nuts/z_en_lift_nuts.c
@@ -383,7 +383,7 @@ void EnLiftNuts_Idle(EnLiftNuts* this, PlayState* play) {
     } else if (this->actor.xzDistToPlayer > 120.0f) {
         EnLiftNuts_SetupBurrow(this);
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (GET_PLAYER_FORM == PLAYER_FORM_DEKU) {
             if (EnLiftNuts_MinigameState(ENLIFTNUTS_MINIGAME_STATE_MODE_CHECK, ENLIFTNUTS_MINIGAME_STATE_NONE)) {
                 switch (CURRENT_DAY) {
@@ -944,7 +944,7 @@ void EnLiftNuts_SetupResumeConversation(EnLiftNuts* this) {
  * Resumes the current conversation after giving player the reward for winning the minigame.
  */
 void EnLiftNuts_ResumeConversation(EnLiftNuts* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_WON_DEKU_PLAYGROUND_DAY_1) &&
             CHECK_WEEKEVENTREG(WEEKEVENTREG_WON_DEKU_PLAYGROUND_DAY_2) && (CURRENT_DAY == 3)) {
             Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, ENLIFTNUTS_ANIM_SHOCKED_END);

--- a/src/overlays/actors/ovl_En_Ma4/z_en_ma4.c
+++ b/src/overlays/actors/ovl_En_Ma4/z_en_ma4.c
@@ -370,7 +370,7 @@ void EnMa4_Wait(EnMa4* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnMa4_StartDialogue(this, play);
         EnMa4_SetupDialogueHandler(this);
     } else if (this->type != MA4_TYPE_ALIENS_WON || ABS_ALT(yaw) < 0x4000) {
@@ -703,7 +703,7 @@ void EnMa4_BeginHorsebackGame(EnMa4* this, PlayState* play) {
 }
 
 void EnMa4_HorsebackGameCheckPlayerInteractions(EnMa4* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         // "You're feeling confident"
         Message_StartTextbox(play, 0x336E, &this->actor);
         this->actionFunc = EnMa4_HorsebackGameTalking;
@@ -880,7 +880,7 @@ void EnMa4_EndEponasSongCs(EnMa4* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     this->actor.flags |= ACTOR_FLAG_10000;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         player->stateFlags1 &= ~PLAYER_STATE1_20;
         Message_StartTextbox(play, 0x334C, &this->actor);
         this->textId = 0x334C;

--- a/src/overlays/actors/ovl_En_Ma_Yto/z_en_ma_yto.c
+++ b/src/overlays/actors/ovl_En_Ma_Yto/z_en_ma_yto.c
@@ -431,7 +431,7 @@ void EnMaYto_DefaultWait(EnMaYto* this, PlayState* play) {
         EnMaYto_ChangeAnim(this, CREMIA_ANIM_11);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnMaYto_DefaultStartDialogue(this, play);
         EnMaYto_SetupDefaultDialogueHandler(this);
     } else if (ABS_ALT(direction) < 0x1555) {
@@ -543,13 +543,13 @@ void EnMaYto_SetupDinnerWait(EnMaYto* this) {
 void EnMaYto_DinnerWait(EnMaYto* this, PlayState* play) {
     s16 direction = this->actor.shape.rot.y - this->actor.yawTowardsPlayer;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnMaYto_DinnerStartDialogue(this, play);
         EnMaYto_SetupDinnerDialogueHandler(this);
     } else {
         Actor* child = this->actor.child;
 
-        if ((child != NULL) && Actor_ProcessTalkRequest(child, &play->state)) {
+        if ((child != NULL) && Actor_TalkOfferAccepted(child, &play->state)) {
             Actor_ChangeFocus(&this->actor, play, &this->actor);
             EnMaYto_DinnerStartDialogue(this, play);
             EnMaYto_SetupDinnerDialogueHandler(this);
@@ -740,13 +740,13 @@ void EnMaYto_BarnWait(EnMaYto* this, PlayState* play) {
     s16 direction = this->actor.shape.rot.y + 0x471C;
 
     direction -= this->actor.yawTowardsPlayer;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnMaYto_BarnStartDialogue(this, play);
         EnMaYto_SetupBarnDialogueHandler(this);
     } else {
         Actor* child = this->actor.child;
 
-        if ((child != NULL) && Actor_ProcessTalkRequest(child, &play->state)) {
+        if ((child != NULL) && Actor_TalkOfferAccepted(child, &play->state)) {
             Actor_ChangeFocus(&this->actor, play, &this->actor);
             EnMaYto_BarnStartDialogue(this, play);
             EnMaYto_SetupBarnDialogueHandler(this);
@@ -922,7 +922,7 @@ void EnMaYto_SetupAfterMilkRunInit(EnMaYto* this) {
 void EnMaYto_AfterMilkRunInit(EnMaYto* this, PlayState* play) {
     this->actor.flags |= ACTOR_FLAG_10000;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
 
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_ESCORTED_CREMIA)) {
@@ -1013,7 +1013,7 @@ void EnMaYto_SetupPostMilkRunExplainReward(EnMaYto* this) {
 }
 
 void EnMaYto_PostMilkRunExplainReward(EnMaYto* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->unk310 == 1) {
             // Romani's mask explanation
             EnMaYto_SetFaceExpression(this, 0, 1);

--- a/src/overlays/actors/ovl_En_Ma_Yts/z_en_ma_yts.c
+++ b/src/overlays/actors/ovl_En_Ma_Yts/z_en_ma_yts.c
@@ -328,7 +328,7 @@ void EnMaYts_SetupStartDialogue(EnMaYts* this) {
 void EnMaYts_StartDialogue(EnMaYts* this, PlayState* play) {
     s16 sp26 = this->actor.shape.rot.y - this->actor.yawTowardsPlayer;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (GET_PLAYER_FORM != PLAYER_FORM_HUMAN) {
             if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_65_80)) {
                 // Saying to non-human Link: "Cremia went to town."

--- a/src/overlays/actors/ovl_En_Minifrog/z_en_minifrog.c
+++ b/src/overlays/actors/ovl_En_Minifrog/z_en_minifrog.c
@@ -324,7 +324,7 @@ void EnMinifrog_Idle(EnMinifrog* this, PlayState* play) {
     EnMinifrog_TurnToPlayer(this);
     EnMinifrog_Jump(this);
     EnMinifrog_JumpTimer(this);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnMinifrog_ReturnFrogCutscene;
         if (this->actor.csId != CS_ID_NONE) {
             this->flags |= 1;
@@ -472,7 +472,7 @@ void EnMinifrog_BeginChoirCutscene(EnMinifrog* this, PlayState* play) {
 void EnMinifrog_EndChoir(EnMinifrog* this, PlayState* play) {
     EnMinifrog_TurnToPlayer(this);
     EnMinifrog_Jump(this);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0xD7E, &this->actor);
         this->actionFunc = EnMinifrog_YellowFrogDialog;
     } else {
@@ -576,7 +576,7 @@ void EnMinifrog_SetupYellowFrogDialog(EnMinifrog* this, PlayState* play) {
     EnMinifrog_TurnToPlayer(this);
     EnMinifrog_Jump(this);
     EnMinifrog_JumpTimer(this);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnMinifrog_YellowFrogDialog;
         if (!CHECK_WEEKEVENTREG(WEEKEVENTREG_34_01)) {
             Message_StartTextbox(play, 0xD76, &this->actor);

--- a/src/overlays/actors/ovl_En_Mk/z_en_mk.c
+++ b/src/overlays/actors/ovl_En_Mk/z_en_mk.c
@@ -204,7 +204,7 @@ void func_80959774(EnMk* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 3, 0x400, 0x80);
     this->actor.world.rot.y = this->actor.shape.rot.y;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80959624(this, play);
         this->actionFunc = func_809596A0;
     } else if ((this->actor.xzDistToPlayer < 120.0f) && Player_IsFacingActor(&this->actor, 0x3000, play)) {
@@ -376,7 +376,7 @@ void func_80959A24(EnMk* this, PlayState* play) {
 }
 
 void func_80959C94(EnMk* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80959A24;
         this->unk_27A &= ~2;
         Message_StartTextbox(play, 0xFB3, &this->actor);
@@ -436,7 +436,7 @@ void func_80959E18(EnMk* this, PlayState* play) {
             this->actor.csId = this->csIdList[1];
         }
         CutsceneManager_Queue(this->actor.csId);
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80959844(this, play);
         this->actionFunc = func_80959A24;
         this->unk_27A |= 1;

--- a/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
+++ b/src/overlays/actors/ovl_En_Mm2/z_en_mm2.c
@@ -68,7 +68,7 @@ void EnMm2_Reading(EnMm2* this, PlayState* play) {
  * so (and facing the letter).
  */
 void EnMm2_WaitForRead(EnMm2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x277B, &this->actor);
         this->actionFunc = EnMm2_Reading;
     } else if ((this->actor.xzDistToPlayer < 60.0f) && Player_IsFacingActor(&this->actor, 0x3000, play)) {

--- a/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
+++ b/src/overlays/actors/ovl_En_Mm3/z_en_mm3.c
@@ -139,7 +139,7 @@ void func_80A6F270(EnMm3* this) {
 }
 
 void func_80A6F2C8(EnMm3* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x278A, &this->actor);
         this->unk_2B4 = 0x278A;
         func_80A6F9C8(this);
@@ -418,7 +418,7 @@ void func_80A6FBFC(EnMm3* this, PlayState* play) {
         gSaveContext.postmanTimerStopOsTime = osGetTime();
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         AudioSfx_MuteBanks(0);
         Audio_SetMainBgmVolume(0x7F, 5);
         Message_StartTextbox(play, 0x2791, &this->actor);
@@ -464,7 +464,7 @@ void func_80A6FED8(EnMm3* this) {
 void func_80A6FEEC(EnMm3* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         player->stateFlags1 &= ~PLAYER_STATE1_20;
         Message_StartTextbox(play, 0x2794, &this->actor);
         this->unk_2B4 = 0x2794;

--- a/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
+++ b/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
@@ -768,7 +768,7 @@ void func_80AB64B8(EnMnk* this, PlayState* play) {
         Math_SmoothStepToS(&this->picto.actor.shape.rot.y, this->picto.actor.world.rot.y, 2, 0xBB8, 0xC8);
     }
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->picto.actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = func_80AB63CC;
         EnMnk_Monkey_ChangeAnim(this, 9, ANIMMODE_ONCE, -5.0f);
@@ -876,7 +876,7 @@ void EnMnk_Monkey_WaitToTalkAfterRun(EnMnk* this, PlayState* play) {
     this->picto.actor.shape.rot.y = this->picto.actor.yawTowardsPlayer;
     this->picto.actor.world.rot.y = this->picto.actor.yawTowardsPlayer;
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         Animation_PlayOnce(&this->skelAnime, &object_mnk_Anim_009CC0);
         this->actionFunc = EnMnk_Monkey_TalkAfterRun;
         this->flags &= ~MONKEY_FLAGS_4;
@@ -1057,7 +1057,7 @@ void EnMnk_Monkey_WaitToTalkAfterApproach(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     EnMnk_Monkey_MoveRelativeToPlayer(this, play);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         if (MONKEY_GET_TYPE(&this->picto.actor) == MONKEY_OUTSIDECHAMBER) {
             EnMnk_Monkey_SetAnim(this, 2);
         } else {
@@ -1451,7 +1451,7 @@ void EnMnk_MonkeyTiedUp_WaitUnused(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     SkelAnime_Update(&this->propSkelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_MonkeyTiedUp_TalkUnused;
         this->unk_3E0 = 0;
     } else if (EnMnk_PlayerIsInTalkRange(this, play)) {
@@ -1502,7 +1502,7 @@ void EnMnk_MonkeyTiedUp_WaitForInstrument(EnMnk* this, PlayState* play) {
         this->picto.actor.csId = this->csIdList[0];
         Message_StartTextbox(play, this->picto.actor.textId, NULL);
         CutsceneManager_Queue(this->picto.actor.csId);
-    } else if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_MonkeyTiedUp_TransitionAfterTalk;
         EnMnk_MonkeyTiedUp_SetAnim(this, MONKEY_TIEDUP_ANIM_KICKAROUND);
     } else if (EnMnk_PlayerIsInTalkRange(this, play)) {
@@ -1516,7 +1516,7 @@ void EnMnk_MonkeyTiedUp_TalkAfterCutRope(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     SkelAnime_Update(&this->propSkelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_MonkeyTiedUp_TransitionAfterTalk;
         this->picto.actor.flags &= ~ACTOR_FLAG_10000;
     } else {
@@ -1528,7 +1528,7 @@ void EnMnk_MonkeyTiedUp_WaitForCutRope(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     SkelAnime_Update(&this->propSkelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         if ((gSaveContext.save.playerForm == PLAYER_FORM_FIERCE_DEITY) ||
             (gSaveContext.save.playerForm == PLAYER_FORM_HUMAN)) {
             EnMnk_MonkeyTiedUp_SetAnim(this, MONKEY_TIEDUP_ANIM_SHH);
@@ -1579,7 +1579,7 @@ void EnMnk_MonkeyTiedUp_Wait(EnMnk* this, PlayState* play) {
         this->picto.actor.csId = this->csIdList[2];
         play->msgCtx.ocarinaMode = OCARINA_MODE_END;
         CutsceneManager_Queue(this->csIdList[2]);
-    } else if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         if (gSaveContext.save.playerForm == PLAYER_FORM_DEKU) {
             if (this->picto.actor.textId == 0x8EC) {
                 EnMnk_MonkeyTiedUp_SetAnim(this, MONKEY_TIEDUP_ANIM_SHAKEHEAD);
@@ -1718,7 +1718,7 @@ void EnMnk_MonkeyHanging_WaitAfterDunk(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     SkelAnime_Update(&this->propSkelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_MonkeyHanging_Plead;
         CutsceneManager_Queue(this->picto.actor.csId);
         SET_WEEKEVENTREG(WEEKEVENTREG_83_08);
@@ -1788,7 +1788,7 @@ void EnMnk_MonkeyHanging_StruggleBeforeDunk(EnMnk* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
     SkelAnime_Update(&this->propSkelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_MonkeyHanging_Plead;
         CutsceneManager_Queue(this->picto.actor.csId);
         SET_WEEKEVENTREG(WEEKEVENTREG_83_08);
@@ -1861,7 +1861,7 @@ void EnMnk_Monkey_SetupTalkBeforeGuideThroughWoods(EnMnk* this) {
 
 void EnMnk_Monkey_WaitToGuideThroughWoods(EnMnk* this, PlayState* play) {
     func_80AB5F6C(this);
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         EnMnk_Monkey_SetupTalkBeforeGuideThroughWoods(this);
     } else if (this->picto.actor.isLockedOn || (this->picto.actor.xzDistToPlayer < 100.0f)) {
         Actor_OfferTalk(&this->picto.actor, play, 120.0f);
@@ -1903,7 +1903,7 @@ void EnMnk_Monkey_WaitToTalkAfterSaved(EnMnk* this, PlayState* play) {
     this->picto.actor.world.rot.y = this->picto.actor.yawTowardsPlayer;
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = EnMnk_Monkey_TalkAfterSaved;
         EnMnk_Monkey_SetAnim(this, 7);
     } else if ((this->picto.actor.xzDistToPlayer < 100.0f) && Player_IsFacingActor(&this->picto.actor, 0x3000, play)) {

--- a/src/overlays/actors/ovl_En_Ms/z_en_ms.c
+++ b/src/overlays/actors/ovl_En_Ms/z_en_ms.c
@@ -88,7 +88,7 @@ void EnMs_Wait(EnMs* this, PlayState* play) {
         this->actor.textId = 0x932;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnMs_Talk;
     } else if ((this->actor.xzDistToPlayer < 90.0f) && (ABS_ALT(yawDiff) < 0x2000)) {
         Actor_OfferTalk(&this->actor, play, 90.0f);
@@ -157,7 +157,7 @@ void EnMs_Sell(EnMs* this, PlayState* play) {
 }
 
 void EnMs_TalkAfterPurchase(EnMs* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_ContinueTextbox(play, 0x936);
         this->actionFunc = EnMs_Talk;
     } else {

--- a/src/overlays/actors/ovl_En_Muto/z_en_muto.c
+++ b/src/overlays/actors/ovl_En_Muto/z_en_muto.c
@@ -162,7 +162,7 @@ void EnMuto_Idle(EnMuto* this, PlayState* play) {
         this->actor.textId = 0x2363;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnMuto_SetupDialogue(this, play);
         return;
     }

--- a/src/overlays/actors/ovl_En_Nb/z_en_nb.c
+++ b/src/overlays/actors/ovl_En_Nb/z_en_nb.c
@@ -401,7 +401,7 @@ s32 func_80BC04FC(EnNb* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->stateFlags & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->stateFlags |= EN_NB_FLAG_20;
         SubS_SetOfferMode(&this->stateFlags, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->behaviour = ENNB_BEHAVIOUR_0;

--- a/src/overlays/actors/ovl_En_Nnh/z_en_nnh.c
+++ b/src/overlays/actors/ovl_En_Nnh/z_en_nnh.c
@@ -76,7 +76,7 @@ void EnNnh_SetupWaitForDialogue(EnNnh* this) {
 }
 
 void EnNnh_WaitForDialogue(EnNnh* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x228, &this->actor);
         EnNnh_SetupDialogue(this);
     } else {

--- a/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
+++ b/src/overlays/actors/ovl_En_Onpuman/z_en_onpuman.c
@@ -151,7 +151,7 @@ void func_80B121D8(EnOnpuman* this, PlayState* play) {
         this->actionFunc = func_80B1202C;
         Message_StartTextbox(play, 0x8D4, NULL);
         this->unk_2A0 = func_80B11F44(play);
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B1217C;
     } else {
         yaw = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;

--- a/src/overlays/actors/ovl_En_Osn/z_en_osn.c
+++ b/src/overlays/actors/ovl_En_Osn/z_en_osn.c
@@ -722,14 +722,14 @@ void EnOsn_Idle(EnOsn* this, PlayState* play) {
 
     if ((gSaveContext.save.saveInfo.inventory.items[SLOT_OCARINA] != ITEM_NONE) &&
         !CHECK_QUEST_ITEM(QUEST_SONG_HEALING)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actionFunc = EnOsn_StartCutscene;
         } else if (((this->actor.xzDistToPlayer < 100.0f) || this->actor.isLockedOn) && (yaw < 0x4000) &&
                    (yaw > -0x4000)) {
             Actor_OfferTalkNearColChkInfoCylinder(&this->actor, play);
             this->actor.textId = 0xFFFF;
         }
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->textId = EnOsn_GetInitialText(this, play);
         Message_StartTextbox(play, this->textId, &this->actor);
         this->actionFunc = EnOsn_Talk;

--- a/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
+++ b/src/overlays/actors/ovl_En_Ossan/z_en_ossan.c
@@ -303,7 +303,7 @@ void EnOssan_UpdateCursorPos(PlayState* play, EnOssan* this) {
 void EnOssan_EndInteraction(PlayState* play, EnOssan* this) {
     Player* player = GET_PLAYER(play);
 
-    Actor_ProcessTalkRequest(&this->actor, &play->state);
+    Actor_TalkOfferAccepted(&this->actor, &play->state);
     play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     play->msgCtx.stateTimer = 4;
     Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
@@ -369,7 +369,7 @@ void EnOssan_Idle(EnOssan* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     SubS_UpdateFidgetTables(play, this->fidgetTableY, this->fidgetTableZ, ENOSSAN_LIMB_MAX);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         player->stateFlags2 |= PLAYER_STATE2_20000000;
         EnOssan_SetupAction(this, EnOssan_BeginInteraction);
         if (this->cutsceneState == ENOSSAN_CUTSCENESTATE_STOPPED) {
@@ -1197,7 +1197,7 @@ void EnOssan_ItemPurchased(EnOssan* this, PlayState* play) {
             CutsceneManager_Queue(this->csId);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_ContinueTextbox(play, 0x642);
     } else {
         Actor_OfferTalkExchangeEquiCylinder(&this->actor, play, 400.0f, PLAYER_IA_MINUS1);

--- a/src/overlays/actors/ovl_En_Ot/z_en_ot.c
+++ b/src/overlays/actors/ovl_En_Ot/z_en_ot.c
@@ -534,7 +534,7 @@ void func_80B5C6DC(EnOt* this, PlayState* play) {
     if (CHECK_WEEKEVENTREG(WEEKEVENTREG_84_10) && (this->type == SEAHORSE_TYPE_1)) {
         this->actor.textId = 0;
         this->unk_384 = 1;
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->unk_3A0 = BINANG_ADD(sp3E, 0x4000);
             this->unk_360->unk_3A0 = this->unk_3A0;
             func_80B5C9A8(this, play);
@@ -616,7 +616,7 @@ void func_80B5CBA0(EnOt* this, PlayState* play) {
 }
 
 void func_80B5CBEC(EnOt* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         func_80B5CC88(this, play);
     } else {
@@ -694,7 +694,7 @@ void func_80B5CEC8(EnOt* this, PlayState* play) {
     s32 pad;
 
     this->actor.textId = 0;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80B5D114(this, play);
         return;
     }

--- a/src/overlays/actors/ovl_En_Owl/z_en_owl.c
+++ b/src/overlays/actors/ovl_En_Owl/z_en_owl.c
@@ -224,7 +224,7 @@ void func_8095A920(EnOwl* this, PlayState* play) {
 }
 
 s32 func_8095A978(EnOwl* this, PlayState* play, u16 textId, f32 targetDist, f32 arg4) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         return true;
     }
 
@@ -238,7 +238,7 @@ s32 func_8095A978(EnOwl* this, PlayState* play, u16 textId, f32 targetDist, f32 
 }
 
 s32 func_8095A9FC(EnOwl* this, PlayState* play, u16 textId) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         return true;
     }
 
@@ -506,7 +506,7 @@ void func_8095B480(EnOwl* this, PlayState* play) {
 
 void func_8095B574(EnOwl* this, PlayState* play) {
     func_8095A920(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_8095BA84;
         Audio_PlayFanfare(NA_BGM_OWL);
         this->actionFlags |= 0x40;
@@ -734,7 +734,7 @@ void func_8095BA84(EnOwl* this, PlayState* play) {
 
 void func_8095BE0C(EnOwl* this, PlayState* play) {
     func_8095A920(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_8095BA84;
         Audio_PlayFanfare(NA_BGM_OWL);
         this->csIdIndex = 1;

--- a/src/overlays/actors/ovl_En_Pamera/z_en_pamera.c
+++ b/src/overlays/actors/ovl_En_Pamera/z_en_pamera.c
@@ -597,7 +597,7 @@ void func_80BD9938(EnPamera* this) {
 }
 
 void func_80BD994C(EnPamera* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (Player_GetMask(play) == PLAYER_MASK_GIBDO) {
             func_80BD93CC(this, 0, 1);
             Message_StartTextbox(play, 0x15A8, &this->actor);

--- a/src/overlays/actors/ovl_En_Pm/z_en_pm.c
+++ b/src/overlays/actors/ovl_En_Pm/z_en_pm.c
@@ -1000,7 +1000,7 @@ s32 func_80AF86F0(EnPm* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_356 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_356, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         this->unk_398 = 0;
         this->unk_378 = 0;

--- a/src/overlays/actors/ovl_En_Pst/z_en_pst.c
+++ b/src/overlays/actors/ovl_En_Pst/z_en_pst.c
@@ -281,7 +281,7 @@ s32 EnPst_CheckTalk(EnPst* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->stateFlags & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->stateFlags &= ~0x30;
         if (player->exchangeItemAction == PLAYER_IA_LETTER_TO_KAFEI) {
             this->stateFlags |= 0x10;

--- a/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
+++ b/src/overlays/actors/ovl_En_Rail_Skb/z_en_rail_skb.c
@@ -486,7 +486,7 @@ void func_80B71650(EnRailSkb* this) {
 }
 
 void func_80B716A8(EnRailSkb* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_3FE = 1;
         func_80B71D8C(this, play, func_80B723F8);
         if (!func_80B7285C(this)) {

--- a/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
+++ b/src/overlays/actors/ovl_En_Railgibud/z_en_railgibud.c
@@ -958,7 +958,7 @@ void EnRailgibud_CheckForGibdoMask(EnRailgibud* this, PlayState* play) {
 
 void EnRailgibud_CheckIfTalkingToPlayer(EnRailgibud* this, PlayState* play) {
     if ((this->textId == 0) && (this->type == EN_RAILGIBUD_TYPE_GIBDO)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->isInvincible = true;
             Message_StartTextbox(play, 0x13B2, &this->actor);
             this->textId = 0x13B2;

--- a/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.c
+++ b/src/overlays/actors/ovl_En_Recepgirl/z_en_recepgirl.c
@@ -100,7 +100,7 @@ void EnRecepgirl_Wait(EnRecepgirl* this, PlayState* play) {
         }
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnRecepgirl_SetupTalk(this);
     } else if (Actor_IsFacingPlayer(&this->actor, 0x2000)) {
         Actor_OfferTalk(&this->actor, play, 60.0f);

--- a/src/overlays/actors/ovl_En_Rz/z_en_rz.c
+++ b/src/overlays/actors/ovl_En_Rz/z_en_rz.c
@@ -514,7 +514,7 @@ void func_80BFC3F8(EnRz* this, PlayState* play) {
     }
 
     if (!func_80BFBE70(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actionFunc = func_80BFC078;
 
             if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_10000)) {
@@ -565,7 +565,7 @@ void func_80BFC608(EnRz* this, PlayState* play) {
 void func_80BFC674(EnRz* this, PlayState* play) {
     EnRz_UpdateSkelAnime(this, play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BFC608;
         if (Player_GetMask(play) == PLAYER_MASK_KAMARO) {
             Message_StartTextbox(play, 0x2925, &this->actor);
@@ -604,7 +604,7 @@ void func_80BFC7E0(EnRz* this, PlayState* play) {
         func_80BFB9E4(play, this, EN_RZ_ANIM_WALKING);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BFC728;
         func_80BFB9E4(play, this, EN_RZ_ANIM_THINKING);
         this->actor.speed = 0.0f;
@@ -639,7 +639,7 @@ void EnRz_Walk(EnRz* this, PlayState* play) {
             break;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BFC728;
         func_80BFB9E4(play, this, EN_RZ_ANIM_THINKING);
         this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -1104,7 +1104,7 @@ void EnSGoro_SetupAction(EnSGoro* this, PlayState* play) {
 
 void EnSGoro_WinterShrineGoron_Idle(EnSGoro* this, PlayState* play) {
     if (!EnSGoro_CheckLullaby(this, play) && !EnSGoro_CheckGKBehavior(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actionFlags |= EN_S_GORO_ACTIONFLAG_ENGAGED;
             if (this->actionFlags & EN_S_GORO_ACTIONFLAG_EARSCOVERED) {
                 this->actionFlags |= EN_S_GORO_ACTIONFLAG_EYESOPEN;
@@ -1139,7 +1139,7 @@ void EnSGoro_WinterShrineGoron_Talk(EnSGoro* this, PlayState* play) {
 void EnSGoro_SpringShrineGoron_Idle(EnSGoro* this, PlayState* play) {
     if ((EN_S_GORO_GET_MAIN_TYPE(&this->actor) == EN_S_GORO_TYPE_SHRINE_SPRING_F) ||
         !EnSGoro_UpdateCheerAnimation(this, play)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actionFlags |= EN_S_GORO_ACTIONFLAG_ENGAGED;
             this->textId = EnSGoro_ShrineGoron_NextTextId(this, play);
             Message_StartTextbox(play, this->textId, &this->actor);
@@ -1173,7 +1173,7 @@ void EnSGoro_ShopGoron_Idle(EnSGoro* this, PlayState* play) {
     if (!(this->actionFlags & EN_S_GORO_ACTIONFLAG_ROLLEDUP)) {
         EnSGoro_UpdateToIdleAnimation(this);
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFlags |= EN_S_GORO_ACTIONFLAG_ENGAGED;
         this->textId = EnSGoro_BombshopGoron_NextTextId(this, play);
         if (this->actionFlags & EN_S_GORO_ACTIONFLAG_ROLLEDUP) {
@@ -1267,7 +1267,7 @@ void EnSGoro_ShopGoron_TakePayment(EnSGoro* this, PlayState* play) {
 }
 
 void EnSGoro_ShopGoron_FinishTransaction(EnSGoro* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->textId, &this->actor);
         this->actionFunc = EnSGoro_ShopGoron_Talk;
     } else {
@@ -1276,7 +1276,7 @@ void EnSGoro_ShopGoron_FinishTransaction(EnSGoro* this, PlayState* play) {
 }
 
 void EnSGoro_Sleep(EnSGoro* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x23A, &this->actor);
         this->actionFunc = EnSGoro_SleepTalk;
     } else if (this->actor.isLockedOn) {

--- a/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
+++ b/src/overlays/actors/ovl_En_Scopenuts/z_en_scopenuts.c
@@ -295,7 +295,7 @@ void func_80BCB4DC(EnScopenuts* this, PlayState* play) {
 void func_80BCB52C(EnScopenuts* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 2000, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_33C = func_80BCAF0C(this);
         Message_StartTextbox(play, this->unk_33C, &this->actor);
         this->actionFunc = func_80BCB6D0;
@@ -376,7 +376,7 @@ void func_80BCB90C(EnScopenuts* this, PlayState* play) {
 }
 
 void func_80BCB980(EnScopenuts* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_33C = 0x1637;
         this->unk_328 |= 1;
         Message_StartTextbox(play, this->unk_33C, &this->actor);

--- a/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.c
+++ b/src/overlays/actors/ovl_En_Sekihi/z_en_sekihi.c
@@ -159,7 +159,7 @@ void func_80A44F40(EnSekihi* this, PlayState* play) {
 }
 
 void func_80A450B0(EnSekihi* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         this->actionFunc = func_80A44F40;
     } else if ((this->dyna.actor.xzDistToPlayer < 100.0f) && Player_IsFacingActor(&this->dyna.actor, 0x2600, play)) {
         Actor_OfferTalk(&this->dyna.actor, play, 120.0f);

--- a/src/overlays/actors/ovl_En_Sellnuts/z_en_sellnuts.c
+++ b/src/overlays/actors/ovl_En_Sellnuts/z_en_sellnuts.c
@@ -340,7 +340,7 @@ void func_80ADB544(EnSellnuts* this, PlayState* play) {
 
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 3, 0x7D0, 0);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (Player_GetExchangeItemAction(play) == PLAYER_IA_MOONS_TEAR) {
             player->actor.textId = D_80ADD928[this->unk_33A];
             this->unk_340 = player->actor.textId;
@@ -488,7 +488,7 @@ void func_80ADBBEC(EnSellnuts* this, PlayState* play) {
 }
 
 void func_80ADBC60(EnSellnuts* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->unk_340, &this->actor);
         this->actionFunc = func_80ADB0D8;
     } else {
@@ -697,7 +697,7 @@ void func_80ADC580(EnSellnuts* this, PlayState* play) {
 void func_80ADC5A4(EnSellnuts* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         player->linearVelocity = 0.0f;
         this->actor.flags &= ~ACTOR_FLAG_10000;
         Message_StartTextbox(play, this->unk_340, &this->actor);

--- a/src/overlays/actors/ovl_En_Shn/z_en_shn.c
+++ b/src/overlays/actors/ovl_En_Shn/z_en_shn.c
@@ -291,7 +291,7 @@ s32 func_80AE68F0(EnShn* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_1D8 & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_1D8 &= ~0x180;
         if (player->exchangeItemAction == PLAYER_IA_PICTOGRAPH_BOX) {
             this->unk_1D8 |= 0x80;

--- a/src/overlays/actors/ovl_En_Skb/z_en_skb.c
+++ b/src/overlays/actors/ovl_En_Skb/z_en_skb.c
@@ -317,7 +317,7 @@ void func_80994E94(EnSkb* this, PlayState* play) {
 }
 
 void func_80994F7C(EnSkb* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_3E2 = 1;
         if (this->unk_3E0 == 1) {
             Message_StartTextbox(play, 0x13F8, &this->actor);
@@ -338,7 +338,7 @@ void func_8099504C(EnSkb* this) {
 }
 
 void func_80995068(EnSkb* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_3E2 = 1;
         if (this->unk_3E0 == 1) {
             Message_StartTextbox(play, 0x13F8, &this->actor);

--- a/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
+++ b/src/overlays/actors/ovl_En_Sob1/z_en_sob1.c
@@ -465,7 +465,7 @@ void EnSob1_EndInteraction(PlayState* play, EnSob1* this) {
         CutsceneManager_Stop(this->csId);
         this->cutsceneState = ENSOB1_CUTSCENESTATE_STOPPED;
     }
-    Actor_ProcessTalkRequest(&this->actor, &play->state);
+    Actor_TalkOfferAccepted(&this->actor, &play->state);
     play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     play->msgCtx.stateTimer = 4;
     Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
@@ -550,7 +550,7 @@ void EnSob1_Idle(EnSob1* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     this->headRotTarget = this->actor.yawTowardsPlayer - this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->cutsceneState == ENSOB1_CUTSCENESTATE_STOPPED) {
             if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
                 CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
@@ -808,7 +808,7 @@ void EnSob1_Walking(EnSob1* this, PlayState* play) {
             CutsceneManager_Queue(this->csId);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->cutsceneState == ENSOB1_CUTSCENESTATE_STOPPED) {
             if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
                 CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
@@ -848,7 +848,7 @@ void EnSob1_ItemPurchased(EnSob1* this, PlayState* play) {
             CutsceneManager_Queue(this->csId);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_ContinueTextbox(play, 0x647);
     } else {
         Actor_OfferTalkExchangeEquiCylinder(&this->actor, play, 400.0f, PLAYER_IA_MINUS1);

--- a/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
+++ b/src/overlays/actors/ovl_En_Ssh/z_en_ssh.c
@@ -721,7 +721,7 @@ void func_809756D0(EnSsh* this, PlayState* play) {
 }
 
 void EnSsh_Idle(EnSsh* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnSsh_Talk;
         func_809756D0(this, play);
         return;

--- a/src/overlays/actors/ovl_En_Sth/z_en_sth.c
+++ b/src/overlays/actors/ovl_En_Sth/z_en_sth.c
@@ -243,7 +243,7 @@ void EnSth_HandlePanicConversation(EnSth* this, PlayState* play) {
 void EnSth_PanicIdle(EnSth* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnSth_GetInitialPanicText(this, play);
         this->actionFunc = EnSth_HandlePanicConversation;
     } else if ((this->actor.xzDistToPlayer < 100.0f) && Player_IsFacingActor(&this->actor, 0x3000, play)) {
@@ -277,7 +277,7 @@ void EnSth_PostOceanspiderhouseReward(EnSth* this, PlayState* play) {
 
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = EnSth_HandleOceansideSpiderHouseConversation;
 
@@ -430,7 +430,7 @@ void EnSth_HandleOceansideSpiderHouseConversation(EnSth* this, PlayState* play) 
 void EnSth_OceansideSpiderHouseIdle(EnSth* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnSth_GetInitialOceansideSpiderHouseText(this, play);
         this->actionFunc = EnSth_HandleOceansideSpiderHouseConversation;
     } else if (EnSth_CanSpeakToPlayer(this, play)) {
@@ -451,7 +451,7 @@ void EnSth_HandleMoonLookingConversation(EnSth* this, PlayState* play) {
 void EnSth_MoonLookingIdle(EnSth* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnSth_HandleMoonLookingConversation;
     } else if (EnSth_CanSpeakToPlayer(this, play) || this->actor.isLockedOn) {
         if ((gSaveContext.save.time >= CLOCK_TIME(6, 0)) && (gSaveContext.save.time <= CLOCK_TIME(18, 0))) {
@@ -505,7 +505,7 @@ void EnSth_GetInitialSwampSpiderHouseText(EnSth* this, PlayState* play) {
 void EnSth_TalkAfterSwampSpiderHouseGiveMask(EnSth* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnSth_HandleSwampSpiderHouseConversation;
         SET_WEEKEVENTREG(WEEKEVENTREG_RECEIVED_MASK_OF_TRUTH);
         Message_StartTextbox(play, 0x918, &this->actor); // I've had enough of this, going home
@@ -588,7 +588,7 @@ void EnSth_HandleSwampSpiderHouseConversation(EnSth* this, PlayState* play) {
 void EnSth_SwampSpiderHouseIdle(EnSth* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnSth_GetInitialSwampSpiderHouseText(this, play);
         this->actionFunc = EnSth_HandleSwampSpiderHouseConversation;
     } else if (EnSth_CanSpeakToPlayer(this, play)) {

--- a/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.c
+++ b/src/overlays/actors/ovl_En_Stone_heishi/z_en_stone_heishi.c
@@ -180,7 +180,7 @@ void func_80BC9560(EnStoneheishi* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s32 yawDiff;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BC9660(this);
         return;
     }
@@ -397,7 +397,7 @@ void func_80BC9D28(EnStoneheishi* this, PlayState* play) {
         this->textIdIndex++;
         this->actor.textId = sEnStoneHeishiTextIds[this->textIdIndex];
         SET_WEEKEVENTREG(WEEKEVENTREG_41_40);
-        Actor_ProcessTalkRequest(&this->actor, &play->state);
+        Actor_TalkOfferAccepted(&this->actor, &play->state);
         Actor_OfferTalkExchange(&this->actor, play, 400.0f, 400.0f, PLAYER_IA_MINUS1);
         this->actionFunc = func_80BC9E50;
     } else if (INV_CONTENT(ITEM_MASK_STONE) == ITEM_MASK_STONE) {
@@ -410,7 +410,7 @@ void func_80BC9D28(EnStoneheishi* this, PlayState* play) {
 void func_80BC9E50(EnStoneheishi* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_RECEIVED_STONE_MASK);
         Message_BombersNotebookQueueEvent(play, BOMBERS_NOTEBOOK_EVENT_MET_SHIRO);
         this->action = EN_STONE_ACTION_1;

--- a/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
+++ b/src/overlays/actors/ovl_En_Stop_heishi/z_en_stop_heishi.c
@@ -496,7 +496,7 @@ void func_80AE7F34(EnStopheishi* this, PlayState* play) {
     yawDiff = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
     yawDiffAbs = ABS_ALT(yawDiff);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->skelAnime.playSpeed = 1.0f;
         func_80AE854C(this, play);
     } else if (yawDiffAbs < 0x4BB9) {

--- a/src/overlays/actors/ovl_En_Suttari/z_en_suttari.c
+++ b/src/overlays/actors/ovl_En_Suttari/z_en_suttari.c
@@ -1074,7 +1074,7 @@ void func_80BACA14(EnSuttari* this, PlayState* play) {
         }
     } else if ((player->transformation == PLAYER_FORM_HUMAN) &&
                (GET_CUR_EQUIP_VALUE(EQUIP_TYPE_SWORD) != EQUIP_VALUE_SWORD_NONE)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->unk3F2 = this->headRot.y;
             func_80BAAB78(this, play);
             this->actionFunc = func_80BADA9C;
@@ -1188,7 +1188,7 @@ void func_80BAD004(EnSuttari* this, PlayState* play) {
     }
     this->unk428 = scheduleOutput.result;
     func_80BAC2FC(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x2A3A, &this->actor);
         this->actionFunc = func_80BAD130;
     } else if ((this->actor.xzDistToPlayer < 200.0f) || this->actor.isLockedOn) {
@@ -1321,7 +1321,7 @@ void func_80BAD5F8(EnSuttari* this, PlayState* play) {
     }
     func_80BAB434(this);
     if ((this->flags1 & 0x20) && (this->unk430 == 0) && (scheduleOutput.result != 7)) {
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             Message_StartTextbox(play, 0x2A02, &this->actor);
             this->actionFunc = func_80BAD130;
         } else if ((this->actor.xzDistToPlayer < 100.0f) || this->actor.isLockedOn) {
@@ -1358,7 +1358,7 @@ void func_80BAD7F8(EnSuttari* this, PlayState* play) {
             return;
         }
         if ((this->flags1 & 0x20) && (scheduleOutput.result != 9)) {
-            if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+            if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
                 Message_StartTextbox(play, 0x2A02, &this->actor);
                 this->actionFunc = func_80BAD130;
             } else if ((this->actor.xzDistToPlayer < 100.0f) || this->actor.isLockedOn) {
@@ -1370,7 +1370,7 @@ void func_80BAD7F8(EnSuttari* this, PlayState* play) {
 }
 
 void func_80BADA08(EnSuttari* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         func_80BAAB78(this, play);
         SET_WEEKEVENTREG(WEEKEVENTREG_81_04);
@@ -1475,7 +1475,7 @@ void func_80BADE14(EnSuttari* this, PlayState* play) {
 void func_80BADE8C(EnSuttari* this, PlayState* play) {
     this->unk3F2 = this->headRot.y;
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.yawTowardsPlayer, 1, 0xBB8, 0);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         Message_StartTextbox(play, 0x2A3A, &this->actor);
         this->actionFunc = func_80BAD130;

--- a/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
+++ b/src/overlays/actors/ovl_En_Syateki_Man/z_en_syateki_man.c
@@ -286,7 +286,7 @@ void EnSyatekiMan_SetupIdle(EnSyatekiMan* this, PlayState* play) {
 void EnSyatekiMan_Swamp_Idle(EnSyatekiMan* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         u16 faceReactionTextId;
 
         Actor_ChangeAnimationByInfo(&this->skelAnime, sAnimationInfo, SG_MAN_ANIM_HEAD_SCRATCH_END);
@@ -618,7 +618,7 @@ void EnSyatekiMan_Town_StartIntroTextbox(EnSyatekiMan* this, PlayState* play) {
 }
 
 void EnSyatekiMan_Town_Idle(EnSyatekiMan* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         u16 faceReactionTextId = Text_GetFaceReaction(play, FACE_REACTION_SET_TOWN_SHOOTING_GALLERY_MAN);
 
         if (faceReactionTextId != 0) {
@@ -916,7 +916,7 @@ void EnSyatekiMan_Swamp_SetupGiveReward(EnSyatekiMan* this, PlayState* play) {
 void EnSyatekiMan_Swamp_GiveReward(EnSyatekiMan* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if ((CURRENT_DAY == 3) && (gSaveContext.save.time > CLOCK_TIME(12, 0))) {
             // We've been having a lot of earthquakes lately.
             Message_StartTextbox(play, 0xA36, &this->actor);
@@ -988,7 +988,7 @@ void EnSyatekiMan_Town_GiveReward(EnSyatekiMan* this, PlayState* play) {
             CLEAR_WEEKEVENTREG(WEEKEVENTREG_KICKOUT_TIME_PASSED);
             this->actionFunc = EnSyatekiMan_SetupIdle;
         }
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         // This may be our last day in business...
         Message_StartTextbox(play, 0x408, &this->actor);
         this->prevTextId = 0x408;

--- a/src/overlays/actors/ovl_En_Tab/z_en_tab.c
+++ b/src/overlays/actors/ovl_En_Tab/z_en_tab.c
@@ -184,7 +184,8 @@ void func_80BE0664(EnTab* this) {
 s32 func_80BE06DC(EnTab* this, PlayState* play) {
     s32 ret = false;
 
-    if (((this->unk_2FC & 7) != SUBS_OFFER_MODE_NONE) && Actor_TalkOfferAccepted(&this->actor, &play->state)) {
+    if (((this->unk_2FC & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_2FC, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         ret = true;
         this->unk_320 = 0;

--- a/src/overlays/actors/ovl_En_Tab/z_en_tab.c
+++ b/src/overlays/actors/ovl_En_Tab/z_en_tab.c
@@ -184,7 +184,7 @@ void func_80BE0664(EnTab* this) {
 s32 func_80BE06DC(EnTab* this, PlayState* play) {
     s32 ret = false;
 
-    if (((this->unk_2FC & 7) != SUBS_OFFER_MODE_NONE) && Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (((this->unk_2FC & 7) != SUBS_OFFER_MODE_NONE) && Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         SubS_SetOfferMode(&this->unk_2FC, SUBS_OFFER_MODE_NONE, SUBS_OFFER_MODE_MASK);
         ret = true;
         this->unk_320 = 0;

--- a/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.c
+++ b/src/overlays/actors/ovl_En_Takaraya/z_en_takaraya.c
@@ -175,7 +175,7 @@ void EnTakaraya_Wait(EnTakaraya* this, PlayState* play) {
             Animation_MorphToLoop(&this->skelAnime, &object_bg_Anim_009890, -4.0f);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (Text_GetFaceReaction(play, FACE_REACTION_SET_TREASURE_CHEST_SHOP_GAL) == 0) {
             Animation_MorphToPlayOnce(&this->skelAnime, &object_bg_Anim_00A280, -4.0f);
         }
@@ -354,7 +354,7 @@ void func_80ADF6DC(EnTakaraya* this) {
 
 void func_80ADF730(EnTakaraya* this, PlayState* play) {
     SkelAnime_Update(&this->skelAnime);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         func_80ADF7B8(this);
     } else {

--- a/src/overlays/actors/ovl_En_Talk/z_en_talk.c
+++ b/src/overlays/actors/ovl_En_Talk/z_en_talk.c
@@ -51,7 +51,7 @@ void func_80BDE058(EnTalk* this, PlayState* play) {
 }
 
 void func_80BDE090(EnTalk* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BDE058;
         return;
     }

--- a/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
+++ b/src/overlays/actors/ovl_En_Talk_Gibud/z_en_talk_gibud.c
@@ -780,7 +780,7 @@ void EnTalkGibud_SetupPassiveIdle(EnTalkGibud* this) {
  * Gibdo will not attempt to attack the player and can be spoken to.
  */
 void EnTalkGibud_PassiveIdle(EnTalkGibud* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->isTalking = true;
         Message_StartTextbox(play, 0x1388, &this->actor);
         this->textId = 0x1388;

--- a/src/overlays/actors/ovl_En_Test3/z_en_test3.c
+++ b/src/overlays/actors/ovl_En_Test3/z_en_test3.c
@@ -653,7 +653,7 @@ s32 func_80A3F62C(EnTest3* this, PlayState* play, struct_80A41828* arg2, Schedul
 }
 
 s32 func_80A3F73C(EnTest3* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->player.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->player.actor, &play->state)) {
         func_80A3E7E0(this, func_80A4084C);
         this->player.lockOnActor = &GET_PLAYER(play)->actor;
         this->player.stateFlags2 &= ~PLAYER_STATE2_40000;
@@ -1016,7 +1016,7 @@ void func_80A4084C(EnTest3* this, PlayState* play) {
 }
 
 void func_80A40908(EnTest3* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->player.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->player.actor, &play->state)) {
         func_80A3E7E0(this, func_80A4084C);
         this->player.lockOnActor = &GET_PLAYER(play)->actor;
         SET_WEEKEVENTREG(WEEKEVENTREG_51_08);

--- a/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
+++ b/src/overlays/actors/ovl_En_Time_Tag/z_en_time_tag.c
@@ -154,7 +154,7 @@ void EnTimeTag_SoaringEngraving_SubsequentInteraction(EnTimeTag* this, PlayState
 }
 
 void EnTimeTag_SoaringEngraving_Wait(EnTimeTag* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->actor.textId == 0) {
             this->actionFunc = EnTimeTag_SoaringEngraving_StartCutscene;
         } else {
@@ -255,7 +255,7 @@ void EnTimeTag_Diary_Cutscene(EnTimeTag* this, PlayState* play) {
 }
 
 void EnTimeTag_Diary_Wait(EnTimeTag* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (GET_PLAYER_FORM == PLAYER_FORM_ZORA) {
             if (TIMETAG_DIARY_GET_TYPE(&this->actor) == TIMETAG_DIARY_LULU) {
                 Message_StartTextbox(play, 0x101C, &this->actor);

--- a/src/overlays/actors/ovl_En_Tk/z_en_tk.c
+++ b/src/overlays/actors/ovl_En_Tk/z_en_tk.c
@@ -289,7 +289,7 @@ void func_80AECA3C(EnTk* this, PlayState* play) {
 }
 
 void func_80AECA90(EnTk* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         play->msgCtx.msgMode = MSGMODE_NONE;
         play->msgCtx.msgLength = 0;
         func_80AEDE10(this, play);
@@ -316,7 +316,7 @@ void func_80AECB6C(EnTk* this, PlayState* play) {
     u8 temp4;
 
     this->actor.textId = 0;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         play->msgCtx.msgMode = MSGMODE_NONE;
         play->msgCtx.msgLength = 0;
         func_80AED4F8(this, play);
@@ -688,7 +688,7 @@ void func_80AED940(EnTk* this, PlayState* play) {
         } while (actor != NULL);
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_2CA &= ~0x80;
         this->actor.flags &= ~ACTOR_FLAG_10000;
         play->msgCtx.msgMode = MSGMODE_NONE;

--- a/src/overlays/actors/ovl_En_Toto/z_en_toto.c
+++ b/src/overlays/actors/ovl_En_Toto/z_en_toto.c
@@ -245,7 +245,7 @@ void func_80BA39C8(EnToto* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
 
     func_80BA383C(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BA36C0(this, play, 1);
         if (play->sceneId != SCENE_SONCHONOIE) {
             Flags_SetSwitch(play, ENTOTO_GET_SWITCH_FLAG_1(&this->actor));

--- a/src/overlays/actors/ovl_En_Trt/z_en_trt.c
+++ b/src/overlays/actors/ovl_En_Trt/z_en_trt.c
@@ -216,7 +216,7 @@ void EnTrt_EndInteraction(PlayState* play, EnTrt* this) {
         CutsceneManager_Stop(this->csId);
         this->cutsceneState = ENTRT_CUTSCENESTATE_STOPPED;
     }
-    Actor_ProcessTalkRequest(&this->actor, &play->state);
+    Actor_TalkOfferAccepted(&this->actor, &play->state);
     play->msgCtx.msgMode = MSGMODE_TEXT_CLOSING;
     play->msgCtx.stateTimer = 4;
     Interface_SetHudVisibility(HUD_VISIBILITY_ALL);
@@ -800,7 +800,7 @@ void EnTrt_IdleSleeping(EnTrt* this, PlayState* play) {
     if (Player_GetMask(play) == PLAYER_MASK_SCENTS) {
         this->textId = 0x890;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (player->transformation == PLAYER_FORM_HUMAN) {
             this->flags |= ENTRT_TALKED;
         }
@@ -844,7 +844,7 @@ void EnTrt_IdleAwake(EnTrt* this, PlayState* play) {
     } else {
         this->textId = 0x850;
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->cutsceneState == ENTRT_CUTSCENESTATE_STOPPED) {
             if (CutsceneManager_GetCurrentCsId() == CS_ID_GLOBAL_TALK) {
                 CutsceneManager_Stop(CS_ID_GLOBAL_TALK);
@@ -1033,7 +1033,7 @@ void EnTrt_ItemGiven(EnTrt* this, PlayState* play) {
             CutsceneManager_Queue(this->csId);
         }
     }
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         switch (this->textId) {
             case 0x889:
                 this->textId = 0x88A;
@@ -1072,7 +1072,7 @@ void EnTrt_ShopkeeperGone(EnTrt* this, PlayState* play) {
     u8 talkState = Message_GetState(&play->msgCtx);
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, this->textId, &this->actor);
     } else {
         if ((player->actor.world.pos.x >= -50.0f) && (player->actor.world.pos.x <= 50.0f) &&

--- a/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
+++ b/src/overlays/actors/ovl_En_Trt2/z_en_trt2.c
@@ -432,7 +432,7 @@ void func_80AD40AC(EnTrt2* this, PlayState* play) {
 }
 
 void func_80AD4110(EnTrt2* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_3A8 = 0x84C;
         Message_ContinueTextbox(play, this->unk_3A8);
         this->unk_3B2 = 10;
@@ -662,7 +662,7 @@ s32 func_80AD4B4C(EnTrt2* this, PlayState* play) {
     s32 sp24 = false;
     Player* player = GET_PLAYER(play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         sp24 = true;
         this->actor.speed = 0.0f;
         func_80AD349C(this);

--- a/src/overlays/actors/ovl_En_Tru/z_en_tru.c
+++ b/src/overlays/actors/ovl_En_Tru/z_en_tru.c
@@ -686,7 +686,7 @@ s32 func_80A872AC(EnTru* this, PlayState* play) {
     s32 ret = false;
 
     if (((this->unk_34E & SUBS_OFFER_MODE_MASK) != SUBS_OFFER_MODE_NONE) &&
-        Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (player->transformation == PLAYER_FORM_HUMAN) {
             this->unk_34E &= ~0x80;
         }
@@ -1118,7 +1118,7 @@ void func_80A881E0(EnTru* this, PlayState* play) {
         this->unk_34E &= ~(0x1000 | 0x8);
         this->unk_34E |= 0x10;
         this->actor.shape.rot.y = this->actor.world.rot.y;
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         this->unk_1E8 = 0;
         this->actionFunc = func_80A87FD0;
     }

--- a/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
+++ b/src/overlays/actors/ovl_En_Tsn/z_en_tsn.c
@@ -268,7 +268,7 @@ void func_80AE0010(EnTsn* this, PlayState* play) {
 }
 
 void func_80AE0304(EnTsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80AE0010;
         this->unk_220 |= 1;
         if (this->actor.textId == 0) {
@@ -434,7 +434,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
                             this->unk_220 &= ~2;
                             this->actor.focus.pos = this->actor.world.pos;
                             CutsceneManager_Stop(this->actor.csId);
-                            this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+                            this->actor.flags &= ~ACTOR_FLAG_TALK;
                             REMOVE_QUEST_ITEM(QUEST_PICTOGRAPH);
                         } else {
                             Message_ContinueTextbox(play, 0x10A8);
@@ -458,7 +458,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
                     case 0x10A8:
                         Animation_MorphToLoop(&this->unk_1D8->skelAnime, &object_tsn_Anim_0092FC, -10.0f);
                         func_80AE0698(this, play);
-                        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+                        this->actor.flags &= ~ACTOR_FLAG_TALK;
                         this->actionFunc = func_80AE04C4;
                         break;
 
@@ -498,7 +498,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
 
                     case 0x10A9:
                         func_80AE0698(this, play);
-                        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+                        this->actor.flags &= ~ACTOR_FLAG_TALK;
                         this->actionFunc = func_80AE04C4;
                         break;
                 }
@@ -530,7 +530,7 @@ void func_80AE0704(EnTsn* this, PlayState* play) {
 }
 
 void func_80AE0C88(EnTsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80AE0704;
         if ((this->actor.textId == 0x108A) || (this->actor.textId == 0x1091)) {
             this->unk_220 |= 4;
@@ -550,7 +550,7 @@ void func_80AE0D10(EnTsn* this, PlayState* play) {
 }
 
 void func_80AE0D78(EnTsn* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80AE0D10;
         this->unk_220 |= 4;
     } else if (this->actor.isLockedOn) {

--- a/src/overlays/actors/ovl_En_Warp_Uzu/z_en_warp_uzu.c
+++ b/src/overlays/actors/ovl_En_Warp_Uzu/z_en_warp_uzu.c
@@ -95,7 +95,7 @@ void func_80A66278(EnWarpUzu* this, PlayState* play) {
 
     do {
         player = GET_PLAYER(play);
-        if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             func_80A66384(this, play);
         } else {
             phi_a0 = ABS((s16)(Actor_WorldYawTowardActor(&this->actor, &player->actor) - this->actor.shape.rot.y));

--- a/src/overlays/actors/ovl_En_Yb/z_en_yb.c
+++ b/src/overlays/actors/ovl_En_Yb/z_en_yb.c
@@ -261,7 +261,7 @@ void EnYb_Disappear(EnYb* this, PlayState* play) {
 
 void EnYb_SetupLeaving(EnYb* this, PlayState* play) {
     EnYb_UpdateAnimation(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         this->actionFunc = EnYb_Talk;
         // I am counting on you
@@ -327,7 +327,7 @@ void EnYb_Talk(EnYb* this, PlayState* play) {
 
 void EnYb_TeachingDanceFinish(EnYb* this, PlayState* play) {
     EnYb_UpdateAnimation(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = EnYb_Talk;
         // Spread my dance across the world
         Message_StartTextbox(play, 0x147C, &this->actor);
@@ -364,7 +364,7 @@ void EnYb_Idle(EnYb* this, PlayState* play) {
         this->actionFunc = EnYb_TeachingDance;
         this->teachingCutsceneTimer = 200;
         EnYb_ChangeCutscene(this, 0);
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BFA2FC(play);
         this->actionFunc = EnYb_Talk;
         if (Player_GetMask(play) == PLAYER_MASK_KAMARO) {

--- a/src/overlays/actors/ovl_En_Zob/z_en_zob.c
+++ b/src/overlays/actors/ovl_En_Zob/z_en_zob.c
@@ -535,7 +535,7 @@ void func_80BA0374(EnZob* this, PlayState* play) {
 
 void func_80BA0610(EnZob* this, PlayState* play) {
     func_80B9F86C(this);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         Message_StartTextbox(play, 0x120D, &this->actor);
         this->unk_304 = 3;
@@ -574,7 +574,7 @@ void func_80BA0728(EnZob* this, PlayState* play) {
         func_80B9F7E4(this, 2, ANIMMODE_ONCE);
         this->csIdIndex = 0;
         this->unk_2F4 |= 1;
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BA0374;
         func_80B9FA3C(this, play);
     } else if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_500)) {
@@ -653,7 +653,7 @@ void func_80BA0AD8(EnZob* this, PlayState* play) {
         this->actor.world.rot.y = this->actor.shape.rot.y;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BA0A04;
         func_80BA08E8(this, play);
     } else if ((this->actor.xzDistToPlayer < 120.0f) && Player_IsFacingActor(&this->actor, 0x3000, play) &&

--- a/src/overlays/actors/ovl_En_Zod/z_en_zod.c
+++ b/src/overlays/actors/ovl_En_Zod/z_en_zod.c
@@ -376,7 +376,7 @@ void EnZod_PlayDrumsSequence(EnZod* this, PlayState* play) {
 
     EnZod_UpdateAnimation(this);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         EnZod_HandleRoomConversation(this, play);
         this->actionFunc = func_80BAF7CC;
     } else if (EnZod_PlayerIsFacingTijo(this, play)) {
@@ -432,7 +432,7 @@ void func_80BAFADC(EnZod* this, PlayState* play) {
 void func_80BAFB84(EnZod* this, PlayState* play) {
     EnZod_UpdateAnimation(this);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         func_80BAFA44(this, play);
         this->actionFunc = func_80BAFADC;
     } else if (EnZod_PlayerIsFacingTijo(this, play)) {

--- a/src/overlays/actors/ovl_En_Zog/z_en_zog.c
+++ b/src/overlays/actors/ovl_En_Zog/z_en_zog.c
@@ -599,7 +599,7 @@ void func_80B94470(EnZog* this, PlayState* play) {
 }
 
 void func_80B9451C(EnZog* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_300 = 2;
         this->actionFunc = func_80B94470;
     } else if ((play->msgCtx.ocarinaMode == OCARINA_MODE_EVENT) && (this->actor.xzDistToPlayer < 120.0f)) {
@@ -687,7 +687,7 @@ void func_80B946FC(EnZog* this, PlayState* play) {
 }
 
 void func_80B948A8(EnZog* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->unk_300 = 2;
         this->actionFunc = func_80B946FC;
     } else if ((play->msgCtx.ocarinaMode == OCARINA_MODE_EVENT) && (this->actor.xzDistToPlayer < 120.0f)) {
@@ -863,7 +863,7 @@ void func_80B94E34(EnZog* this, PlayState* play) {
         this->unk_324--;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B94D0C;
         this->actor.speed = 0.0f;
         this->unk_300 = 2;
@@ -892,7 +892,7 @@ void func_80B95128(EnZog* this, PlayState* play) {
     func_80B93D2C(this, play);
     func_80B93BE0(this, play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B94D0C;
         this->unk_300 = 2;
         this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.c
+++ b/src/overlays/actors/ovl_En_Zoraegg/z_en_zoraegg.c
@@ -338,7 +338,7 @@ void func_80B320E0(EnZoraegg* this, PlayState* play) {
     if (Actor_HasParent(&this->actor, play)) {
         Flags_SetSwitch(play, ZORA_EGG_GET_SWITCH_FLAG(&this->actor));
         Actor_Kill(&this->actor);
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B32094;
         Message_StartTextbox(play, 0x24B, &this->actor);
     } else {

--- a/src/overlays/actors/ovl_En_Zos/z_en_zos.c
+++ b/src/overlays/actors/ovl_En_Zos/z_en_zos.c
@@ -249,7 +249,7 @@ void func_80BBB15C(EnZos* this, PlayState* play) {
 }
 
 void func_80BBB2C4(EnZos* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         Message_StartTextbox(play, 0x124F, &this->actor);
         this->actionFunc = func_80BBB8AC;
         this->actor.flags &= ~ACTOR_FLAG_10000;
@@ -475,7 +475,7 @@ void func_80BBB8AC(EnZos* this, PlayState* play) {
         case 0x123D:
         case 0x1242:
             EnZos_ChangeAnim(this, EN_ZOS_ANIM_HANDS_ON_HIPS, ANIMMODE_LOOP);
-            Actor_ProcessTalkRequest(&this->actor, &play->state);
+            Actor_TalkOfferAccepted(&this->actor, &play->state);
             Message_CloseTextbox(play);
             this->actionFunc = func_80BBBDE0;
             this->unk_2B6 |= 1;
@@ -497,7 +497,7 @@ void func_80BBB8AC(EnZos* this, PlayState* play) {
 }
 
 void func_80BBBB84(EnZos* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         if (GET_PLAYER_FORM == PLAYER_FORM_ZORA) {
             Message_StartTextbox(play, 0x1248, &this->actor);
@@ -521,7 +521,7 @@ void func_80BBBB84(EnZos* this, PlayState* play) {
 }
 
 void func_80BBBCBC(EnZos* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         EnZos_ChangeAnim(this, EN_ZOS_ANIM_TALK_ARMS_OUT, ANIMMODE_LOOP);
         Message_StartTextbox(play, 0x124D, &this->actor);
@@ -563,7 +563,7 @@ void func_80BBBDE0(EnZos* this, PlayState* play) {
         return;
     }
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BBB8AC;
         func_80BBB15C(this, play);
     } else if (Cutscene_IsCueInChannel(play, CS_CMD_ACTOR_CUE_501)) {
@@ -641,7 +641,7 @@ void func_80BBC14C(EnZos* this, PlayState* play) {
 
     func_80BBB0D4(this, play);
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BBC070;
         func_80BBBFBC(this, play);
     } else if (func_80BBAF5C(this, play)) {

--- a/src/overlays/actors/ovl_En_Zot/z_en_zot.c
+++ b/src/overlays/actors/ovl_En_Zot/z_en_zot.c
@@ -399,7 +399,7 @@ void func_80B97194(EnZot* this, PlayState* play) {
 }
 
 void func_80B97240(EnZot* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B97194;
         func_80B97110(this, play);
     } else if ((this->actor.xzDistToPlayer < 100.0f) && Player_IsFacingActor(&this->actor, 0x3000, play) &&
@@ -514,7 +514,7 @@ void func_80B973BC(EnZot* this, PlayState* play) {
 
 void func_80B975F8(EnZot* this, PlayState* play) {
     func_80B96D4C(this);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B973BC;
     } else {
         Actor_OfferTalkExchange(&this->actor, play, 10000.0f, 1000.0f, PLAYER_IA_NONE);
@@ -549,7 +549,7 @@ void func_80B97708(EnZot* this, PlayState* play) {
     func_80B96D4C(this);
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 2, 0x400, 0x100);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B9765C;
         func_80B972E8(this, play);
         return;
@@ -699,7 +699,7 @@ void func_80B97A44(EnZot* this, PlayState* play) {
 void func_80B97B5C(EnZot* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 2, 0x400, 0x100);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B97A44;
         func_80B9787C(this, play);
     } else if (func_80B96DF0(this, play)) {
@@ -728,7 +728,7 @@ void func_80B97C40(EnZot* this, PlayState* play) {
 }
 
 void func_80B97CC8(EnZot* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B97C40;
         Message_StartTextbox(play, 0x128B, &this->actor);
     } else if (Player_IsFacingActor(&this->actor, 0x3000, play) && (this->actor.xzDistToPlayer < 100.0f)) {
@@ -805,7 +805,7 @@ void func_80B97E4C(EnZot* this, PlayState* play) {
 void func_80B97FD0(EnZot* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 2, 0x800, 0x100);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B97E4C;
         func_80B97BF8(this, play);
     } else if (CHECK_WEEKEVENTREG(WEEKEVENTREG_38_08)) {
@@ -928,7 +928,7 @@ void func_80B98348(EnZot* this, PlayState* play) {
 
 void func_80B9849C(EnZot* this, PlayState* play) {
     func_80B98348(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->unk_2D4 == 2) {
             Message_StartTextbox(play, 0x12AD, &this->actor);
         } else {
@@ -1069,7 +1069,7 @@ void func_80B98728(EnZot* this, PlayState* play) {
 
 void func_80B98998(EnZot* this, PlayState* play) {
     this->unk_2F2 &= ~8;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B98728;
         func_80B98178(this, play);
     } else if ((this->actor.xzDistToPlayer < 100.0f) && Player_IsFacingActor(&this->actor, 0x3000, play) &&
@@ -1130,7 +1130,7 @@ void func_80B98AD0(EnZot* this, PlayState* play) {
 }
 
 void func_80B98BF4(EnZot* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.flags &= ~ACTOR_FLAG_10000;
         if (CHECK_WEEKEVENTREG(WEEKEVENTREG_41_20)) {
             Message_StartTextbox(play, 0x12B7, &this->actor);
@@ -1151,7 +1151,7 @@ void func_80B98CA8(EnZot* this, PlayState* play) {
         this->actionFunc = func_80B98BF4;
         this->actor.flags |= ACTOR_FLAG_10000;
         Actor_OfferTalk(&this->actor, play, 120.0f);
-    } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B98AD0;
         func_80B98A4C(this, play);
     } else {
@@ -1248,7 +1248,7 @@ void func_80B98F94(EnZot* this, PlayState* play) {
 void func_80B990A4(EnZot* this, PlayState* play) {
     Math_SmoothStepToS(&this->actor.shape.rot.y, this->actor.home.rot.y, 2, 0x400, 0x100);
     this->actor.world.rot.y = this->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B98F94;
         func_80B98E10(this, play);
     } else if (Player_IsFacingActor(&this->actor, 0x3000, play) && (this->actor.xzDistToPlayer < 100.0f)) {
@@ -1296,7 +1296,7 @@ void func_80B991E4(EnZot* this, PlayState* play) {
 }
 
 void func_80B992C0(EnZot* this, PlayState* play) {
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80B991E4;
         func_80B99160(this, play);
         this->actor.speed = 0.0f;

--- a/src/overlays/actors/ovl_En_Zov/z_en_zov.c
+++ b/src/overlays/actors/ovl_En_Zov/z_en_zov.c
@@ -373,7 +373,7 @@ void func_80BD1C38(EnZov* this, PlayState* play) {
 void func_80BD1C84(EnZov* this, PlayState* play) {
     func_80BD1764(this);
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = func_80BD187C;
         func_80BD160C(this, play);
     } else if (func_80BD15A4(this, play)) {
@@ -447,7 +447,7 @@ void func_80BD1F1C(EnZov* this, PlayState* play) {
         this->picto.actor.world.rot.y = this->picto.actor.shape.rot.y;
     }
 
-    if (Actor_ProcessTalkRequest(&this->picto.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->picto.actor, &play->state)) {
         this->actionFunc = func_80BD1DB8;
         func_80BD1D30(this, play);
     } else if (func_80BD15A4(this, play)) {

--- a/src/overlays/actors/ovl_En_Zow/z_en_zow.c
+++ b/src/overlays/actors/ovl_En_Zow/z_en_zow.c
@@ -498,7 +498,7 @@ void func_80BDD570(EnZow* this, PlayState* play) {
 
 void func_80BDD634(EnZow* this, PlayState* play) {
     func_80BDD490(this, play);
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actionFunc = func_80BDD570;
         func_80BDD1E0(this, play);
     } else if (func_80BDD154(this, play)) {

--- a/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
+++ b/src/overlays/actors/ovl_Obj_Bean/z_obj_bean.c
@@ -547,7 +547,7 @@ void func_80937FB0(ObjBean* this) {
 void func_80937FC8(ObjBean* this, PlayState* play) {
     this->unk_1E8(this);
 
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         if (Player_GetExchangeItemAction(play) == PLAYER_IA_MAGIC_BEANS) {
             func_809383B4(this);
             Flags_SetSwitch(play, OBJBEAN_GET_SWITCH_FLAG_2(&this->dyna.actor, 0));

--- a/src/overlays/actors/ovl_Obj_Ghaka/z_obj_ghaka.c
+++ b/src/overlays/actors/ovl_Obj_Ghaka/z_obj_ghaka.c
@@ -72,7 +72,7 @@ void func_80B3C39C(ObjGhaka* this, PlayState* play) {
     Player* player = GET_PLAYER(play);
     s16 yaw = this->dyna.actor.yawTowardsPlayer - this->dyna.actor.shape.rot.y;
 
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         func_80B3C29C(this);
     } else if ((this->dyna.actor.xzDistToPlayer < 100.0f) || this->dyna.actor.isLockedOn) {
         if ((yaw <= -0x5556) || (yaw >= 0x5556)) {

--- a/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.c
+++ b/src/overlays/actors/ovl_Obj_Hakaisi/z_obj_hakaisi.c
@@ -164,7 +164,7 @@ void func_80B1444C(ObjHakaisi* this) {
 void func_80B14460(ObjHakaisi* this, PlayState* play) {
     s16 sp26 = BINANG_SUB(this->dyna.actor.shape.rot.y, this->dyna.actor.yawTowardsPlayer);
 
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         func_80B14510(this);
     } else if (this->dyna.actor.textId != 0) {
         if (ABS_ALT(sp26) < 0x2000) {

--- a/src/overlays/actors/ovl_Obj_Moon_Stone/z_obj_moon_stone.c
+++ b/src/overlays/actors/ovl_Obj_Moon_Stone/z_obj_moon_stone.c
@@ -73,7 +73,7 @@ void func_80C06640(ObjMoonStone* this, PlayState* play) {
     s16 sp1A = this->actor.yawTowardsPlayer - 0x8000;
 
     sp1A -= player->actor.shape.rot.y;
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         this->actor.colChkInfo.health = 1;
         Message_StartTextbox(play, 0x5E3, &this->actor);
         func_80C066F8(this);

--- a/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
+++ b/src/overlays/actors/ovl_Obj_Mu_Pict/z_obj_mu_pict.c
@@ -63,7 +63,7 @@ void func_80C06B5C(ObjMuPict* this) {
 void func_80C06B70(ObjMuPict* this, PlayState* play) {
     s16 yawDiff = this->actor.yawTowardsPlayer - this->actor.world.rot.y;
 
-    if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
         if (this->actor.csId <= CS_ID_NONE) {
             func_80C06DC8(this, play);
             func_80C06CC4(this);

--- a/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.c
+++ b/src/overlays/actors/ovl_Obj_Nozoki/z_obj_nozoki.c
@@ -424,7 +424,7 @@ void func_80BA3230(ObjNozoki* this, PlayState* play) {
                 }
             }
 
-            if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+            if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
                 ObjNozoki_SetupAction(this, func_80BA3344);
             } else {
                 Actor_OfferTalk(&this->dyna.actor, play, 50.0f);

--- a/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.c
+++ b/src/overlays/actors/ovl_Obj_Snowball/z_obj_snowball.c
@@ -760,7 +760,7 @@ void ObjSnowball_Update(Actor* thisx, PlayState* play) {
                 this->actor.flags &= ~ACTOR_FLAG_10;
                 this->unk_211 = 0;
             }
-        } else if (Actor_ProcessTalkRequest(&this->actor, &play->state)) {
+        } else if (Actor_TalkOfferAccepted(&this->actor, &play->state)) {
             this->actor.flags |= ACTOR_FLAG_10;
             this->unk_211 = 1;
         } else if (this->actor.isLockedOn) {

--- a/src/overlays/actors/ovl_Obj_Um/z_obj_um.c
+++ b/src/overlays/actors/ovl_Obj_Um/z_obj_um.c
@@ -947,7 +947,7 @@ s32 func_80B7984C(PlayState* play, ObjUm* this, s32 arg2, s32* arg3) {
         return 0;
     }
 
-    if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         *arg3 = 1;
         return 1;
     }

--- a/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.c
+++ b/src/overlays/actors/ovl_Obj_Warpstone/z_obj_warpstone.c
@@ -149,7 +149,7 @@ void ObjWarpstone_Update(Actor* thisx, PlayState* play) {
                 Message_CloseTextbox(play);
             }
         }
-    } else if (Actor_ProcessTalkRequest(&this->dyna.actor, &play->state)) {
+    } else if (Actor_TalkOfferAccepted(&this->dyna.actor, &play->state)) {
         this->isTalking = true;
     } else if (!this->actionFunc(this, play)) {
         Actor_OfferTalkNearColChkInfoCylinder(&this->dyna.actor, play);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -545,7 +545,7 @@ void func_8082DAD4(Player* this) {
 s32 func_8082DAFC(PlayState* play) {
     Player* player = GET_PLAYER(play);
 
-    return CHECK_FLAG_ALL(player->actor.flags, ACTOR_FLAG_TALK_REQUESTED);
+    return CHECK_FLAG_ALL(player->actor.flags, ACTOR_FLAG_TALK);
 }
 
 void Player_Anim_PlayOnce(PlayState* play, Player* this, PlayerAnimationHeader* anim) {
@@ -4382,8 +4382,7 @@ void Player_UseItem(PlayState* play, Player* this, ItemId item) {
         f32 sp54;
         PlayerExplosive explosiveType;
 
-        if (var_v1 ||
-            (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK_REQUESTED) && (itemAction != PLAYER_IA_NONE)) ||
+        if (var_v1 || (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK) && (itemAction != PLAYER_IA_NONE)) ||
             (itemAction == PLAYER_IA_OCARINA) ||
             ((itemAction > PLAYER_IA_BOTTLE_MIN) && itemAction < PLAYER_IA_MASK_MIN) ||
             ((itemAction == PLAYER_IA_PICTOGRAPH_BOX) && (this->talkActor != NULL) &&
@@ -6505,7 +6504,7 @@ s32 Player_ActionChange_1(Player* this, PlayState* play) {
             if (this->doorType <= PLAYER_DOORTYPE_TALKING) {
                 Player_TalkWithPlayer(play, doorActor);
                 if (doorActor->textId == 0x1821) {
-                    doorActor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+                    doorActor->flags |= ACTOR_FLAG_TALK;
                 }
                 return true;
             }
@@ -7298,7 +7297,7 @@ void Player_StopCutscene(Player* this) {
 s32 Player_StartCsAction(PlayState* play, Player* this) {
     if (this->unk_AA5 == PLAYER_UNKAA5_4) {
         Player_StopCutscene(this);
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         Player_SetAction(play, this, Player_Action_CsAction, 0);
 
         if (this->cv.haltActorsDuringCsAction) {
@@ -7513,7 +7512,7 @@ s32 Player_ActionChange_13(Player* this, PlayState* play) {
                         func_808388B8(play, this, this->itemAction - PLAYER_IA_MASK_FIERCE_DEITY);
                     }
                     gSaveContext.save.equippedMask = this->currentMask;
-                } else if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK_REQUESTED) ||
+                } else if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK) ||
                            (this->itemAction == PLAYER_IA_PICTOGRAPH_BOX) ||
                            ((this->itemAction != this->unk_B2B) &&
                             ((this->itemAction == PLAYER_IA_BOTTLE_BIG_POE) ||
@@ -7559,7 +7558,7 @@ s32 Player_ActionChange_13(Player* this, PlayState* play) {
                             this->csId = CS_ID_GLOBAL_TALK;
                         }
 
-                        talkActor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+                        talkActor->flags |= ACTOR_FLAG_TALK;
                         this->actor.textId = 0;
                         this->lockOnActor = this->talkActor;
                     } else {
@@ -7568,7 +7567,7 @@ s32 Player_ActionChange_13(Player* this, PlayState* play) {
                         this->av1.actionVar1 = 1;
                         this->actor.textId = 0xFE;
                     }
-                    this->actor.flags |= ACTOR_FLAG_TALK_REQUESTED;
+                    this->actor.flags |= ACTOR_FLAG_TALK;
                     this->exchangeItemAction = this->itemAction;
                     if (this->av1.actionVar1 >= 0) {
                         Player_Anim_PlayOnce(play, this, D_8085D1F8[this->av1.actionVar1]);
@@ -11516,7 +11515,7 @@ void Player_UpdateCamAndSeqModes(PlayState* play, Player* this) {
             } else if (this->stateFlags2 & PLAYER_STATE2_100) {
                 camMode = CAM_MODE_PUSHPULL;
             } else if (this->lockOnActor != NULL) {
-                if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK_REQUESTED)) {
+                if (CHECK_FLAG_ALL(this->actor.flags, ACTOR_FLAG_TALK)) {
                     camMode = CAM_MODE_TALK;
                 } else if (this->stateFlags1 & PLAYER_STATE1_10000) {
                     if (this->stateFlags1 & PLAYER_STATE1_2000000) {
@@ -12235,7 +12234,7 @@ void Player_UpdateCommon(Player* this, PlayState* play, Input* input) {
         }
 
         func_80832578(this, play);
-        if (this->actor.flags & ACTOR_FLAG_TALK_REQUESTED) {
+        if (this->actor.flags & ACTOR_FLAG_TALK) {
             this->talkActorDistance = 0.0f;
         } else {
             this->talkActor = NULL;
@@ -14358,7 +14357,7 @@ void Player_Action_17(Player* this, PlayState* play) {
         if (!Player_ActionChange_13(this, play)) {
             func_80836A98(this, D_8085BE84[PLAYER_ANIMGROUP_33][this->modelAnimType], play);
         }
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         func_800E0238(Play_GetCamera(play, CAM_ID_MAIN));
     }
 }
@@ -15504,7 +15503,7 @@ void Player_Action_44(Player* this, PlayState* play) {
     func_8083249C(this);
     Player_UpdateUpperBody(this, play);
     if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
-        this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+        this->actor.flags &= ~ACTOR_FLAG_TALK;
         if (!CHECK_FLAG_ALL(this->talkActor->flags, ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_UNFRIENDLY)) {
             this->stateFlags2 &= ~PLAYER_STATE2_2000;
         }
@@ -17416,7 +17415,7 @@ void Player_Action_71(Player* this, PlayState* play) {
             this->getItemDrawIdPlusOne = GID_NONE + 1;
 
             if ((talkActor->textId != 0) && (talkActor->textId != 0xFFFF)) {
-                this->actor.flags |= ACTOR_FLAG_TALK_REQUESTED;
+                this->actor.flags |= ACTOR_FLAG_TALK;
             }
             Player_TalkWithPlayer(play, talkActor);
         } else {
@@ -17435,7 +17434,7 @@ void Player_Action_71(Player* this, PlayState* play) {
             } else if (Message_GetState(&play->msgCtx) == TEXT_STATE_CLOSING) {
                 Player_StopCutscene(this);
                 this->getItemDrawIdPlusOne = GID_NONE + 1;
-                this->actor.flags &= ~ACTOR_FLAG_TALK_REQUESTED;
+                this->actor.flags &= ~ACTOR_FLAG_TALK;
                 func_80839E74(this, play);
                 this->unk_B5E = 0xA;
             }
@@ -20540,7 +20539,7 @@ void Player_TalkWithPlayer(PlayState* play, Actor* actor) {
     func_808323C0(player, CS_ID_GLOBAL_TALK);
     if ((player->talkActor != NULL) || (actor == player->tatlActor) ||
         CHECK_FLAG_ALL(actor->flags, ACTOR_FLAG_TARGETABLE | ACTOR_FLAG_40000)) {
-        actor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+        actor->flags |= ACTOR_FLAG_TALK;
     }
 
     player->talkActor = actor;
@@ -20549,13 +20548,13 @@ void Player_TalkWithPlayer(PlayState* play, Actor* actor) {
 
     if (actor->textId == 0xFFFF) {
         Player_SetCsActionWithHaltedActors(play, actor, PLAYER_CSACTION_1);
-        actor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+        actor->flags |= ACTOR_FLAG_TALK;
         func_8082DE14(play, player);
     } else {
-        if (player->actor.flags & ACTOR_FLAG_TALK_REQUESTED) {
+        if (player->actor.flags & ACTOR_FLAG_TALK) {
             player->actor.textId = 0;
         } else {
-            player->actor.flags |= ACTOR_FLAG_TALK_REQUESTED;
+            player->actor.flags |= ACTOR_FLAG_TALK;
             player->actor.textId = actor->textId;
         }
 
@@ -20597,7 +20596,7 @@ void Player_TalkWithPlayer(PlayState* play, Actor* actor) {
     }
 
     if ((player->tatlActor == player->talkActor) && ((player->talkActor->textId & 0xFF00) != 0x200)) {
-        player->tatlActor->flags |= ACTOR_FLAG_TALK_REQUESTED;
+        player->tatlActor->flags |= ACTOR_FLAG_TALK;
     }
 }
 
@@ -20660,7 +20659,7 @@ PlayerItemAction func_8085B854(PlayState* play, Player* this, ItemId itemId) {
 s32 func_8085B930(PlayState* play, PlayerAnimationHeader* talkAnim, AnimationMode animMode) {
     Player* player = GET_PLAYER(play);
 
-    if (!(player->actor.flags & ACTOR_FLAG_TALK_REQUESTED)) {
+    if (!(player->actor.flags & ACTOR_FLAG_TALK)) {
         return false;
     }
 

--- a/tools/disasm/functions.txt
+++ b/tools/disasm/functions.txt
@@ -769,7 +769,7 @@
     0x800B82EC:("Target_GetAdjustedDistSq",),
     0x800B83BC:("Target_IsActorInRange",),
     0x800B83F8:("Target_OutsideLeashRange",),
-    0x800B84D0:("Actor_ProcessTalkRequest",),
+    0x800B84D0:("Actor_TalkOfferAccepted",),
     0x800B8500:("Actor_OfferTalkExchange",),
     0x800B85E0:("Actor_OfferTalkExchangeEquiCylinder",),
     0x800B8614:("Actor_OfferTalk",),

--- a/tools/namefixer.py
+++ b/tools/namefixer.py
@@ -125,7 +125,8 @@ wordReplace = {
     "Actor_IsActorFacingActor": "Actor_ActorAIsFacingActorB",
     "Actor_IsActorFacedByActor": "Actor_ActorBIsFacingActorA",
     "Actor_MarkForDeath": "Actor_Kill",
-    "func_800B84D0": "Actor_ProcessTalkRequest",
+    "func_800B84D0": "Actor_TalkOfferAccepted",
+    "Actor_ProcessTalkRequest": "Actor_TalkOfferAccepted",
     "func_8017D668": "Math3D_PointDistToLine2D",
 
     "THGA_GetSize": "THGA_GetRemaining",
@@ -1295,7 +1296,8 @@ wordReplace = {
     "ACTOR_FLAG_1": "ACTOR_FLAG_TARGETABLE",
     "ACTOR_FLAG_4": "ACTOR_FLAG_UNFRIENDLY",
     "ACTOR_FLAG_8": "ACTOR_FLAG_FRIENDLY",
-    "ACTOR_FLAG_100": "ACTOR_FLAG_TALK_REQUESTED",
+    "ACTOR_FLAG_100": "ACTOR_FLAG_TALK",
+    "ACTOR_FLAG_TALK_REQUESTED": "ACTOR_FLAG_TALK",
     "ACTOR_FLAG_8000000": "ACTOR_FLAG_CANT_LOCK_ON",
 
     "EXCH_ITEM_MINUS1": "PLAYER_IA_MINUS1",

--- a/tools/sizes/code_functions.csv
+++ b/tools/sizes/code_functions.csv
@@ -283,7 +283,7 @@ asm/non_matchings/code/z_actor/Actor_GetWorldPosShapeRot.s,Actor_GetWorldPosShap
 asm/non_matchings/code/z_actor/Target_GetAdjustedDistSq.s,Target_GetAdjustedDistSq,0x800B82EC,0x34
 asm/non_matchings/code/z_actor/Target_IsActorInRange.s,Target_IsActorInRange,0x800B83BC,0xF
 asm/non_matchings/code/z_actor/Target_OutsideLeashRange.s,Target_OutsideLeashRange,0x800B83F8,0x36
-asm/non_matchings/code/z_actor/Actor_ProcessTalkRequest.s,Actor_ProcessTalkRequest,0x800B84D0,0xC
+asm/non_matchings/code/z_actor/Actor_TalkOfferAccepted.s,Actor_TalkOfferAccepted,0x800B84D0,0xC
 asm/non_matchings/code/z_actor/Actor_OfferTalkExchange.s,Actor_OfferTalkExchange,0x800B8500,0x38
 asm/non_matchings/code/z_actor/Actor_OfferTalkExchangeEquiCylinder.s,Actor_OfferTalkExchangeEquiCylinder,0x800B85E0,0xD
 asm/non_matchings/code/z_actor/Actor_OfferTalk.s,Actor_OfferTalk,0x800B8614,0xA


### PR DESCRIPTION
Parallels the discussion happening in OoT, always good to get more thoughts:
https://github.com/zeldaret/oot/pull/1567

Only names and documents 2 things:
`Actor_ProcessTalkRequest` -> `Actor_TalkOfferAccepted`
`ACTOR_FLAG_TALK_REQUESTED` -> `ACTOR_FLAG_TALK` to account for it's multipurpose and that player doesn't really request to talk from the actor, it just initiates talking on it's own after accepting the actors offer and gives a courteous notification to the actor through this flag