### PR TITLE
Document bug in talk wait animation frame count

### DIFF
--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -20681,6 +20681,9 @@ s32 func_8085B930(PlayState* play, PlayerAnimationHeader* talkAnim, AnimationMod
         return false;
     }
 
+    //! @bug When func_8082ED20 is used to get a wait animation, NULL is still passed to Animation_GetLastFrame,
+    // causing it to read the frame count from address 0x80000000 casted to AnimationHeaderCommon via
+    // Lib_SegmentedToVirtual operating on NULL, which ends up returning 15385 as the last frame
     PlayerAnimation_Change(play, &player->skelAnime, (talkAnim == NULL) ? func_8082ED20(player) : talkAnim,
                            PLAYER_ANIM_ADJUSTED_SPEED, 0.0f, Animation_GetLastFrame(talkAnim), animMode, -6.0f);
     return true;


### PR DESCRIPTION
This last function in z_player seems to be responsible for setting the players animation during dialogue sequences. There are times where the passed in `talkAnim` will be `NULL`.

There is a ternary on `talkAnim` to use an alternate animation provided by `func_8082ED20` (which chooses a default wait animation based on the players form/current mask), but this only happens for one of the arguments to `PlayerAnimation_Change`. `Animation_GetLastFrame` in this case will still get `NULL` passed into it, which internally is fed into `Lib_SegmentedToVirtual`. This leads to `Animation_GetLastFrame` returning a value of `15385`.

I can't seem to discern a difference between the real last frame value being passed in vs this large value, so I didn't elect to document the result of it.

I also tried to see if this was a fake match and tried to set the result of the ternary back to `talkAnim` but I couldn't find anything that would match.