### PR TITLE
Add original asset names to all `object_s*` files

### DIFF
--- a/assets/xml/objects/object_sb.xml
+++ b/assets/xml/objects/object_sb.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_sb" Segment="6">
-        <Animation Name="object_sb_Anim_00004C" Offset="0x4C" />
-        <Animation Name="object_sb_Anim_0000B4" Offset="0xB4" />
-        <Animation Name="object_sb_Anim_000124" Offset="0x124" />
-        <Animation Name="object_sb_Anim_000194" Offset="0x194" />
+        <Animation Name="object_sb_Anim_00004C" Offset="0x4C" /> <!-- Original name is "sb_close" -->
+        <Animation Name="object_sb_Anim_0000B4" Offset="0xB4" />  <!-- Original name is "sb_jump_end" -->
+        <Animation Name="object_sb_Anim_000124" Offset="0x124" /> <!-- Original name is "sb_jump_start" -->
+        <Animation Name="object_sb_Anim_000194" Offset="0x194" /> <!-- Original name is "sb_open" -->
         <!-- <Blob Name="object_sb_Blob_0001A4" Size="0x49C" Offset="0x1A4" /> -->
         <!-- <Blob Name="object_sb_Blob_000840" Size="0x3C0" Offset="0x840" /> -->
         <DList Name="object_sb_DL_000D80" Offset="0xD80" />
@@ -25,6 +25,6 @@
         <Limb Name="object_sb_Standardlimb_002BB8" Type="Standard" EnumName="OBJECT_SB_LIMB_07" Offset="0x2BB8" />
         <Limb Name="object_sb_Standardlimb_002BC4" Type="Standard" EnumName="OBJECT_SB_LIMB_08" Offset="0x2BC4" />
         <Skeleton Name="object_sb_Skel_002BF0" Type="Flex" LimbType="Standard" LimbNone="OBJECT_SB_LIMB_NONE" LimbMax="OBJECT_SB_LIMB_MAX" EnumName="ObjectSbLimb" Offset="0x2BF0" />
-        <Animation Name="object_sb_Anim_002C8C" Offset="0x2C8C" />
+        <Animation Name="object_sb_Anim_002C8C" Offset="0x2C8C" /> <!-- Original name is "sb_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_sdn.xml
+++ b/assets/xml/objects/object_sdn.xml
@@ -4,18 +4,18 @@
         <DList Name="gSoldierBottleContentsDL" Offset="0x768" />
         <DList Name="gSoldierBottleEmptyContentsDL" Offset="0x800" />
         <Texture Name="gSoldierBottleTex" OutName="soldier_bottle" Format="i4" Width="16" Height="16" Offset="0x808" />
-        <Animation Name="gSoldierStandWithHandOnChestAnim" Offset="0xA54" />
-        <Animation Name="gSoldierDrinkAnim" Offset="0x20D8" />
-        <Animation Name="gSoldierCheerWithSpearAnim" Offset="0x2A84" />
-        <Animation Name="gSoldierSitAndReachAnim" Offset="0x3380" />
-        <Animation Name="gSoldierWaveAnim" Offset="0x3BFC" />
-        <Animation Name="gSoldierStandUpAnim" Offset="0x4770" />
-        <Animation Name="gSoldierLookDownAnim" Offset="0x4AC0" />
-        <Animation Name="gSoldierComeUpHereAnim" Offset="0x5320" />
-        <Animation Name="object_sdn_Anim_0057BC" Offset="0x57BC" /><!-- gSoldierHaltStartAnim? -->
-        <Animation Name="object_sdn_Anim_005D28" Offset="0x5D28" /><!-- gSoldierHaltIdleAnim? -->
-        <Animation Name="object_sdn_Anim_0064C0" Offset="0x64C0" /><!-- gSoldierHaltLoopAnim? -->
-        <Animation Name="gSoldierStandHandOnHipAnim" Offset="0x6C18" />
+        <Animation Name="gSoldierStandWithHandOnChestAnim" Offset="0xA54" /> <!-- Original name is "sdn_lastwait" -->
+        <Animation Name="gSoldierDrinkAnim" Offset="0x20D8" /> <!-- Original name is "sdn_nomu" -->
+        <Animation Name="gSoldierCheerWithSpearAnim" Offset="0x2A84" /> <!-- Original name is "sdn_renshuu" -->
+        <Animation Name="gSoldierSitAndReachAnim" Offset="0x3380" /> <!-- Original name is "sdn_suwaritalk" -->
+        <Animation Name="gSoldierWaveAnim" Offset="0x3BFC" /> <!-- Original name is "sdn_suwariwait" -->
+        <Animation Name="gSoldierStandUpAnim" Offset="0x4770" /> <!-- Original name is "sdn_tatsu" -->
+        <Animation Name="gSoldierLookDownAnim" Offset="0x4AC0" /> <!-- Original name is "sdn_tome01" -->
+        <Animation Name="gSoldierComeUpHereAnim" Offset="0x5320" /> <!-- Original name is "sdn_tome02" -->
+        <Animation Name="object_sdn_Anim_0057BC" Offset="0x57BC" /><!-- gSoldierHaltStartAnim? Original name is "sdn_tome03" -->
+        <Animation Name="object_sdn_Anim_005D28" Offset="0x5D28" /><!-- gSoldierHaltIdleAnim? Original name is "sdn_tome04" -->
+        <Animation Name="object_sdn_Anim_0064C0" Offset="0x64C0" /><!-- gSoldierHaltLoopAnim? Original name is "sdn_tome05" -->
+        <Animation Name="gSoldierStandHandOnHipAnim" Offset="0x6C18" /> <!-- Original name is "sdn_wait01" -->
         <DList Name="gSoldierTorsoDL" Offset="0x9EB0" />
         <DList Name="gSoldierHeadDL" Offset="0xA1A8" />
         <DList Name="gSoldierRightShoulderDL" Offset="0xA678" />
