### PR TITLE
Document missing gDPSetEnvColor

### DIFF
--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -4055,6 +4055,11 @@ void Interface_DrawAmmoCount(PlayState* play, s16 button, s16 alpha) {
         }
 
         gDPPipeSync(OVERLAY_DISP++);
+        // @bug Missing a gDPSetEnvColor here, which means the ammo count will be drawn with the last env color set.
+        // Once you have the magic meter, this becomes a non issue, as the magic meter will set the color to black,
+        // but prior to that, when certain conditions are met, the color will have last been set by the wallet icon
+        // causing the ammo count to be drawn incorrectly. This is most obvious when you get deku nuts early on, and
+        // the ammo count is drawn with a shade of green.
 
         if ((button == EQUIP_SLOT_B) && (gSaveContext.minigameStatus == MINIGAME_STATUS_ACTIVE)) {
             ammo = play->interfaceCtx.minigameAmmo;


### PR DESCRIPTION
Examples of what the ammo count looks like with each of the wallet tiers:
<img width="150" alt="Screenshot 2024-05-01 at 10 07 26 AM" src="https://github.com/zeldaret/mm/assets/7316699/940ed67f-3d87-4a64-852d-a6c529ddea85">
<img width="146" alt="Screenshot 2024-05-01 at 10 07 59 AM" src="https://github.com/zeldaret/mm/assets/7316699/7e8dced5-3cd5-4cd2-8f67-30d285dda07f">
<img width="160" alt="Screenshot 2024-05-01 at 10 08 11 AM" src="https://github.com/zeldaret/mm/assets/7316699/ab177800-d1bf-4ed3-9e2d-6b70f8964fcc">
