### PR TITLE
Document Bug in EnMttag_GetCurrentCheckpoint and Cleanup

### DIFF
--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -153,7 +153,8 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     checkpointIterator = sStartingCheckpointPerSceneExitIndex[sceneExitIndex];
 
     // Iterates through all possible checkpoints that are associated with this sceneExitIndex.
-    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18, due to the `sceneExitIndex + 1` access.
+    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18, due to the
+    //! `sceneExitIndex + 1` access.
     do {
         if (Math3D_PointDistToLine2D(
                 actor->world.pos.x, actor->world.pos.z, sCheckpointPositions[checkpointIterator - 1].x,

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -155,7 +155,7 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     // Iterates through all possible checkpoints that are associated with this sceneExitIndex.
     //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18
     do {
-        if (Math3D_PointDistSqToLine2DImpl(
+        if (Math3D_PointDistToLine2D(
                 actor->world.pos.x, actor->world.pos.z, sCheckpointPositions[checkpointIterator - 1].x,
                 sCheckpointPositions[checkpointIterator - 1].z, sCheckpointPositions[checkpointIterator + 1].x,
                 sCheckpointPositions[checkpointIterator + 1].z, &perpendicularPointX, &perpendicularPointZ,

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -133,7 +133,7 @@ s32 EnMttag_AreFourRaceGoronsPresent(EnMttag* this, PlayState* play) {
  */
 s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingCheckpoint, f32* outPerpendicularPointX,
                                  f32* outPerpendicularPointZ) {
-    s32 curentCheckpoint = -1;
+    s32 currentCheckpoint = -1;
     s32 hasSetCurrentCheckpointOnce = false;
     f32 minLineLengthSq = 0.0f;
     s32 sceneExitIndex;
@@ -153,16 +153,17 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     checkpointIterator = sStartingCheckpointPerSceneExitIndex[sceneExitIndex];
 
     // Iterates through all possible checkpoints that are associated with this sceneExitIndex.
+    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18
     do {
-        if (Math3D_PointDistToLine2D(
-                actor->world.pos.x, actor->world.pos.z, (&sCheckpointPositions[checkpointIterator])[-1].x,
-                (&sCheckpointPositions[checkpointIterator])[-1].z, (&sCheckpointPositions[checkpointIterator])[1].x,
-                (&sCheckpointPositions[checkpointIterator])[1].z, &perpendicularPointX, &perpendicularPointZ,
+        if (Math3D_PointDistSqToLine2DImpl(
+                actor->world.pos.x, actor->world.pos.z, sCheckpointPositions[checkpointIterator - 1].x,
+                sCheckpointPositions[checkpointIterator - 1].z, sCheckpointPositions[checkpointIterator + 1].x,
+                sCheckpointPositions[checkpointIterator + 1].z, &perpendicularPointX, &perpendicularPointZ,
                 &lineLenSq) &&
-            (!hasSetCurrentCheckpointOnce || ((curentCheckpoint + 1) == checkpointIterator) ||
+            (!hasSetCurrentCheckpointOnce || ((currentCheckpoint + 1) == checkpointIterator) ||
              (lineLenSq < minLineLengthSq))) {
             minLineLengthSq = lineLenSq;
-            curentCheckpoint = checkpointIterator;
+            currentCheckpoint = checkpointIterator;
             *outPerpendicularPointX = perpendicularPointX;
             *outPerpendicularPointZ = perpendicularPointZ;
             hasSetCurrentCheckpointOnce = true;
@@ -170,8 +171,8 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
         checkpointIterator++;
     } while (checkpointIterator < sStartingCheckpointPerSceneExitIndex[sceneExitIndex + 1]);
 
-    *upcomingCheckpoint = curentCheckpoint + 1;
-    return curentCheckpoint;
+    *upcomingCheckpoint = currentCheckpoint + 1;
+    return currentCheckpoint;
 }
 
 /**

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -153,7 +153,7 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     checkpointIterator = sStartingCheckpointPerSceneExitIndex[sceneExitIndex];
 
     // Iterates through all possible checkpoints that are associated with this sceneExitIndex.
-    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18
+    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18, due to the `sceneExitIndex + 1` access.
     do {
         if (Math3D_PointDistToLine2D(
                 actor->world.pos.x, actor->world.pos.z, sCheckpointPositions[checkpointIterator - 1].x,

--- a/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
+++ b/src/overlays/actors/ovl_En_Mt_tag/z_en_mt_tag.c
@@ -145,6 +145,8 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     // The Goron Racetrack is configured such that the sceneExitIndex for any given floor polygon
     // gradually increases as you move forward through the racetrack.
     sceneExitIndex = SurfaceType_GetSceneExitIndex(&play->colCtx, actor->floorPoly, actor->floorBgId);
+    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18, due to the
+    //! `sceneExitIndex + 1` access.
     if ((sceneExitIndex < 4) || (sceneExitIndex >= 19)) {
         //! @bug - upcomingCheckpoint is not initialized here
         return -1;
@@ -153,8 +155,6 @@ s32 EnMttag_GetCurrentCheckpoint(Actor* actor, PlayState* play, s32* upcomingChe
     checkpointIterator = sStartingCheckpointPerSceneExitIndex[sceneExitIndex];
 
     // Iterates through all possible checkpoints that are associated with this sceneExitIndex.
-    //! @bug - sStartingCheckpointPerSceneExitIndex is indexed out of bounds when sceneExitIndex is 18, due to the
-    //! `sceneExitIndex + 1` access.
     do {
         if (Math3D_PointDistToLine2D(
                 actor->world.pos.x, actor->world.pos.z, sCheckpointPositions[checkpointIterator - 1].x,


### PR DESCRIPTION
Not sure what the extent of the bug causes but surprised it doesn't cause crashes since from my understanding, the upper limit of the loop should be 3268542464 for sceneExitIndex 18.