@@ -61,6 +61,6 @@
         <Limb Name="gSoldierRightHandWithSpearLimb" Type="Standard" EnumName="SOLDIER_LIMB_RIGHT_HAND_WITH_SPEAR" Offset="0xD5E8" />
         <Limb Name="gSoldierHeadLimb" Type="Standard" EnumName="SOLDIER_LIMB_HEAD" Offset="0xD5F4" />
         <Skeleton Name="gSoldierSkel" Type="Flex" LimbType="Standard" LimbNone="SOLDIER_LIMB_NONE" LimbMax="SOLDIER_LIMB_MAX" EnumName="SoldierLimb" Offset="0xD640" />
-        <Animation Name="gSoldierStandAndLookDownAnim" Offset="0xDC7C" />
+        <Animation Name="gSoldierStandAndLookDownAnim" Offset="0xDC7C" /> <!-- Original name is "sdn_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_secom_obj.xml
+++ b/assets/xml/objects/object_secom_obj.xml
@@ -1,15 +1,15 @@
 ﻿<Root>
     <File Name="object_secom_obj" Segment="6">
-        <DList Name="object_secom_obj_DL_000080" Offset="0x80" />
-        <Collision Name="object_secom_obj_Colheader_0001C0" Offset="0x1C0" />
+        <DList Name="object_secom_obj_DL_000080" Offset="0x80" /> <!-- Original name is "z2_secom_dor_model" -->
+        <Collision Name="object_secom_obj_Colheader_0001C0" Offset="0x1C0" /> <!-- Original name is "z2_secom_dor_bgdatainfo" -->
         <Texture Name="object_secom_obj_Tex_0001F0" OutName="tex_0001F0" Format="rgba16" Width="32" Height="64" Offset="0x1F0" />
-        <DList Name="object_secom_obj_DL_001230" Offset="0x1230" />
-        <DList Name="object_secom_obj_DL_001300" Offset="0x1300" />
+        <DList Name="object_secom_obj_DL_001230" Offset="0x1230" /> <!-- Original name is "z2_secom_huta_model" -->
+        <DList Name="object_secom_obj_DL_001300" Offset="0x1300" /> <!-- Original name is "z2_secom_huta2_model" -->
         <Texture Name="object_secom_obj_Tex_001390" OutName="tex_001390" Format="rgba16" Width="15" Height="32" Offset="0x1390" />
         <Texture Name="object_secom_obj_Tex_001750" OutName="tex_001750" Format="rgba16" Width="16" Height="16" Offset="0x1750" />
         <DList Name="object_secom_obj_DL_001A50" Offset="0x1A50" />
-        <DList Name="object_secom_obj_DL_001A58" Offset="0x1A58" />
+        <DList Name="object_secom_obj_DL_001A58" Offset="0x1A58" /> <!-- Original name is "m2_TOGEblockSECOM_model" -->
         <Texture Name="object_secom_obj_Tex_001B08" OutName="tex_001B08" Format="rgba16" Width="32" Height="64" Offset="0x1B08" />
