### PR TITLE
Fix Song of Time frustum Vtx count

### DIFF
--- a/assets/xml/overlays/ovl_Oceff_Wipe.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe.xml
@@ -1,7 +1,7 @@
 <Root>
     <File Name="ovl_Oceff_Wipe" BaseAddress="0x809764B0" RangeStart="0x4F0" RangeEnd="0xCB0">
         <Texture Name="sSongOfTimeEffectTex" OutName="song_of_time_effect" Format="i8" Width="32" Height="32" Offset="0x4F0"/>
-        <Array Name="sSongOfTimeFrustumVtx" Count="32" Offset="0x8F0">
+        <Array Name="sSongOfTimeFrustumVtx" Count="40" Offset="0x8F0">
             <Vtx/>
         </Array>
         <DList Name="sSongOfTimeFrustumMaterialDL" Offset="0xB70"/>


### PR DESCRIPTION
The song of time frustum vtx count in the xml did not match the actual size used by the code.

https://github.com/zeldaret/mm/blob/7a26cca36d87d228909c9ecda0dc3403f2b150df/src/overlays/actors/ovl_Oceff_Wipe/z_oceff_wipe.c#L94-L98

Here the loop happens 20 times, with `i` being multiplied by 2 for a total of 40 vtx.

This aligns with an additional 8 vtx being extracted unnamed.