### PR TITLE
Fix a fake match on `EnSGoro`

### DIFF
--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -894,8 +894,9 @@ void EnSGoro_UpdateCollider(EnSGoro* this, PlayState* play) {
     this->collider.dim.radius = radius;
     this->collider.dim.height = height;
 
-    //! @bug: It is not clear what this is for.
-    if ((s32)this != -0x190) {
+    //! @bug: The check is useless. If &this->collider somehow was NULL the above code would have already dereferenced
+    //! it.
+    if (&this->collider != NULL) {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }
 }

--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -884,13 +884,13 @@ void EnSGoro_UpdateToIdleAnimation(EnSGoro* this) {
 }
 
 void EnSGoro_UpdateCollider(EnSGoro* this, PlayState* play) {
-    Vec3f world_pos = this->actor.world.pos;
+    Vec3f worldPos = this->actor.world.pos;
     f32 radius = 24.0f;
     f32 height = 62.0f;
 
-    this->collider.dim.pos.x = world_pos.x;
-    this->collider.dim.pos.y = world_pos.y;
-    this->collider.dim.pos.z = world_pos.z;
+    this->collider.dim.pos.x = worldPos.x;
+    this->collider.dim.pos.y = worldPos.y;
+    this->collider.dim.pos.z = worldPos.z;
     this->collider.dim.radius = radius;
     this->collider.dim.height = height;
 


### PR DESCRIPTION
This code
```c
if ((s32)this != -0x190) {
```

Was actually a `NULL` check for the member at offset `0x190`, in this case `collider`. The only way for `&this->collider` could be `NULL` is that `this` has value `-0x190`.

Shoutouts to @cadmic for figuring this out for an AF scratch.
Convo: https://discord.com/channels/688807550715560050/1139317895491506197/1240420736095490239