### PR TITLE
CLOSE_DISPS fixes and avoid early return

### DIFF
--- a/src/code/z_eff_blure.c
+++ b/src/code/z_eff_blure.c
@@ -658,7 +658,8 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
     OPEN_DISPS(gfxCtx);
 
     if (this->numElements < 2) {
-        goto close_disps;
+        //! @bug Skips CLOSE_DISPS
+        return;
     }
 
     this->elements[0].flags &= ~(EFFECT_BLURE_ELEMENT_FLAG_1 | EFFECT_BLURE_ELEMENT_FLAG_2);
@@ -678,7 +679,8 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &sp5C);
     if (mtx == NULL) {
-        goto close_disps;
+        //! @bug Skips CLOSE_DISPS
+        return;
     }
 
     gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -705,7 +707,6 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
         }
     }
 
-close_disps:
     CLOSE_DISPS(gfxCtx);
 }
 

--- a/src/code/z_eff_blure.c
+++ b/src/code/z_eff_blure.c
@@ -658,7 +658,7 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
     OPEN_DISPS(gfxCtx);
 
     if (this->numElements < 2) {
-        return;
+        goto close_disps;
     }
 
     this->elements[0].flags &= ~(EFFECT_BLURE_ELEMENT_FLAG_1 | EFFECT_BLURE_ELEMENT_FLAG_2);
@@ -678,7 +678,7 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
 
     mtx = SkinMatrix_MtxFToNewMtx(gfxCtx, &sp5C);
     if (mtx == NULL) {
-        return;
+        goto close_disps;
     }
 
     gSPMatrix(POLY_XLU_DISP++, mtx, G_MTX_NOPUSH | G_MTX_LOAD | G_MTX_MODELVIEW);
@@ -705,6 +705,7 @@ void EffectBlure_DrawSmooth(EffectBlure* this2, GraphicsContext* gfxCtx) {
         }
     }
 
+close_disps:
     CLOSE_DISPS(gfxCtx);
 }
 

--- a/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
+++ b/src/overlays/actors/ovl_En_Mnk/z_en_mnk.c
@@ -2203,17 +2203,17 @@ void EnMnk_Monkey_DrawFace(EnMnk* this, PlayState* play) {
             } else {
                 gSPSegment(POLY_OPA_DISP++, 0x08, Lib_SegmentedToVirtual(sMonkeyFaceTextures[this->blinkFrame]));
             }
-            return;
+            break;
 
         case 2:
         case 3:
             gSPSegment(POLY_OPA_DISP++, 0x08, Lib_SegmentedToVirtual(sMonkeyFaceTextures[this->unk_3E0]));
-            return;
+            break;
 
         default:
+            gSPSegment(POLY_OPA_DISP++, 0x08, Lib_SegmentedToVirtual(sMonkeyFaceTextures[this->blinkFrame]));
             break;
     }
-    gSPSegment(POLY_OPA_DISP++, 0x08, Lib_SegmentedToVirtual(sMonkeyFaceTextures[this->blinkFrame]));
 
     CLOSE_DISPS(play->state.gfxCtx);
 }

--- a/src/overlays/actors/ovl_En_Osn/z_en_osn.c
+++ b/src/overlays/actors/ovl_En_Osn/z_en_osn.c
@@ -1064,7 +1064,7 @@ void EnOsn_Draw(Actor* thisx, PlayState* play) {
         POLY_XLU_DISP =
             SkelAnime_DrawFlex(play, this->skelAnime.skeleton, this->skelAnime.jointTable, this->skelAnime.dListCount,
                                EnOsn_OverrideLimbDraw, EnOsn_PostLimbDraw, &this->actor, POLY_XLU_DISP);
-
-        CLOSE_DISPS(play->state.gfxCtx);
     }
+
+    CLOSE_DISPS(play->state.gfxCtx);
 }


### PR DESCRIPTION
After seeing the bug about early returns in a OPEN/CLOSE_DISPS pairs, I did some poking around and found some areas that I think can be improved.

* Happy Mask Salesman draw had a misplaced `CLOSE_DISPS`. Originally this matched for retail, but I imagine would fail for debug rom matching (when CLOSE_DISPS becomes more than a closing bracket)
* The Monkey face draw had some returns in a switch, but reworking this to move the one `gSPSegment` up into the `default` case means we can swap the `return` for `break` in the other cases and still be matching
* The last one I found was in `eff_blure` where there are returns for null mtx or no elements to draw. ~~Here I opted for `goto close_disps` which sorta matches other places that this is done (`z_eff_spark`, `z_skin`)~~ Instead, per feedback about this being like this even in debug rom, I've added `@bug` tags indicating that the CLOSE_DISPS is skipped.