-        <Collision Name="object_secom_obj_Colheader_002CB8" Offset="0x2CB8" />
+        <Collision Name="object_secom_obj_Colheader_002CB8" Offset="0x2CB8" /> <!-- Original name is "pzlblock_secom_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_sek.xml
+++ b/assets/xml/objects/object_sek.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_sek" Segment="6">
-        <DList Name="gOwlStatueClosedDL" Offset="0x1D0" />
+        <DList Name="gOwlStatueClosedDL" Offset="0x1D0" /> <!-- Original name is "sek_close_model" -->
         <Texture Name="object_sek_Tex_0003F0" OutName="tex_0003F0" Format="ci8" Width="32" Height="32" Offset="0x3F0" />
         <Texture Name="object_sek_Tex_0007F0" OutName="tex_0007F0" Format="ci8" Width="32" Height="32" Offset="0x7F0" />
-        <DList Name="object_sek_DL_001110" Offset="0x1110" />
+        <DList Name="object_sek_DL_001110" Offset="0x1110" /> <!-- Original name is "sek_head_model" -->
         <Texture Name="object_sek_TLUT_001610" OutName="tlut_001610" Format="rgba16" Width="16" Height="16" Offset="0x1610" />
         <Texture Name="object_sek_Tex_001810" OutName="tex_001810" Format="ci8" Width="32" Height="32" Offset="0x1810" />
         <Texture Name="object_sek_Tex_001C10" OutName="tex_001C10" Format="ci8" Width="32" Height="32" Offset="0x1C10" />
@@ -11,7 +11,7 @@
         <Texture Name="object_sek_Tex_002410" OutName="tex_002410" Format="ci8" Width="32" Height="32" Offset="0x2410" />
         <Texture Name="object_sek_Tex_002810" OutName="tex_002810" Format="ci8" Width="32" Height="32" Offset="0x2810" />
         <Texture Name="object_sek_Tex_002C10" OutName="tex_002C10" Format="ci8" Width="32" Height="32" Offset="0x2C10" />
-        <DList Name="gOwlStatueOpenedDL" Offset="0x3770" />
+        <DList Name="gOwlStatueOpenedDL" Offset="0x3770" /> <!-- Original name is "sek_open_model" -->
         <Texture Name="object_sek_Tex_003A70" OutName="tex_003A70" Format="ci8" Width="32" Height="64" Offset="0x3A70" />
         <Texture Name="object_sek_Tex_004270" OutName="tex_004270" Format="ci8" Width="32" Height="64" Offset="0x4270" />
     </File>

--- a/assets/xml/objects/object_sichitai_obj.xml
+++ b/assets/xml/objects/object_sichitai_obj.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_sichitai_obj" Segment="6">
-        <DList Name="gSichitaiBoatDL" Offset="0x6B0" />
+        <DList Name="gSichitaiBoatDL" Offset="0x6B0" /> <!-- Original name is "z2_20_hune01_model" -->
         <Texture Name="gSichitaiThwartTex" OutName="tex_000878" Format="rgba16" Width="16" Height="16" Offset="0x878" />
         <Texture Name="gSichitaiHullTex" OutName="tex_000A78" Format="rgba16" Width="32" Height="32" Offset="0xA78" />
-        <Collision Name="gSichitaiBoatCol" Offset="0x16DC" />
+        <Collision Name="gSichitaiBoatCol" Offset="0x16DC" /> <!-- Original name is "z2_20_hune01_bgdatainfo" -->
         <DList Name="object_sichitai_obj_DL_001820" Offset="0x1820" />
         <Texture Name="object_sichitai_obj_Tex_001908" OutName="tex_001908" Format="rgba16" Width="32" Height="32" Offset="0x1908" />
         <Texture Name="object_sichitai_obj_Tex_002108" OutName="tex_002108" Format="i4" Width="64" Height="64" Offset="0x2108" />

--- a/assets/xml/objects/object_sinkai_kabe.xml
+++ b/assets/xml/objects/object_sinkai_kabe.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <!-- The collision for the front of the Deep Python's den (the invisible wall) -->
     <File Name="object_sinkai_kabe" Segment="6">
