### PR TITLE
Add venv to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,10 @@ pipeline {
         stage('Install Python dependencies') {
             steps {
                 echo 'Installing Python dependencies'
-                sh 'python3 -m pip install -r requirements.txt'
+                sh 'python3 -m venv .venv'
+                sh '''. .venv/bin/activate
+                python3 -m pip install -U -r requirements.txt
+                '''
             }
         }
         stage('Copy ROM') {
@@ -34,7 +37,9 @@ pipeline {
         }
         stage('Setup') {
             steps {
-                sh 'bash -c "make -j setup 2> >(tee tools/warnings_count/warnings_setup_new.txt)"'
+                sh '''. .venv/bin/activate
+                bash -c "make -j setup 2> >(tee tools/warnings_count/warnings_setup_new.txt)"
+                '''
             }
         }
         stage('Check setup warnings') {
@@ -44,7 +49,9 @@ pipeline {
         }
         stage('Assets') {
             steps {
-                sh 'bash -c "make -j assets 2> >(tee tools/warnings_count/warnings_assets_new.txt)"'
+                sh '''. .venv/bin/activate
+                bash -c "make -j assets 2> >(tee tools/warnings_count/warnings_assets_new.txt)"
+                '''
             }
         }
         stage('Check assets warnings') {
@@ -54,7 +61,9 @@ pipeline {
         }
         stage('Disasm') {
             steps {
-                sh 'bash -c "make -j disasm 2> >(tee tools/warnings_count/warnings_disasm_new.txt)"'
+                sh '''. .venv/bin/activate
+                bash -c "make -j disasm 2> >(tee tools/warnings_count/warnings_disasm_new.txt)"
+                '''
             }
         }
         stage('Check disasm warnings') {
@@ -64,7 +73,9 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'bash -c "make -j uncompressed 2> >(tee tools/warnings_count/warnings_build_new.txt)"'
+                sh '''. .venv/bin/activate
+                bash -c "make -j uncompressed 2> >(tee tools/warnings_count/warnings_build_new.txt)"
+                '''
             }
         }
         stage('Check build warnings') {
@@ -74,7 +85,9 @@ pipeline {
         }
         stage('Compress') {
             steps {
-                sh 'bash -c "make -j compressed 2> >(tee tools/warnings_count/warnings_compress_new.txt)"'
+                sh '''. .venv/bin/activate
+                bash -c "make -j compressed 2> >(tee tools/warnings_count/warnings_compress_new.txt)"
+                '''
             }
         }
         stage('Check compress warnings') {
@@ -88,9 +101,15 @@ pipeline {
             }
             steps {
                 sh 'mkdir reports'
-                sh 'python3 ./tools/progress.py csv >> reports/progress-mm-nonmatching.csv'
-                sh 'python3 ./tools/progress.py csv -m >> reports/progress-mm-matching.csv'
-                sh 'python3 ./tools/progress.py shield-json > reports/progress-mm-shield.json'
+                sh '''. .venv/bin/activate
+                python3 ./tools/progress.py csv >> reports/progress-mm-nonmatching.csv
+                '''
+                sh '''. .venv/bin/activate
+                python3 ./tools/progress.py csv -m >> reports/progress-mm-matching.csv
+                '''
+                sh '''. .venv/bin/activate
+                python3 ./tools/progress.py shield-json > reports/progress-mm-shield.json
+                '''
                 stash includes: 'reports/*', name: 'reports'
             }
         }

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -6,7 +6,8 @@ all: $(PROGRAMS)
 	$(MAKE) -C ZAPD
 	$(MAKE) -C fado
 	$(MAKE) -C buildtools
-	$(MAKE) -C z64compress
+# Some gcc versions give a warning about the -flto flag with no parameters. So we override the CFLAGS as a workaround
+	$(MAKE) -C z64compress CFLAGS="-Os -flto=auto"
 
 clean:
 	$(RM) $(PROGRAMS)


### PR DESCRIPTION
Jenkins updated and it now requires to use a venv to install Python packages.

Also, building z64compress on the new Jenkins produce a warning about `-flto`, which produces the CI to fail. As a workaround I'm overriding its CFLAGS on the tools makefile
https://stackoverflow.com/questions/72218980/gcc-v12-1-warning-about-serial-compilation