### PR TITLE
bg_hakugin_post: replace hardcoded size for sizeof

### DIFF
--- a/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.c
+++ b/src/overlays/actors/ovl_Bg_Hakugin_Post/z_bg_hakugin_post.c
@@ -146,7 +146,7 @@ void func_80A9AFB4(BgHakuginPost* this, PlayState* play, BgHakuginPostUnkStruct*
             if ((unkStruct->unk_0000[i].unk_34 == 0) ||
                 (this->dyna.actor.world.pos.y < unkStruct->unk_0000[i].unk_08.y)) {
                 for (j = 10; j >= i; j--) {
-                    bcopy(&unkStruct->unk_0000[j], &unkStruct->unk_0000[j + 1], 0x38);
+                    bcopy(&unkStruct->unk_0000[j], &unkStruct->unk_0000[j + 1], sizeof(BgHakuginPostUnkStruct1));
                 }
                 break;
             }


### PR DESCRIPTION
`unkStruct->unk_0000` is an array of `BgHakuginPostUnkStruct1` and this copy call is copying one entry to another index, so the hardcoded size can be switched to a `sizeof(BgHakuginPostUnkStruct1)` to better represent that.