### PR TITLE
Remove tailing comma from vscode json file

### DIFF
--- a/docs/tutorial/vscode.md
+++ b/docs/tutorial/vscode.md
@@ -50,7 +50,7 @@ You can create a `.vscode/c_cpp_properties.json` file with `C/C++: Edit Configur
                 "src",
                 "assets",
                 "build/n64-us/",
-                "${workspaceFolder}",
+                "${workspaceFolder}"
             ],
             "defines": [
                 "_LANGUAGE_C" // For gbi.h


### PR DESCRIPTION
JSON does not like trailing comma on arrays.