### PR TITLE
Allow the mips tool chain to be picked via command argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ OBJDUMP_BUILD ?= 0
 ASM_PROC_FORCE ?= 0
 # Number of threads to disassmble, extract, and compress with
 N_THREADS ?= $(shell nproc)
-
+#MIPS toolchain
+MIPS_BINUTILS_PREFIX ?= mips-linux-gnu-
 #### Setup ####
 
 # Ensure the map file being created using English localization
@@ -62,10 +63,6 @@ else
     CPPFLAGS += -xc++
   endif
 endif
-
-#### Tools ####
-
-MIPS_BINUTILS_PREFIX := mips-linux-gnu-
 
 #### Tools ####
 ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)ld >/dev/null 2>/dev/null; echo $$?), 0)

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,11 @@ endif
 
 #### Tools ####
 
-ifeq ($(shell type mips-linux-gnu-ld >/dev/null 2>/dev/null; echo $$?), 0)
-  MIPS_BINUTILS_PREFIX := mips-linux-gnu-
-else
-  $(error Please install or build mips-linux-gnu)
+MIPS_BINUTILS_PREFIX := mips-linux-gnu-
+
+#### Tools ####
+ifneq ($(shell type $(MIPS_BINUTILS_PREFIX)ld >/dev/null 2>/dev/null; echo $$?), 0)
+  $(error Unable to find $(MIPS_BINUTILS_PREFIX)ld. Please install or build MIPS binutils, commonly mips-linux-gnu. (or set MIPS_BINUTILS_PREFIX if your MIPS binutils install uses another prefix))
 endif
 
 CC       := tools/ido_recomp/$(DETECTED_OS)/7.1/cc


### PR DESCRIPTION
Bring over OOT's makefile section to allow changing the default mips tool chain.