### PR TITLE
bg_breakwall: fix great bay storm dl reference

### DIFF
--- a/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
+++ b/src/overlays/actors/ovl_Bg_Breakwall/z_bg_breakwall.c
@@ -369,7 +369,7 @@ void func_808B7B54(Actor* thisx, PlayState* play) {
 
     gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, sp50.r, sp50.g, sp50.b, 255);
     gDPSetEnvColor(POLY_XLU_DISP++, sp4C.r, sp4C.g, sp4C.b, 255);
-    gSPDisplayList(POLY_XLU_DISP++, object_posthouse_obj_DL_000A50);
+    gSPDisplayList(POLY_XLU_DISP++, object_kumo30_DL_000A50);
 
     Environment_LerpSandstormColors(D_808B8320, &sp50);
     Environment_LerpSandstormColors(D_808B8340, &sp4C);


### PR DESCRIPTION
This fixes an incorrect DL reference for the great bay storm effect. `func_808B7B54` renders two separate "storm" effects. One of the DL calls goes to `object_posthouse_obj_DL_000A50`, but that is the postmans backpack and hat in the post office. The correct DL for the storm should be `object_kumo30_DL_000A50`.

I presume since both `object_posthouse_obj_DL_000A50` and `object_kumo30_DL_000A50` have the same offset of `0xA50` and objects are loaded into segment 6, that that is why both are considered matching.