### PR TITLE
Fix disasm.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ crunch64>=0.3.1,<1.0.0
 ipl3checksum>=1.2.0,<2.0.0
 
 # disasm
-rabbitizer>=1.0.0,<2.0.0
+rabbitizer>=1.3.0,<2.0.0
 
 # Compression
 pyelftools>=0.26

--- a/tools/disasm/disasm.py
+++ b/tools/disasm/disasm.py
@@ -1112,7 +1112,7 @@ def asm_header(section_name: str):
 def getImmOverride(insn: rabbitizer.Instruction):
     if insn.isBranch():
         return f".L{insn.getBranchOffset() + insn.vram:08X}"
-    elif insn.isJump():
+    elif insn.isJumpWithAddress():
         return proper_name(insn.getInstrIndexAsVram(), in_data=False, is_symbol=True)
 
     elif insn.uniqueId == rabbitizer.InstrId.cpu_ori:


### PR DESCRIPTION
The latest version of `rabbitizer` (1.9.1) performs a few runtime checks to prevent the user from doing the wrong thing, which just bite us and showed a bug on our usage of `rabbitizer`.

The bug was caused because we were trying to check if the processed instruction was the jump kind of instruction but it has the target address embedded in the instruction itself (like `jal` and `j`), but the code was checking for every kind of jump, including the ones that use a register to jump to (like `jalr` and `jr`), meaning we were sometimes reading garbage :sweat_smile: .

I bumped the required rabbitizer version to the version that introduces the new function I'm using instead of the latest one.