-        <Collision Name="gPinnacleRockPythonDenCol" Offset="0x48" />
+        <Collision Name="gPinnacleRockPythonDenCol" Offset="0x48" /> <!-- Original name is "z2_32_kabe_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_skb.xml
+++ b/assets/xml/objects/object_skb.xml
@@ -1,16 +1,16 @@
 ﻿<Root>
     <!-- Assets for Stalchild -->
     <File Name="object_skb" Segment="6">
-        <Animation Name="gStalchildIdleAnim" Offset="0x9E4" />
-        <Animation Name="gStalchildSaluteAnim" Offset="0x15EC" />
-        <Animation Name="gStalchildSwingOnBranchAnim" Offset="0x1D1C" />
-        <Animation Name="gStalchildAttackAnim" Offset="0x2190" />
+        <Animation Name="gStalchildIdleAnim" Offset="0x9E4" /> <!-- Original name is "babestl_kaiwa" -->
+        <Animation Name="gStalchildSaluteAnim" Offset="0x15EC" /> <!-- Original name is "babestl_keirei" -->
+        <Animation Name="gStalchildSwingOnBranchAnim" Offset="0x1D1C" /> <!-- Original name is "burasagari_wait" -->
+        <Animation Name="gStalchildAttackAnim" Offset="0x2190" /> <!-- Original name is "stal_baby_attack" -->
         <!-- <Blob Name="object_skb_zeroes_unk_000021A0" Size="0x20" Offset="0x21A0" /> -->
-        <Animation Name="gStalchildCollapseAnim" Offset="0x270C" />
+        <Animation Name="gStalchildCollapseAnim" Offset="0x270C" /> <!-- Original name is "stal_baby_down" -->
         <!-- <Blob Name="object_skb_zeroes_unk_00002720" Size="0x20" Offset="0x2720" /> -->
-        <Animation Name="gStalchildStaggerAnim" Offset="0x2AC8" />
+        <Animation Name="gStalchildStaggerAnim" Offset="0x2AC8" /> <!-- Original name is "stal_baby_hit" -->
         <!-- <Blob Name="object_skb_zeroes_unk_00002AE0" Size="0x10" Offset="0x2AE0" /> -->
-        <Animation Name="gStalchildStandUpAnim" Offset="0x3584" />
+        <Animation Name="gStalchildStandUpAnim" Offset="0x3584" /> <!-- Original name is "stal_baby_start" -->
         <Texture Name="gStalchildPelvisTex" OutName="stalchild_pelvis" Format="rgba16" Width="16" Height="16" Offset="0x35A0" />
         <Texture Name="gStalchildRibcageTex" OutName="stalchild_ribcage" Format="rgba16" Width="8" Height="16" Offset="0x37A0" />
         <Texture Name="gStalchildSkullTex" OutName="stalchild_skull" Format="rgba16" Width="8" Height="8" Offset="0x38A0" />
@@ -57,9 +57,9 @@
         <Limb Name="gStalchildLeftHandLimb" Type="Standard" EnumName="STALCHILD_LIMB_LEFT_HAND" Offset="0x5E94" />
         <Limb Name="gStalchildSpineLimb" Type="Standard" EnumName="STALCHILD_LIMB_SPINE" Offset="0x5EA0" />
         <Skeleton Name="gStalchildSkel" Type="Normal" LimbType="Standard" LimbNone="STALCHILD_LIMB_NONE" LimbMax="STALCHILD_LIMB_MAX" EnumName="StalchildLimb" Offset="0x5EF8" />
-        <Animation Name="gStalchildWalkAnim" Offset="0x64E0" />
+        <Animation Name="gStalchildWalkAnim" Offset="0x64E0" /> <!-- Original name is "stal_baby_walk" -->
         <!-- <Blob Name="object_skb_zeroes_unk_000064F0" Size="0x20" Offset="0x64F0" /> -->
-        <Animation Name="gStalchildSitLaughAnim" Offset="0x697C" />
-        <Animation Name="gStalchildSitTapToesAnim" Offset="0x6D90" />
+        <Animation Name="gStalchildSitLaughAnim" Offset="0x697C" /> <!-- Original name is "suwari_wait" -->
+        <Animation Name="gStalchildSitTapToesAnim" Offset="0x6D90" /> <!-- Original name is "yankey_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_slime.xml
+++ b/assets/xml/objects/object_slime.xml
@@ -4,7 +4,7 @@
         <DList Name="gChuchuBodyDL" Offset="0x4C0" />
         <DList Name="gChuchuEyesDL" Offset="0x650" />
         <TextureAnimation Name="gChuchuSlimeFlowTexAnim" Offset="0x828" />
