### PR TITLE
Jenkinsfile Hotfix: install GitPython for progress script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,6 +23,7 @@ pipeline {
         stage('Install Python dependencies') {
             steps {
                 sh 'bash -c "make -j venv"'
+                sh '.venv/bin/python3 -m pip install GitPython' // Progress script from jenkins requires GitPython
             }
         }
         stage('Copy ROM') {


### PR DESCRIPTION
Missed installing GitPython in the new `venv` environment for running the progress script for Jenkins