-        <DList Name="gChuchuPuddleDL" Offset="0xA10" />
+        <DList Name="gChuchuPuddleDL" Offset="0xA10" /> <!-- Original name is "chuchu_dodai" -->
         <DList Name="gChuchuEmptyDL" Offset="0xB68" />
         <Texture Name="gChuchuMouthTex" OutName="chuchu_mouth" Format="rgba16" Width="16" Height="16" Offset="0xB70" />
         <Texture Name="gChuchuEyeSocketTex" OutName="chuchu_eye_socket" Format="rgba16" Width="16" Height="16" Offset="0xD70" />

--- a/assets/xml/objects/object_smtower.xml
+++ b/assets/xml/objects/object_smtower.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_smtower" Segment="6">
-        <DList Name="object_smtower_DL_000520" Offset="0x520" />
+        <DList Name="object_smtower_DL_000520" Offset="0x520" /> <!-- Original name is "smtower_model" -->
         <Texture Name="object_smtower_Tex_000778" OutName="tex_000778" Format="i8" Width="64" Height="32" Offset="0x778" />
         <Texture Name="object_smtower_Tex_000F78" OutName="tex_000F78" Format="i4" Width="64" Height="64" Offset="0xF78" />
         <TextureAnimation Name="object_smtower_Matanimheader_001788" Offset="0x1788" />

--- a/assets/xml/objects/object_snowwd.xml
+++ b/assets/xml/objects/object_snowwd.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_snowwd" Segment="6">
-        <DList Name="gSnowTreeEmptyDL" Offset="0x190" />
-        <DList Name="gSnowTreeDL" Offset="0x198" />
+        <DList Name="gSnowTreeEmptyDL" Offset="0x190" /> <!-- Original name is "z2_snowwood_modelT" -->
+        <DList Name="gSnowTreeDL" Offset="0x198" /> <!-- Original name is "z2_snowwood_model" -->
         <Texture Name="gSnowTreeLeavesTex" OutName="snow_tree_leaves" Format="rgba16" Width="32" Height="64" Offset="0x2A0" />
         <Texture Name="gSnowTreeBodyTex" OutName="snow_tree_body" Format="rgba16" Width="32" Height="32" Offset="0x12A0" />
         <Texture Name="gSnowTreeSnowLeavesTex" OutName="snow_tree_snow_leaves" Format="rgba16" Width="32" Height="64" Offset="0x1AA0" />

--- a/assets/xml/objects/object_spdweb.xml
+++ b/assets/xml/objects/object_spdweb.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_spdweb" Segment="6">
-        <DList Name="object_spdweb_DL_000060" Offset="0x60" />
-        <DList Name="object_spdweb_DL_000130" Offset="0x130" />
+        <DList Name="object_spdweb_DL_000060" Offset="0x60" /> <!-- Original name is "m2_KUMOkabeFIRE_modelT" -->
+        <DList Name="object_spdweb_DL_000130" Offset="0x130" /> <!-- Original name is "m2_KUMOkabeFIRE_model" -->
         <Texture Name="object_spdweb_Tex_000138" OutName="tex_000138" Format="rgba16" Width="32" Height="32" Offset="0x138" />
         <Texture Name="object_spdweb_Tex_000938" OutName="tex_000938" Format="ia8" Width="32" Height="64" Offset="0x938" />
-        <Collision Name="object_spdweb_Colheader_0011C0" Offset="0x11C0" />
-        <DList Name="object_spdweb_DL_0012F0" Offset="0x12F0" />
-        <DList Name="object_spdweb_DL_001400" Offset="0x1400" />
+        <Collision Name="object_spdweb_Colheader_0011C0" Offset="0x11C0" /> <!-- Original name is "m2_KUMOkabeFIRE_bgdatainfo" -->
+        <DList Name="object_spdweb_DL_0012F0" Offset="0x12F0" /> <!-- Original name is "m2_KUMOyukaBOYON_modelT" -->
+        <DList Name="object_spdweb_DL_001400" Offset="0x1400" /> <!-- Original name is "m2_KUMOyukaBOYON_model" -->
         <Texture Name="object_spdweb_Tex_001408" OutName="tex_001408" Format="ia8" Width="64" Height="64" Offset="0x1408" />
-        <Collision Name="object_spdweb_Colheader_002678" Offset="0x2678" />
+        <Collision Name="object_spdweb_Colheader_002678" Offset="0x2678" /> <!-- Original name is "m2_KUMOyukaBOYON_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_spidertent.xml
+++ b/assets/xml/objects/object_spidertent.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_spidertent" Segment="6">
-        <DList Name="object_spidertent_DL_000070" Offset="0x70" />
+        <DList Name="object_spidertent_DL_000070" Offset="0x70" /> <!-- Original name is "m2_KinKumonosu01_modelT" -->
         <DList Name="object_spidertent_DL_000108" Offset="0x108" />
         <Texture Name="object_spidertent_Tex_000110" OutName="tex_000110" Format="ia8" Width="64" Height="64" Offset="0x110" />
-        <Collision Name="object_spidertent_Colheader_0011AC" Offset="0x11AC" />
-        <DList Name="object_spidertent_DL_001250" Offset="0x1250" />
+        <Collision Name="object_spidertent_Colheader_0011AC" Offset="0x11AC" /> <!-- Original name is "m2_KinKumonosu01_bgdatainfo" -->
+        <DList Name="object_spidertent_DL_001250" Offset="0x1250" /> <!-- Original name is "m2_KinKumonosu02_modelT" -->
         <DList Name="object_spidertent_DL_0012E8" Offset="0x12E8" />
         <Texture Name="object_spidertent_Tex_0012F0" OutName="tex_0012F0" Format="ia8" Width="64" Height="64" Offset="0x12F0" />
-        <Collision Name="object_spidertent_Colheader_00238C" Offset="0x238C" />
+        <Collision Name="object_spidertent_Colheader_00238C" Offset="0x238C" /> <!-- Original name is "m2_KinKumonosu02_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_spinyroll.xml
+++ b/assets/xml/objects/object_spinyroll.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <File Name="object_spinyroll" Segment="6">
-        <DList Name="object_spinyroll_DL_000460" Offset="0x460" />
+        <DList Name="object_spinyroll_DL_000460" Offset="0x460" /> <!-- Original name is "yda5_02_model" -->
         <Texture Name="object_spinyroll_Tex_0005C0" OutName="tex_0005C0" Format="rgba16" Width="32" Height="32" Offset="0x5C0" />
-        <Collision Name="object_spinyroll_Colheader_000E68" Offset="0xE68" />
-        <Collision Name="object_spinyroll_Colheader_000F80" Offset="0xF80" />
+        <Collision Name="object_spinyroll_Colheader_000E68" Offset="0xE68" /> <!-- Original name is "spinyroll_bgdatainfo" -->
+        <Collision Name="object_spinyroll_Colheader_000F80" Offset="0xF80" /> <!-- Original name is "vspinyroll_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_spot11_obj.xml
+++ b/assets/xml/objects/object_spot11_obj.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_spot11_obj" Segment="6">
-        <DList Name="gSpot11EmptyDL" Offset="0x80" />
-        <DList Name="gGoronDoorDL" Offset="0x88" />
+        <DList Name="gSpot11EmptyDL" Offset="0x80" /> <!-- Original name is "z2_11_tobira01_modelT" -->
+        <DList Name="gGoronDoorDL" Offset="0x88" /> <!-- Original name is "z2_11_tobira01_model" -->
         <Texture Name="gGoronDoorTex" OutName="goron_door" Format="rgba16" Width="32" Height="64" Offset="0x120" />
-        <Collision Name="gGoronDoorCol" Offset="0x11C0" />
-        <DList Name="gWoodStepDL" Offset="0x13F0" />
+        <Collision Name="gGoronDoorCol" Offset="0x11C0" /> <!-- Original name is "z2_11_tobira01_bgdatainfo" -->
+        <DList Name="gWoodStepDL" Offset="0x13F0" /> <!-- Original name is "z2_11_dai_model" -->
         <Texture Name="gWoodTLUT" OutName="wood_tlut" Format="rgba16" Width="16" Height="16" Offset="0x1560" />
         <Texture Name="gWoodStepTopTex" OutName="wood_step_top" Format="ci8" Width="32" Height="32" Offset="0x1760" />
         <Texture Name="gWoodStepSideTex" OutName="wood_step_side" Format="ci8" Width="32" Height="16" Offset="0x1B60" />
-        <Collision Name="gWoodStepCol" Offset="0x1EB8" />
+        <Collision Name="gWoodStepCol" Offset="0x1EB8" /> <!-- Original name is "z2_11_dai_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_ssh.xml
+++ b/assets/xml/objects/object_ssh.xml
@@ -3,7 +3,7 @@
         <DList Name="object_ssh_DL_0000D0" Offset="0xD0" />
         <DList Name="object_ssh_DL_0000D8" Offset="0xD8" />
         <Texture Name="object_ssh_Tex_000190" OutName="tex_000190" Format="rgba16" Width="32" Height="64" Offset="0x190" />
-        <Animation Name="object_ssh_Anim_001494" Offset="0x1494" />
+        <Animation Name="object_ssh_Anim_001494" Offset="0x1494" /> <!-- Original name is "st_matsu" -->
         <Texture Name="object_ssh_TLUT_0014B0" OutName="tlut_0014B0" Format="rgba16" Width="16" Height="16" Offset="0x14B0" />
         <Texture Name="object_ssh_Tex_0016B0" OutName="tex_0016B0" Format="ci8" Width="8" Height="8" Offset="0x16B0" />
         <Texture Name="object_ssh_Tex_0016F0" OutName="tex_0016F0" Format="ci8" Width="16" Height="8" Offset="0x16F0" />
@@ -58,7 +58,7 @@
         <Limb Name="object_ssh_Standardlimb_0063E4" Type="Standard" EnumName="OBJECT_SSH_LIMB_1C" Offset="0x63E4" />
         <Limb Name="object_ssh_Standardlimb_0063F0" Type="Standard" EnumName="OBJECT_SSH_LIMB_1D" Offset="0x63F0" />
         <Skeleton Name="object_ssh_Skel_006470" Type="Normal" LimbType="Standard" LimbNone="OBJECT_SSH_LIMB_NONE" LimbMax="OBJECT_SSH_LIMB_MAX" EnumName="ObjectSshLimb" Offset="0x6470" />
-        <Animation Name="object_ssh_Anim_006788" Offset="0x6788" />
-        <Animation Name="object_ssh_Anim_006D78" Offset="0x6D78" />
+        <Animation Name="object_ssh_Anim_006788" Offset="0x6788" /> <!-- Original name is "st_otchiru" -->
+        <Animation Name="object_ssh_Anim_006D78" Offset="0x6D78" /> <!-- Original name is "st_yarare" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_st.xml
+++ b/assets/xml/objects/object_st.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_st" Segment="6">
-        <Animation Name="object_st_Anim_000304" Offset="0x304" />
+        <Animation Name="object_st_Anim_000304" Offset="0x304" /> <!-- Original name is "st_matsu" -->
         <Texture Name="object_st_Tex_000320" OutName="tex_000320" Format="i4" Width="16" Height="8" Offset="0x320" />
         <Texture Name="object_st_Tex_000360" OutName="tex_000360" Format="rgba16" Width="16" Height="8" Offset="0x360" />
         <Texture Name="object_st_Tex_000460" OutName="tex_000460" Format="rgba16" Width="8" Height="8" Offset="0x460" />
@@ -33,8 +33,8 @@
         <DList Name="object_st_DL_0048B8" Offset="0x48B8" />
         <DList Name="object_st_DL_004950" Offset="0x4950" />
         <DList Name="object_st_DL_0049E8" Offset="0x49E8" />
-        <DList Name="gSkulltulaTokenDL" Offset="0x4DB0" />
-        <DList Name="gSkulltulaTokenFlameDL" Offset="0x4EB8" />
+        <DList Name="gSkulltulaTokenDL" Offset="0x4DB0" /> <!-- Original name is "gi_sutaru_model" -->
+        <DList Name="gSkulltulaTokenFlameDL" Offset="0x4EB8" /> <!-- Original name is "gi_sutaru_modelT" -->
         <Limb Name="object_st_Standardlimb_0050C8" Type="Standard" EnumName="OBJECT_ST_LIMB_01" Offset="0x50C8" />
         <Limb Name="object_st_Standardlimb_0050D4" Type="Standard" EnumName="OBJECT_ST_LIMB_02" Offset="0x50D4" />
         <Limb Name="object_st_Standardlimb_0050E0" Type="Standard" EnumName="OBJECT_ST_LIMB_03" Offset="0x50E0" />
@@ -65,7 +65,7 @@
         <Limb Name="object_st_Standardlimb_00520C" Type="Standard" EnumName="OBJECT_ST_LIMB_1C" Offset="0x520C" />
         <Limb Name="object_st_Standardlimb_005218" Type="Standard" EnumName="OBJECT_ST_LIMB_1D" Offset="0x5218" />
         <Skeleton Name="object_st_Skel_005298" Type="Normal" LimbType="Standard" LimbNone="OBJECT_ST_LIMB_NONE" LimbMax="OBJECT_ST_LIMB_MAX" EnumName="ObjectStLimb" Offset="0x5298" />
-        <Animation Name="object_st_Anim_0055A8" Offset="0x55A8" />
-        <Animation Name="object_st_Anim_005B98" Offset="0x5B98" />
+        <Animation Name="object_st_Anim_0055A8" Offset="0x55A8" /> <!-- Original name is "st_otchiru" -->
+        <Animation Name="object_st_Anim_005B98" Offset="0x5B98" /> <!-- Original name is "st_yarare" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_syokudai.xml
+++ b/assets/xml/objects/object_syokudai.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <ExternalFile XmlPath="objects/gameplay_dangeon_keep.xml" OutPath="assets/objects/gameplay_dangeon_keep/"/>
     <File Name="object_syokudai" Segment="6">
-        <DList Name="gObjectSyokudaiTypeSwitchCausesFlameDL" Offset="0x3A0" />
-        <DList Name="gObjectSyokudaiTypeNoSwitchDL" Offset="0x870" />
-        <DList Name="gObjectSyokudaiTypeFlameCausesSwitchDL" Offset="0xB90" />
+        <DList Name="gObjectSyokudaiTypeSwitchCausesFlameDL" Offset="0x3A0" /> <!-- Original name is "syokudai_model" -->
+        <DList Name="gObjectSyokudaiTypeNoSwitchDL" Offset="0x870" /> <!-- Original name is "syokudai_isi_model" -->
+        <DList Name="gObjectSyokudaiTypeFlameCausesSwitchDL" Offset="0xB90" /> <!-- Original name is "syokudai_ki_model" -->
         <Texture Name="object_syokudai_Tex_000C90" OutName="tex_000C90" Format="rgba16" Width="32" Height="32" Offset="0xC90" />
         <Texture Name="object_syokudai_Tex_001490" OutName="tex_001490" Format="rgba16" Width="32" Height="64" Offset="0x1490" />
         <Texture Name="object_syokudai_Tex_002490" OutName="tex_002490" Format="rgba16" Width="32" Height="32" Offset="0x2490" />

--- a/assets/xml/objects/object_syoten.xml
+++ b/assets/xml/objects/object_syoten.xml
@@ -26,7 +26,7 @@
         <Array Name="object_syotenVtx_0018C0" Count="81" Offset="0x18C0">
             <Vtx/>
         </Array>
-        <DList Name="object_syoten_DL_001DD0" Offset="0x1DD0" />
+        <DList Name="object_syoten_DL_001DD0" Offset="0x1DD0" /> <!-- Original name is "soul_shoten4" -->
         <DList Name="object_syoten_DL_002018" Offset="0x2018" />
         <DList Name="object_syoten_DL_002880" Offset="0x2880" />
         <DList Name="object_syoten_DL_002A20" Offset="0x2A20" />


### PR DESCRIPTION
A couple of notes:
- MM3D removed `object_sth`, `object_stream`, and all of the `object_sekihi*` objects. The first was just `object_boj` with the animations removed, and the second was the object used for an unused actor. However, while most of the `sekihi` objects were unused grave variations, `object_sekihiz` *was* used for the Song of Soaring pedestal in MM64. How did they handle that pedestal in MM3D? They simply baked it into the Southern Swamp scene.
- The original skulltula token assets from MM64 are actually in MM3D's version of `object_st`. This isn't exactly noteworthy by itself, but it explicitly confirms that the `_model` DList comes before the `_modelT` DList, which is extremely rare.
- Speaking of Skulltulas, the unused animation in `object_sth` is clearly intended to be a death animation, as it looks exactly like the animation of the same name used in `object_st`.
- It's probably possible to name more assets in `object_syoten` once we have some `c_keyframe` docs and some docs for the actor. I only managed to name one thing because it was the only asset that was obvious just by looking at it.