### PR TITLE
Explicitly extract room DLs that ZAPD can't detect

### DIFF
--- a/assets/xml/scenes/KAKUSIANA/KAKUSIANA.xml
+++ b/assets/xml/scenes/KAKUSIANA/KAKUSIANA.xml
@@ -4,47 +4,77 @@
     </File>
     <File Name="KAKUSIANA_room_00" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_00" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_00DL_001E70" Offset="0x1E70"/>
+        <DList Name="KAKUSIANA_room_00DL_003A68" Offset="0x3A68"/>
     </File>
     <File Name="KAKUSIANA_room_01" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_01" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_01DL_001610" Offset="0x1610"/>
+        <DList Name="KAKUSIANA_room_01DL_004910" Offset="0x4910"/>
     </File>
     <File Name="KAKUSIANA_room_02" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_02" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_02DL_001730" Offset="0x1730"/>
+        <DList Name="KAKUSIANA_room_02DL_002188" Offset="0x2188"/>
     </File>
     <File Name="KAKUSIANA_room_03" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_03" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_03DL_001038" Offset="0x1038"/>
+        <DList Name="KAKUSIANA_room_03DL_002288" Offset="0x2288"/>
     </File>
     <File Name="KAKUSIANA_room_04" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_04" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_04DL_001598" Offset="0x1598"/>
+        <DList Name="KAKUSIANA_room_04DL_001980" Offset="0x1980"/>
     </File>
     <File Name="KAKUSIANA_room_05" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_05" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_05DL_000C60" Offset="0xC60"/>
+        <DList Name="KAKUSIANA_room_05DL_0016E0" Offset="0x16E0"/>
     </File>
     <File Name="KAKUSIANA_room_06" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_06" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_06DL_0015F0" Offset="0x15F0"/>
+        <DList Name="KAKUSIANA_room_06DL_002320" Offset="0x2320"/>
     </File>
     <File Name="KAKUSIANA_room_07" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_07" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_07DL_001018" Offset="0x1018"/>
+        <DList Name="KAKUSIANA_room_07DL_002A68" Offset="0x2A68"/>
     </File>
     <File Name="KAKUSIANA_room_08" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_08" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_08DL_001660" Offset="0x1660"/>
+        <DList Name="KAKUSIANA_room_08DL_002D48" Offset="0x2D48"/>
     </File>
     <File Name="KAKUSIANA_room_09" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_09" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_09DL_0015A0" Offset="0x15A0"/>
+        <DList Name="KAKUSIANA_room_09DL_0021F8" Offset="0x21F8"/>
     </File>
     <File Name="KAKUSIANA_room_10" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_10" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_10DL_001130" Offset="0x1130"/>
+        <DList Name="KAKUSIANA_room_10DL_001388" Offset="0x1388"/>
     </File>
     <File Name="KAKUSIANA_room_11" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_11" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_11DL_0013B0" Offset="0x13B0"/>
+        <DList Name="KAKUSIANA_room_11DL_0025D0" Offset="0x25D0"/>
     </File>
     <File Name="KAKUSIANA_room_12" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_12" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_12DL_0034A0" Offset="0x34A0"/>
+        <DList Name="KAKUSIANA_room_12DL_0064C8" Offset="0x64C8"/>
     </File>
     <File Name="KAKUSIANA_room_13" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_13" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_13DL_001CD0" Offset="0x1CD0"/>
+        <DList Name="KAKUSIANA_room_13DL_003740" Offset="0x3740"/>
     </File>
     <File Name="KAKUSIANA_room_14" Segment="3" Game="MM">
         <Room Name="KAKUSIANA_room_14" Offset="0x0"/>
+        <DList Name="KAKUSIANA_room_14DL_001630" Offset="0x1630"/>
+        <DList Name="KAKUSIANA_room_14DL_0022B0" Offset="0x22B0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/SPOT00/SPOT00.xml
+++ b/assets/xml/scenes/SPOT00/SPOT00.xml
@@ -4,5 +4,6 @@
     </File>
     <File Name="SPOT00_room_00" Segment="3" Game="MM">
         <Room Name="SPOT00_room_00" Offset="0x0"/>
+        <DList Name="SPOT00_room_00DL_000900" Offset="0x900"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_00KEIKOKU/Z2_00KEIKOKU.xml
+++ b/assets/xml/scenes/Z2_00KEIKOKU/Z2_00KEIKOKU.xml
@@ -29,5 +29,8 @@
     </File>
     <File Name="Z2_00KEIKOKU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_00KEIKOKU_room_00" Offset="0x0"/>
+        <DList Name="Z2_00KEIKOKU_room_00DL_026C10" Offset="0x26C10"/>
+        <DList Name="Z2_00KEIKOKU_room_00DL_026A58" Offset="0x26A58"/>
+        <DList Name="Z2_00KEIKOKU_room_00DL_0287F8" Offset="0x287F8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_10YUKIYAMANOMURA/Z2_10YUKIYAMANOMURA.xml
+++ b/assets/xml/scenes/Z2_10YUKIYAMANOMURA/Z2_10YUKIYAMANOMURA.xml
@@ -5,5 +5,9 @@
     </File>
     <File Name="Z2_10YUKIYAMANOMURA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_10YUKIYAMANOMURA_room_00" Offset="0x0"/>
+        <DList Name="Z2_10YUKIYAMANOMURA_room_00DL_00B120" Offset="0xB120"/>
+        <DList Name="Z2_10YUKIYAMANOMURA_room_00DL_000610" Offset="0x610"/>
+        <DList Name="Z2_10YUKIYAMANOMURA_room_00DL_00B028" Offset="0xB028"/>
+        <DList Name="Z2_10YUKIYAMANOMURA_room_00DL_00B678" Offset="0xB678"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_10YUKIYAMANOMURA2/Z2_10YUKIYAMANOMURA2.xml
+++ b/assets/xml/scenes/Z2_10YUKIYAMANOMURA2/Z2_10YUKIYAMANOMURA2.xml
@@ -5,8 +5,13 @@
     </File>
     <File Name="Z2_10YUKIYAMANOMURA2_room_00" Segment="3" Game="MM">
         <Room Name="Z2_10YUKIYAMANOMURA2_room_00" Offset="0x0"/>
+        <DList Name="Z2_10YUKIYAMANOMURA2_room_00DL_00F0B0" Offset="0xF0B0"/>
+        <DList Name="Z2_10YUKIYAMANOMURA2_room_00DL_01B310" Offset="0x1B310"/>
+        <DList Name="Z2_10YUKIYAMANOMURA2_room_00DL_01BC20" Offset="0x1BC20"/>
     </File>
     <File Name="Z2_10YUKIYAMANOMURA2_room_01" Segment="3" Game="MM">
         <Room Name="Z2_10YUKIYAMANOMURA2_room_01" Offset="0x0"/>
+        <DList Name="Z2_10YUKIYAMANOMURA2_room_01DL_0002C0" Offset="0x2C0"/>
+        <DList Name="Z2_10YUKIYAMANOMURA2_room_01DL_001A18" Offset="0x1A18"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_11GORONNOSATO/Z2_11GORONNOSATO.xml
+++ b/assets/xml/scenes/Z2_11GORONNOSATO/Z2_11GORONNOSATO.xml
@@ -5,8 +5,14 @@
     </File>
     <File Name="Z2_11GORONNOSATO_room_00" Segment="3" Game="MM">
         <Room Name="Z2_11GORONNOSATO_room_00" Offset="0x0"/>
+        <DList Name="Z2_11GORONNOSATO_room_00DL_000670" Offset="0x670"/>
+        <DList Name="Z2_11GORONNOSATO_room_00DL_00C740" Offset="0xC740"/>
+        <DList Name="Z2_11GORONNOSATO_room_00DL_013080" Offset="0x13080"/>
+        <DList Name="Z2_11GORONNOSATO_room_00DL_013420" Offset="0x13420"/>
     </File>
     <File Name="Z2_11GORONNOSATO_room_01" Segment="3" Game="MM">
         <Room Name="Z2_11GORONNOSATO_room_01" Offset="0x0"/>
+        <DList Name="Z2_11GORONNOSATO_room_01DL_0000F0" Offset="0xF0"/>
+        <DList Name="Z2_11GORONNOSATO_room_01DL_001E38" Offset="0x1E38"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_11GORONNOSATO2/Z2_11GORONNOSATO2.xml
+++ b/assets/xml/scenes/Z2_11GORONNOSATO2/Z2_11GORONNOSATO2.xml
@@ -5,8 +5,14 @@
     </File>
     <File Name="Z2_11GORONNOSATO2_room_00" Segment="3" Game="MM">
         <Room Name="Z2_11GORONNOSATO2_room_00" Offset="0x0"/>
+        <DList Name="Z2_11GORONNOSATO2_room_00DL_0003D0" Offset="0x3D0"/>
+        <DList Name="Z2_11GORONNOSATO2_room_00DL_00C9B8" Offset="0xC9B8"/>
+        <DList Name="Z2_11GORONNOSATO2_room_00DL_015310" Offset="0x15310"/>
+        <DList Name="Z2_11GORONNOSATO2_room_00DL_0156B0" Offset="0x156B0"/>
     </File>
     <File Name="Z2_11GORONNOSATO2_room_01" Segment="3" Game="MM">
         <Room Name="Z2_11GORONNOSATO2_room_01" Offset="0x0"/>
+        <DList Name="Z2_11GORONNOSATO2_room_01DL_000130" Offset="0x130"/>
+        <DList Name="Z2_11GORONNOSATO2_room_01DL_001E78" Offset="0x1E78"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_12HAKUGINMAE/Z2_12HAKUGINMAE.xml
+++ b/assets/xml/scenes/Z2_12HAKUGINMAE/Z2_12HAKUGINMAE.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_12HAKUGINMAE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_12HAKUGINMAE_room_00" Offset="0x0"/>
+        <DList Name="Z2_12HAKUGINMAE_room_00DL_006CE0" Offset="0x6CE0"/>
+        <DList Name="Z2_12HAKUGINMAE_room_00DL_007098" Offset="0x7098"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_13HUBUKINOMITI/Z2_13HUBUKINOMITI.xml
+++ b/assets/xml/scenes/Z2_13HUBUKINOMITI/Z2_13HUBUKINOMITI.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_13HUBUKINOMITI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_13HUBUKINOMITI_room_00" Offset="0x0"/>
+        <DList Name="Z2_13HUBUKINOMITI_room_00DL_004510" Offset="0x4510"/>
+        <DList Name="Z2_13HUBUKINOMITI_room_00DL_0044C0" Offset="0x44C0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_14YUKIDAMANOMITI/Z2_14YUKIDAMANOMITI.xml
+++ b/assets/xml/scenes/Z2_14YUKIDAMANOMITI/Z2_14YUKIDAMANOMITI.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_14YUKIDAMANOMITI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_14YUKIDAMANOMITI_room_00" Offset="0x0"/>
+        <DList Name="Z2_14YUKIDAMANOMITI_room_00DL_003C98" Offset="0x3C98"/>
+        <DList Name="Z2_14YUKIDAMANOMITI_room_00DL_004598" Offset="0x4598"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_16GORON_HOUSE/Z2_16GORON_HOUSE.xml
+++ b/assets/xml/scenes/Z2_16GORON_HOUSE/Z2_16GORON_HOUSE.xml
@@ -4,8 +4,12 @@
     </File>
     <File Name="Z2_16GORON_HOUSE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_16GORON_HOUSE_room_00" Offset="0x0"/>
+        <DList Name="Z2_16GORON_HOUSE_room_00DL_0086B0" Offset="0x86B0"/>
+        <DList Name="Z2_16GORON_HOUSE_room_00DL_00BDA8" Offset="0xBDA8"/>
     </File>
     <File Name="Z2_16GORON_HOUSE_room_01" Segment="3" Game="MM">
         <Room Name="Z2_16GORON_HOUSE_room_01" Offset="0x0"/>
+        <DList Name="Z2_16GORON_HOUSE_room_01DL_0056A0" Offset="0x56A0"/>
+        <DList Name="Z2_16GORON_HOUSE_room_01DL_007138" Offset="0x7138"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_17SETUGEN/Z2_17SETUGEN.xml
+++ b/assets/xml/scenes/Z2_17SETUGEN/Z2_17SETUGEN.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_17SETUGEN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_17SETUGEN_room_00" Offset="0x0"/>
+        <DList Name="Z2_17SETUGEN_room_00DL_007208" Offset="0x7208"/>
+        <DList Name="Z2_17SETUGEN_room_00DL_0076B8" Offset="0x76B8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_17SETUGEN2/Z2_17SETUGEN2.xml
+++ b/assets/xml/scenes/Z2_17SETUGEN2/Z2_17SETUGEN2.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_17SETUGEN2_room_00" Segment="3" Game="MM">
         <Room Name="Z2_17SETUGEN2_room_00" Offset="0x0"/>
+        <DList Name="Z2_17SETUGEN2_room_00DL_006D08" Offset="0x6D08"/>
+        <DList Name="Z2_17SETUGEN2_room_00DL_0071B0" Offset="0x71B0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_20SICHITAI/Z2_20SICHITAI.xml
+++ b/assets/xml/scenes/Z2_20SICHITAI/Z2_20SICHITAI.xml
@@ -5,11 +5,23 @@
     </File>
     <File Name="Z2_20SICHITAI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI_room_00" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI_room_00DL_0006B0" Offset="0x6B0"/>
+        <DList Name="Z2_20SICHITAI_room_00DL_011A70" Offset="0x11A70"/>
+        <DList Name="Z2_20SICHITAI_room_00DL_01B120" Offset="0x1B120"/>
+        <DList Name="Z2_20SICHITAI_room_00DL_01CAE8" Offset="0x1CAE8"/>
     </File>
     <File Name="Z2_20SICHITAI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI_room_01" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI_room_01DL_000570" Offset="0x570"/>
+        <DList Name="Z2_20SICHITAI_room_01DL_00B9F0" Offset="0xB9F0"/>
+        <DList Name="Z2_20SICHITAI_room_01DL_011860" Offset="0x11860"/>
+        <DList Name="Z2_20SICHITAI_room_01DL_013458" Offset="0x13458"/>
     </File>
     <File Name="Z2_20SICHITAI_room_02" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI_room_02" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI_room_02DL_000370" Offset="0x370"/>
+        <DList Name="Z2_20SICHITAI_room_02DL_008BA0" Offset="0x8BA0"/>
+        <DList Name="Z2_20SICHITAI_room_02DL_00D480" Offset="0xD480"/>
+        <DList Name="Z2_20SICHITAI_room_02DL_00DCA0" Offset="0xDCA0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_20SICHITAI2/Z2_20SICHITAI2.xml
+++ b/assets/xml/scenes/Z2_20SICHITAI2/Z2_20SICHITAI2.xml
@@ -5,11 +5,23 @@
     </File>
     <File Name="Z2_20SICHITAI2_room_00" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI2_room_00" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI2_room_00DL_0003E0" Offset="0x3E0"/>
+        <DList Name="Z2_20SICHITAI2_room_00DL_0111C8" Offset="0x111C8"/>
+        <DList Name="Z2_20SICHITAI2_room_00DL_019490" Offset="0x19490"/>
+        <DList Name="Z2_20SICHITAI2_room_00DL_01A608" Offset="0x1A608"/>
     </File>
     <File Name="Z2_20SICHITAI2_room_01" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI2_room_01" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI2_room_01DL_0004C0" Offset="0x4C0"/>
+        <DList Name="Z2_20SICHITAI2_room_01DL_00C220" Offset="0xC220"/>
+        <DList Name="Z2_20SICHITAI2_room_01DL_011D90" Offset="0x11D90"/>
+        <DList Name="Z2_20SICHITAI2_room_01DL_0125A0" Offset="0x125A0"/>
     </File>
     <File Name="Z2_20SICHITAI2_room_02" Segment="3" Game="MM">
         <Room Name="Z2_20SICHITAI2_room_02" Offset="0x0"/>
+        <DList Name="Z2_20SICHITAI2_room_02DL_000300" Offset="0x300"/>
+        <DList Name="Z2_20SICHITAI2_room_02DL_008AC8" Offset="0x8AC8"/>
+        <DList Name="Z2_20SICHITAI2_room_02DL_00BFB0" Offset="0xBFB0"/>
+        <DList Name="Z2_20SICHITAI2_room_02DL_00C658" Offset="0xC658"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_21MITURINMAE/Z2_21MITURINMAE.xml
+++ b/assets/xml/scenes/Z2_21MITURINMAE/Z2_21MITURINMAE.xml
@@ -4,5 +4,9 @@
     </File>
     <File Name="Z2_21MITURINMAE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_21MITURINMAE_room_00" Offset="0x0"/>
+        <DList Name="Z2_21MITURINMAE_room_00DL_00FB30" Offset="0xFB30"/>
+        <DList Name="Z2_21MITURINMAE_room_00DL_000AC0" Offset="0xAC0"/>
+        <DList Name="Z2_21MITURINMAE_room_00DL_00FA68" Offset="0xFA68"/>
+        <DList Name="Z2_21MITURINMAE_room_00DL_00FBF8" Offset="0xFBF8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_22DEKUCITY/Z2_22DEKUCITY.xml
+++ b/assets/xml/scenes/Z2_22DEKUCITY/Z2_22DEKUCITY.xml
@@ -5,11 +5,23 @@
     </File>
     <File Name="Z2_22DEKUCITY_room_00" Segment="3" Game="MM">
         <Room Name="Z2_22DEKUCITY_room_00" Offset="0x0"/>
+        <DList Name="Z2_22DEKUCITY_room_00DL_000540" Offset="0x540"/>
+        <DList Name="Z2_22DEKUCITY_room_00DL_00F3D8" Offset="0xF3D8"/>
+        <DList Name="Z2_22DEKUCITY_room_00DL_0119F0" Offset="0x119F0"/>
+        <DList Name="Z2_22DEKUCITY_room_00DL_011A28" Offset="0x11A28"/>
     </File>
     <File Name="Z2_22DEKUCITY_room_01" Segment="3" Game="MM">
         <Room Name="Z2_22DEKUCITY_room_01" Offset="0x0"/>
+        <DList Name="Z2_22DEKUCITY_room_01DL_0003E0" Offset="0x3E0"/>
+        <DList Name="Z2_22DEKUCITY_room_01DL_00CE28" Offset="0xCE28"/>
+        <DList Name="Z2_22DEKUCITY_room_01DL_00E910" Offset="0xE910"/>
+        <DList Name="Z2_22DEKUCITY_room_01DL_00E930" Offset="0xE930"/>
     </File>
     <File Name="Z2_22DEKUCITY_room_02" Segment="3" Game="MM">
         <Room Name="Z2_22DEKUCITY_room_02" Offset="0x0"/>
+        <DList Name="Z2_22DEKUCITY_room_02DL_000460" Offset="0x460"/>
+        <DList Name="Z2_22DEKUCITY_room_02DL_00F488" Offset="0xF488"/>
+        <DList Name="Z2_22DEKUCITY_room_02DL_012490" Offset="0x12490"/>
+        <DList Name="Z2_22DEKUCITY_room_02DL_0124C0" Offset="0x124C0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_24KEMONOMITI/Z2_24KEMONOMITI.xml
+++ b/assets/xml/scenes/Z2_24KEMONOMITI/Z2_24KEMONOMITI.xml
@@ -5,5 +5,9 @@
     </File>
     <File Name="Z2_24KEMONOMITI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_24KEMONOMITI_room_00" Offset="0x0"/>
+        <DList Name="Z2_24KEMONOMITI_room_00DL_0059C0" Offset="0x59C0"/>
+        <DList Name="Z2_24KEMONOMITI_room_00DL_000480" Offset="0x480"/>
+        <DList Name="Z2_24KEMONOMITI_room_00DL_005940" Offset="0x5940"/>
+        <DList Name="Z2_24KEMONOMITI_room_00DL_006190" Offset="0x6190"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_26SARUNOMORI/Z2_26SARUNOMORI.xml
+++ b/assets/xml/scenes/Z2_26SARUNOMORI/Z2_26SARUNOMORI.xml
@@ -5,29 +5,47 @@
     </File>
     <File Name="Z2_26SARUNOMORI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_00" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_00DL_002AF8" Offset="0x2AF8"/>
+        <DList Name="Z2_26SARUNOMORI_room_00DL_0035C0" Offset="0x35C0"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_01" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_01DL_002AE8" Offset="0x2AE8"/>
+        <DList Name="Z2_26SARUNOMORI_room_01DL_0035B0" Offset="0x35B0"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_02" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_02" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_02DL_002F80" Offset="0x2F80"/>
+        <DList Name="Z2_26SARUNOMORI_room_02DL_003A28" Offset="0x3A28"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_03" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_03" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_03DL_001C80" Offset="0x1C80"/>
+        <DList Name="Z2_26SARUNOMORI_room_03DL_002740" Offset="0x2740"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_04" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_04" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_04DL_002940" Offset="0x2940"/>
+        <DList Name="Z2_26SARUNOMORI_room_04DL_003418" Offset="0x3418"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_05" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_05" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_05DL_001C80" Offset="0x1C80"/>
+        <DList Name="Z2_26SARUNOMORI_room_05DL_002740" Offset="0x2740"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_06" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_06" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_06DL_003520" Offset="0x3520"/>
+        <DList Name="Z2_26SARUNOMORI_room_06DL_003FF8" Offset="0x3FF8"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_07" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_07" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_07DL_001C80" Offset="0x1C80"/>
+        <DList Name="Z2_26SARUNOMORI_room_07DL_002740" Offset="0x2740"/>
     </File>
     <File Name="Z2_26SARUNOMORI_room_08" Segment="3" Game="MM">
         <Room Name="Z2_26SARUNOMORI_room_08" Offset="0x0"/>
+        <DList Name="Z2_26SARUNOMORI_room_08DL_002A18" Offset="0x2A18"/>
+        <DList Name="Z2_26SARUNOMORI_room_08DL_0034F8" Offset="0x34F8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_30GYOSON/Z2_30GYOSON.xml
+++ b/assets/xml/scenes/Z2_30GYOSON/Z2_30GYOSON.xml
@@ -5,5 +5,8 @@
     </File>
     <File Name="Z2_30GYOSON_room_00" Segment="3" Game="MM">
         <Room Name="Z2_30GYOSON_room_00" Offset="0x0"/>
+        <DList Name="Z2_30GYOSON_room_00DL_01C1B0" Offset="0x1C1B0"/>
+        <DList Name="Z2_30GYOSON_room_00DL_01C058" Offset="0x1C058"/>
+        <DList Name="Z2_30GYOSON_room_00DL_01D2B0" Offset="0x1D2B0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_31MISAKI/Z2_31MISAKI.xml
+++ b/assets/xml/scenes/Z2_31MISAKI/Z2_31MISAKI.xml
@@ -5,5 +5,9 @@
     </File>
     <File Name="Z2_31MISAKI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_31MISAKI_room_00" Offset="0x0"/>
+        <DList Name="Z2_31MISAKI_room_00DL_0158A0" Offset="0x158A0"/>
+        <DList Name="Z2_31MISAKI_room_00DL_001090" Offset="0x1090"/>
+        <DList Name="Z2_31MISAKI_room_00DL_0157D8" Offset="0x157D8"/>
+        <DList Name="Z2_31MISAKI_room_00DL_017400" Offset="0x17400"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_33ZORACITY/Z2_33ZORACITY.xml
+++ b/assets/xml/scenes/Z2_33ZORACITY/Z2_33ZORACITY.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_33ZORACITY_room_00" Segment="3" Game="MM">
         <Room Name="Z2_33ZORACITY_room_00" Offset="0x0"/>
+        <DList Name="Z2_33ZORACITY_room_00DL_009050" Offset="0x9050"/>
+        <DList Name="Z2_33ZORACITY_room_00DL_009FE8" Offset="0x9FE8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_35TAKI/Z2_35TAKI.xml
+++ b/assets/xml/scenes/Z2_35TAKI/Z2_35TAKI.xml
@@ -4,5 +4,9 @@
     </File>
     <File Name="Z2_35TAKI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_35TAKI_room_00" Offset="0x0"/>
+        <DList Name="Z2_35TAKI_room_00DL_017400" Offset="0x17400"/>
+        <DList Name="Z2_35TAKI_room_00DL_000C00" Offset="0xC00"/>
+        <DList Name="Z2_35TAKI_room_00DL_017350" Offset="0x17350"/>
+        <DList Name="Z2_35TAKI_room_00DL_018CB8" Offset="0x18CB8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_8ITEMSHOP/Z2_8ITEMSHOP.xml
+++ b/assets/xml/scenes/Z2_8ITEMSHOP/Z2_8ITEMSHOP.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_8ITEMSHOP_room_00" Segment="3" Game="MM">
         <Room Name="Z2_8ITEMSHOP_room_00" Offset="0x0"/>
+        <DList Name="Z2_8ITEMSHOP_room_00DL_00C040" Offset="0xC040"/>
+        <DList Name="Z2_8ITEMSHOP_room_00DL_00C9F0" Offset="0xC9F0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_ALLEY/Z2_ALLEY.xml
+++ b/assets/xml/scenes/Z2_ALLEY/Z2_ALLEY.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_ALLEY_room_00" Segment="3" Game="MM">
         <Room Name="Z2_ALLEY_room_00" Offset="0x0"/>
+        <DList Name="Z2_ALLEY_room_00DL_007390" Offset="0x7390"/>
+        <DList Name="Z2_ALLEY_room_00DL_008CC0" Offset="0x8CC0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_AYASHIISHOP/Z2_AYASHIISHOP.xml
+++ b/assets/xml/scenes/Z2_AYASHIISHOP/Z2_AYASHIISHOP.xml
@@ -5,8 +5,12 @@
     </File>
     <File Name="Z2_AYASHIISHOP_room_00" Segment="3" Game="MM">
         <Room Name="Z2_AYASHIISHOP_room_00" Offset="0x0"/>
+        <DList Name="Z2_AYASHIISHOP_room_00DL_00CF78" Offset="0xCF78"/>
+        <DList Name="Z2_AYASHIISHOP_room_00DL_011820" Offset="0x11820"/>
     </File>
     <File Name="Z2_AYASHIISHOP_room_01" Segment="3" Game="MM">
         <Room Name="Z2_AYASHIISHOP_room_01" Offset="0x0"/>
+        <DList Name="Z2_AYASHIISHOP_room_01DL_004F80" Offset="0x4F80"/>
+        <DList Name="Z2_AYASHIISHOP_room_01DL_0054F8" Offset="0x54F8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_BACKTOWN/Z2_BACKTOWN.xml
+++ b/assets/xml/scenes/Z2_BACKTOWN/Z2_BACKTOWN.xml
@@ -4,5 +4,8 @@
     </File>
     <File Name="Z2_BACKTOWN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_BACKTOWN_room_00" Offset="0x0"/>
+        <DList Name="Z2_BACKTOWN_room_00DL_0005E0" Offset="0x5E0"/>
+        <DList Name="Z2_BACKTOWN_room_00DL_008148" Offset="0x8148"/>
+        <DList Name="Z2_BACKTOWN_room_00DL_00A138" Offset="0xA138"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_BANDROOM/Z2_BANDROOM.xml
+++ b/assets/xml/scenes/Z2_BANDROOM/Z2_BANDROOM.xml
@@ -4,19 +4,29 @@
     </File>
     <File Name="Z2_BANDROOM_room_00" Segment="3" Game="MM">
         <Room Name="Z2_BANDROOM_room_00" Offset="0x0"/>
+        <DList Name="Z2_BANDROOM_room_00DL_0068B8" Offset="0x68B8"/>
+        <DList Name="Z2_BANDROOM_room_00DL_00CEF0" Offset="0xCEF0"/>
     </File>
     <File Name="Z2_BANDROOM_room_01" Segment="3" Game="MM">
         <Room Name="Z2_BANDROOM_room_01" Offset="0x0"/>
+        <DList Name="Z2_BANDROOM_room_01DL_004498" Offset="0x4498"/>
+        <DList Name="Z2_BANDROOM_room_01DL_0076D0" Offset="0x76D0"/>
     </File>
     <File Name="Z2_BANDROOM_room_02" Segment="3" Game="MM">
         <Room Name="Z2_BANDROOM_room_02" Offset="0x0"/>
+        <DList Name="Z2_BANDROOM_room_02DL_007200" Offset="0x7200"/>
+        <DList Name="Z2_BANDROOM_room_02DL_00D100" Offset="0xD100"/>
     </File>
     <File Name="Z2_BANDROOM_room_03" Segment="3" Game="MM">
         <Room Name="Z2_BANDROOM_room_03" Offset="0x0"/>
+        <DList Name="Z2_BANDROOM_room_03DL_004730" Offset="0x4730"/>
+        <DList Name="Z2_BANDROOM_room_03DL_008748" Offset="0x8748"/>
     </File>
     <File Name="Z2_BANDROOM_room_04" Segment="3" Game="MM">
         <Texture Name="Z2_BANDROOM_room_04Tex_005A38" Format="rgba16" Width="64" Height="64" Offset="0x5A38"/>
 
         <Room Name="Z2_BANDROOM_room_04" Offset="0x0"/>
+        <DList Name="Z2_BANDROOM_room_04DL_004500" Offset="0x4500"/>
+        <DList Name="Z2_BANDROOM_room_04DL_008630" Offset="0x8630"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_BOMYA/Z2_BOMYA.xml
+++ b/assets/xml/scenes/Z2_BOMYA/Z2_BOMYA.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_BOMYA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_BOMYA_room_00" Offset="0x0"/>
+        <DList Name="Z2_BOMYA_room_00DL_007508" Offset="0x7508"/>
+        <DList Name="Z2_BOMYA_room_00DL_007EA8" Offset="0x7EA8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_BOTI/Z2_BOTI.xml
+++ b/assets/xml/scenes/Z2_BOTI/Z2_BOTI.xml
@@ -4,8 +4,12 @@
     </File>
     <File Name="Z2_BOTI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_BOTI_room_00" Offset="0x0"/>
+        <DList Name="Z2_BOTI_room_00DL_007B40" Offset="0x7B40"/>
+        <DList Name="Z2_BOTI_room_00DL_00B198" Offset="0xB198"/>
     </File>
     <File Name="Z2_BOTI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_BOTI_room_01" Offset="0x0"/>
+        <DList Name="Z2_BOTI_room_01DL_006968" Offset="0x6968"/>
+        <DList Name="Z2_BOTI_room_01DL_0088D8" Offset="0x88D8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_BOWLING/Z2_BOWLING.xml
+++ b/assets/xml/scenes/Z2_BOWLING/Z2_BOWLING.xml
@@ -4,5 +4,6 @@
     </File>
     <File Name="Z2_BOWLING_room_00" Segment="3" Game="MM">
         <Room Name="Z2_BOWLING_room_00" Offset="0x0"/>
+        <DList Name="Z2_BOWLING_room_00DL_004CF0" Offset="0x4CF0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_CASTLE/Z2_CASTLE.xml
+++ b/assets/xml/scenes/Z2_CASTLE/Z2_CASTLE.xml
@@ -7,34 +7,70 @@
         <Texture Name="Z2_CASTLE_room_00Tex_0127B8" Format="rgba16" Width="32" Height="128" Offset="0x127B8"/>
 
         <Room Name="Z2_CASTLE_room_00" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_00DL_000430" Offset="0x430"/>
+        <DList Name="Z2_CASTLE_room_00DL_00CD30" Offset="0xCD30"/>
+        <DList Name="Z2_CASTLE_room_00DL_017A20" Offset="0x17A20"/>
+        <DList Name="Z2_CASTLE_room_00DL_017E18" Offset="0x17E18"/>
     </File>
     <File Name="Z2_CASTLE_room_01" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_01" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_01DL_000190" Offset="0x190"/>
+        <DList Name="Z2_CASTLE_room_01DL_004E00" Offset="0x4E00"/>
+        <DList Name="Z2_CASTLE_room_01DL_006240" Offset="0x6240"/>
+        <DList Name="Z2_CASTLE_room_01DL_006250" Offset="0x6250"/>
     </File>
     <File Name="Z2_CASTLE_room_02" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_02" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_02DL_000180" Offset="0x180"/>
+        <DList Name="Z2_CASTLE_room_02DL_0024C8" Offset="0x24C8"/>
+        <DList Name="Z2_CASTLE_room_02DL_005100" Offset="0x5100"/>
+        <DList Name="Z2_CASTLE_room_02DL_005320" Offset="0x5320"/>
     </File>
     <File Name="Z2_CASTLE_room_03" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_03" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_03DL_000150" Offset="0x150"/>
+        <DList Name="Z2_CASTLE_room_03DL_003518" Offset="0x3518"/>
+        <DList Name="Z2_CASTLE_room_03DL_005550" Offset="0x5550"/>
+        <DList Name="Z2_CASTLE_room_03DL_005560" Offset="0x5560"/>
     </File>
     <File Name="Z2_CASTLE_room_04" Segment="3" Game="MM">
         <Texture Name="Z2_CASTLE_room_04Tex_004AC0" Format="rgba16" Width="64" Height="64" Offset="0x4AC0"/>
 
         <Room Name="Z2_CASTLE_room_04" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_04DL_0001E0" Offset="0x1E0"/>
+        <DList Name="Z2_CASTLE_room_04DL_003A80" Offset="0x3A80"/>
+        <DList Name="Z2_CASTLE_room_04DL_0086C0" Offset="0x86C0"/>
+        <DList Name="Z2_CASTLE_room_04DL_0086D0" Offset="0x86D0"/>
     </File>
     <File Name="Z2_CASTLE_room_05" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_05" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_05DL_000100" Offset="0x100"/>
+        <DList Name="Z2_CASTLE_room_05DL_002C28" Offset="0x2C28"/>
+        <DList Name="Z2_CASTLE_room_05DL_004050" Offset="0x4050"/>
+        <DList Name="Z2_CASTLE_room_05DL_004060" Offset="0x4060"/>
     </File>
     <File Name="Z2_CASTLE_room_06" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_06" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_06DL_0000D0" Offset="0xD0"/>
+        <DList Name="Z2_CASTLE_room_06DL_001D88" Offset="0x1D88"/>
+        <DList Name="Z2_CASTLE_room_06DL_0025A0" Offset="0x25A0"/>
+        <DList Name="Z2_CASTLE_room_06DL_0025B0" Offset="0x25B0"/>
     </File>
     <File Name="Z2_CASTLE_room_07" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_07" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_07DL_000100" Offset="0x100"/>
+        <DList Name="Z2_CASTLE_room_07DL_001E28" Offset="0x1E28"/>
+        <DList Name="Z2_CASTLE_room_07DL_002650" Offset="0x2650"/>
+        <DList Name="Z2_CASTLE_room_07DL_002660" Offset="0x2660"/>
     </File>
     <File Name="Z2_CASTLE_room_08" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_08" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_08DL_000080" Offset="0x80"/>
+        <DList Name="Z2_CASTLE_room_08DL_000AE8" Offset="0xAE8"/>
     </File>
     <File Name="Z2_CASTLE_room_09" Segment="3" Game="MM">
         <Room Name="Z2_CASTLE_room_09" Offset="0x0"/>
+        <DList Name="Z2_CASTLE_room_09DL_000080" Offset="0x80"/>
+        <DList Name="Z2_CASTLE_room_09DL_000AF0" Offset="0xAF0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_CLOCKTOWER/Z2_CLOCKTOWER.xml
+++ b/assets/xml/scenes/Z2_CLOCKTOWER/Z2_CLOCKTOWER.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_CLOCKTOWER_room_00" Segment="3" Game="MM">
         <Room Name="Z2_CLOCKTOWER_room_00" Offset="0x0"/>
+        <DList Name="Z2_CLOCKTOWER_room_00DL_011708" Offset="0x11708"/>
+        <DList Name="Z2_CLOCKTOWER_room_00DL_013880" Offset="0x13880"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_DANPEI/Z2_DANPEI.xml
+++ b/assets/xml/scenes/Z2_DANPEI/Z2_DANPEI.xml
@@ -4,29 +4,41 @@
     </File>
     <File Name="Z2_DANPEI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_00" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_00DL_0078D0" Offset="0x78D0"/>
+        <DList Name="Z2_DANPEI_room_00DL_00A3A0" Offset="0xA3A0"/>
     </File>
     <File Name="Z2_DANPEI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_01" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_01DL_005E50" Offset="0x5E50"/>
+        <DList Name="Z2_DANPEI_room_01DL_007A60" Offset="0x7A60"/>
     </File>
     <File Name="Z2_DANPEI_room_02" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_02" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_02DL_00A070" Offset="0xA070"/>
     </File>
     <File Name="Z2_DANPEI_room_03" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_03" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_03DL_006E70" Offset="0x6E70"/>
+        <DList Name="Z2_DANPEI_room_03DL_0096F0" Offset="0x96F0"/>
     </File>
     <File Name="Z2_DANPEI_room_04" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_04" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_04DL_004080" Offset="0x4080"/>
     </File>
     <File Name="Z2_DANPEI_room_05" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_05" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_05DL_007640" Offset="0x7640"/>
     </File>
     <File Name="Z2_DANPEI_room_06" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_06" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_06DL_008E18" Offset="0x8E18"/>
     </File>
     <File Name="Z2_DANPEI_room_07" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_07" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_07DL_00B2B0" Offset="0xB2B0"/>
     </File>
     <File Name="Z2_DANPEI_room_08" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI_room_08" Offset="0x0"/>
+        <DList Name="Z2_DANPEI_room_08DL_003DE8" Offset="0x3DE8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_DANPEI2TEST/Z2_DANPEI2TEST.xml
+++ b/assets/xml/scenes/Z2_DANPEI2TEST/Z2_DANPEI2TEST.xml
@@ -4,8 +4,11 @@
     </File>
     <File Name="Z2_DANPEI2TEST_room_00" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI2TEST_room_00" Offset="0x0"/>
+        <DList Name="Z2_DANPEI2TEST_room_00DL_00F360" Offset="0xF360"/>
+        <DList Name="Z2_DANPEI2TEST_room_00DL_016C50" Offset="0x16C50"/>
     </File>
     <File Name="Z2_DANPEI2TEST_room_01" Segment="3" Game="MM">
         <Room Name="Z2_DANPEI2TEST_room_01" Offset="0x0"/>
+        <DList Name="Z2_DANPEI2TEST_room_01DL_004F48" Offset="0x4F48"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_DEKUTES/Z2_DEKUTES.xml
+++ b/assets/xml/scenes/Z2_DEKUTES/Z2_DEKUTES.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_DEKUTES_room_00" Segment="3" Game="MM">
         <Room Name="Z2_DEKUTES_room_00" Offset="0x0"/>
+        <DList Name="Z2_DEKUTES_room_00DL_003FB0" Offset="0x3FB0"/>
+        <DList Name="Z2_DEKUTES_room_00DL_004350" Offset="0x4350"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_DEKU_KING/Z2_DEKU_KING.xml
+++ b/assets/xml/scenes/Z2_DEKU_KING/Z2_DEKU_KING.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_DEKU_KING_room_00" Segment="3" Game="MM">
         <Room Name="Z2_DEKU_KING_room_00" Offset="0x0"/>
+        <DList Name="Z2_DEKU_KING_room_00DL_0093A0" Offset="0x93A0"/>
+        <DList Name="Z2_DEKU_KING_room_00DL_0094B0" Offset="0x94B0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_DOUJOU/Z2_DOUJOU.xml
+++ b/assets/xml/scenes/Z2_DOUJOU/Z2_DOUJOU.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_DOUJOU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_DOUJOU_room_00" Offset="0x0"/>
+        <DList Name="Z2_DOUJOU_room_00DL_0062B0" Offset="0x62B0"/>
+        <DList Name="Z2_DOUJOU_room_00DL_0064C0" Offset="0x64C0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_F01/Z2_F01.xml
+++ b/assets/xml/scenes/Z2_F01/Z2_F01.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_F01_room_00" Segment="3" Game="MM">
         <Room Name="Z2_F01_room_00" Offset="0x0"/>
+        <DList Name="Z2_F01_room_00DL_00BB78" Offset="0xBB78"/>
+        <DList Name="Z2_F01_room_00DL_00D248" Offset="0xD248"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_F01C/Z2_F01C.xml
+++ b/assets/xml/scenes/Z2_F01C/Z2_F01C.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_F01C_room_00" Segment="3" Game="MM">
         <Room Name="Z2_F01C_room_00" Offset="0x0"/>
+        <DList Name="Z2_F01C_room_00DL_0055C8" Offset="0x55C8"/>
+        <DList Name="Z2_F01C_room_00DL_0059D0" Offset="0x59D0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_F01_B/Z2_F01_B.xml
+++ b/assets/xml/scenes/Z2_F01_B/Z2_F01_B.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_F01_B_room_00" Segment="3" Game="MM">
         <Room Name="Z2_F01_B_room_00" Offset="0x0"/>
+        <DList Name="Z2_F01_B_room_00DL_006C20" Offset="0x6C20"/>
+        <DList Name="Z2_F01_B_room_00DL_007250" Offset="0x7250"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_F40/Z2_F40.xml
+++ b/assets/xml/scenes/Z2_F40/Z2_F40.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_F40_room_00" Segment="3" Game="MM">
         <Room Name="Z2_F40_room_00" Offset="0x0"/>
+        <DList Name="Z2_F40_room_00DL_0090F0" Offset="0x90F0"/>
+        <DList Name="Z2_F40_room_00DL_00BE50" Offset="0xBE50"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_F41/Z2_F41.xml
+++ b/assets/xml/scenes/Z2_F41/Z2_F41.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_F41_room_00" Segment="3" Game="MM">
         <Room Name="Z2_F41_room_00" Offset="0x0"/>
+        <DList Name="Z2_F41_room_00DL_008C20" Offset="0x8C20"/>
+        <DList Name="Z2_F41_room_00DL_00B940" Offset="0xB940"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_FISHERMAN/Z2_FISHERMAN.xml
+++ b/assets/xml/scenes/Z2_FISHERMAN/Z2_FISHERMAN.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_FISHERMAN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_FISHERMAN_room_00" Offset="0x0"/>
+        <DList Name="Z2_FISHERMAN_room_00DL_007140" Offset="0x7140"/>
+        <DList Name="Z2_FISHERMAN_room_00DL_0084F0" Offset="0x84F0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_GORONRACE/Z2_GORONRACE.xml
+++ b/assets/xml/scenes/Z2_GORONRACE/Z2_GORONRACE.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_GORONRACE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_GORONRACE_room_00" Offset="0x0"/>
+        <DList Name="Z2_GORONRACE_room_00DL_00D8A0" Offset="0xD8A0"/>
+        <DList Name="Z2_GORONRACE_room_00DL_00DB50" Offset="0xDB50"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_GORONSHOP/Z2_GORONSHOP.xml
+++ b/assets/xml/scenes/Z2_GORONSHOP/Z2_GORONSHOP.xml
@@ -7,5 +7,7 @@
     </File>
     <File Name="Z2_GORONSHOP_room_00" Segment="3" Game="MM">
         <Room Name="Z2_GORONSHOP_room_00" Offset="0x0"/>
+        <DList Name="Z2_GORONSHOP_room_00DL_008FF8" Offset="0x8FF8"/>
+        <DList Name="Z2_GORONSHOP_room_00DL_009578" Offset="0x9578"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_GORON_HAKA/Z2_GORON_HAKA.xml
+++ b/assets/xml/scenes/Z2_GORON_HAKA/Z2_GORON_HAKA.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_GORON_HAKA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_GORON_HAKA_room_00" Offset="0x0"/>
+        <DList Name="Z2_GORON_HAKA_room_00DL_007A80" Offset="0x7A80"/>
+        <DList Name="Z2_GORON_HAKA_room_00DL_007D98" Offset="0x7D98"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_HAKASHITA/Z2_HAKASHITA.xml
+++ b/assets/xml/scenes/Z2_HAKASHITA/Z2_HAKASHITA.xml
@@ -4,17 +4,25 @@
     </File>
     <File Name="Z2_HAKASHITA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_HAKASHITA_room_00" Offset="0x0"/>
+        <DList Name="Z2_HAKASHITA_room_00DL_005B78" Offset="0x5B78"/>
+        <DList Name="Z2_HAKASHITA_room_00DL_007020" Offset="0x7020"/>
     </File>
     <File Name="Z2_HAKASHITA_room_01" Segment="3" Game="MM">
         <Room Name="Z2_HAKASHITA_room_01" Offset="0x0"/>
+        <DList Name="Z2_HAKASHITA_room_01DL_005BF0" Offset="0x5BF0"/>
     </File>
     <File Name="Z2_HAKASHITA_room_02" Segment="3" Game="MM">
         <Room Name="Z2_HAKASHITA_room_02" Offset="0x0"/>
+        <DList Name="Z2_HAKASHITA_room_02DL_0051A0" Offset="0x51A0"/>
+        <DList Name="Z2_HAKASHITA_room_02DL_006FD0" Offset="0x6FD0"/>
     </File>
     <File Name="Z2_HAKASHITA_room_03" Segment="3" Game="MM">
         <Room Name="Z2_HAKASHITA_room_03" Offset="0x0"/>
+        <DList Name="Z2_HAKASHITA_room_03DL_002E50" Offset="0x2E50"/>
     </File>
     <File Name="Z2_HAKASHITA_room_04" Segment="3" Game="MM">
         <Room Name="Z2_HAKASHITA_room_04" Offset="0x0"/>
+        <DList Name="Z2_HAKASHITA_room_04DL_002FB8" Offset="0x2FB8"/>
+        <DList Name="Z2_HAKASHITA_room_04DL_004980" Offset="0x4980"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_HAKUGIN/Z2_HAKUGIN.xml
+++ b/assets/xml/scenes/Z2_HAKUGIN/Z2_HAKUGIN.xml
@@ -4,44 +4,67 @@
     </File>
     <File Name="Z2_HAKUGIN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_00" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_00DL_003B88" Offset="0x3B88"/>
+        <DList Name="Z2_HAKUGIN_room_00DL_008420" Offset="0x8420"/>
     </File>
     <File Name="Z2_HAKUGIN_room_01" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_01" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_01DL_002CC8" Offset="0x2CC8"/>
     </File>
     <File Name="Z2_HAKUGIN_room_02" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_02" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_02DL_0051E0" Offset="0x51E0"/>
+        <DList Name="Z2_HAKUGIN_room_02DL_00C480" Offset="0xC480"/>
     </File>
     <File Name="Z2_HAKUGIN_room_03" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_03" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_03DL_002808" Offset="0x2808"/>
     </File>
     <File Name="Z2_HAKUGIN_room_04" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_04" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_04DL_0116C0" Offset="0x116C0"/>
+        <DList Name="Z2_HAKUGIN_room_04DL_021760" Offset="0x21760"/>
     </File>
     <File Name="Z2_HAKUGIN_room_05" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_05" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_05DL_004410" Offset="0x4410"/>
     </File>
     <File Name="Z2_HAKUGIN_room_06" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_06" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_06DL_001230" Offset="0x1230"/>
     </File>
     <File Name="Z2_HAKUGIN_room_07" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_07" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_07DL_0029F0" Offset="0x29F0"/>
+        <DList Name="Z2_HAKUGIN_room_07DL_006AA0" Offset="0x6AA0"/>
     </File>
     <File Name="Z2_HAKUGIN_room_08" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_08" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_08DL_002F78" Offset="0x2F78"/>
+        <DList Name="Z2_HAKUGIN_room_08DL_004FC0" Offset="0x4FC0"/>
     </File>
     <File Name="Z2_HAKUGIN_room_09" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_09" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_09DL_003388" Offset="0x3388"/>
+        <DList Name="Z2_HAKUGIN_room_09DL_008428" Offset="0x8428"/>
     </File>
     <File Name="Z2_HAKUGIN_room_10" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_10" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_10DL_001C40" Offset="0x1C40"/>
+        <DList Name="Z2_HAKUGIN_room_10DL_003470" Offset="0x3470"/>
     </File>
     <File Name="Z2_HAKUGIN_room_11" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_11" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_11DL_001700" Offset="0x1700"/>
     </File>
     <File Name="Z2_HAKUGIN_room_12" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_12" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_12DL_001C98" Offset="0x1C98"/>
+        <DList Name="Z2_HAKUGIN_room_12DL_004CF8" Offset="0x4CF8"/>
     </File>
     <File Name="Z2_HAKUGIN_room_13" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_room_13" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_room_13DL_000A50" Offset="0xA50"/>
+        <DList Name="Z2_HAKUGIN_room_13DL_0042F0" Offset="0x42F0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_HAKUGIN_BS/Z2_HAKUGIN_BS.xml
+++ b/assets/xml/scenes/Z2_HAKUGIN_BS/Z2_HAKUGIN_BS.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_HAKUGIN_BS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_HAKUGIN_BS_room_00" Offset="0x0"/>
+        <DList Name="Z2_HAKUGIN_BS_room_00DL_0061E0" Offset="0x61E0"/>
+        <DList Name="Z2_HAKUGIN_BS_room_00DL_006238" Offset="0x6238"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_ICHIBA/Z2_ICHIBA.xml
+++ b/assets/xml/scenes/Z2_ICHIBA/Z2_ICHIBA.xml
@@ -4,5 +4,8 @@
     </File>
     <File Name="Z2_ICHIBA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_ICHIBA_room_00" Offset="0x0"/>
+        <DList Name="Z2_ICHIBA_room_00DL_000530" Offset="0x530"/>
+        <DList Name="Z2_ICHIBA_room_00DL_008CF0" Offset="0x8CF0"/>
+        <DList Name="Z2_ICHIBA_room_00DL_00AAB8" Offset="0xAAB8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_IKANA/Z2_IKANA.xml
+++ b/assets/xml/scenes/Z2_IKANA/Z2_IKANA.xml
@@ -6,17 +6,35 @@
         <Texture Name="Z2_IKANA_room_00Tex_020A40" Format="rgba16" Width="64" Height="64" Offset="0x20A40"/>
 
         <Room Name="Z2_IKANA_room_00" Offset="0x0"/>
+        <DList Name="Z2_IKANA_room_00DL_001040" Offset="0x1040"/>
+        <DList Name="Z2_IKANA_room_00DL_011DF0" Offset="0x11DF0"/>
+        <DList Name="Z2_IKANA_room_00DL_023880" Offset="0x23880"/>
+        <DList Name="Z2_IKANA_room_00DL_025F28" Offset="0x25F28"/>
     </File>
     <File Name="Z2_IKANA_room_01" Segment="3" Game="MM">
         <Room Name="Z2_IKANA_room_01" Offset="0x0"/>
+        <DList Name="Z2_IKANA_room_01DL_000340" Offset="0x340"/>
+        <DList Name="Z2_IKANA_room_01DL_000478" Offset="0x478"/>
     </File>
     <File Name="Z2_IKANA_room_02" Segment="3" Game="MM">
         <Room Name="Z2_IKANA_room_02" Offset="0x0"/>
+        <DList Name="Z2_IKANA_room_02DL_000370" Offset="0x370"/>
+        <DList Name="Z2_IKANA_room_02DL_001348" Offset="0x1348"/>
+        <DList Name="Z2_IKANA_room_02DL_001F70" Offset="0x1F70"/>
+        <DList Name="Z2_IKANA_room_02DL_002B00" Offset="0x2B00"/>
     </File>
     <File Name="Z2_IKANA_room_03" Segment="3" Game="MM">
         <Room Name="Z2_IKANA_room_03" Offset="0x0"/>
+        <DList Name="Z2_IKANA_room_03DL_0002A0" Offset="0x2A0"/>
+        <DList Name="Z2_IKANA_room_03DL_001510" Offset="0x1510"/>
+        <DList Name="Z2_IKANA_room_03DL_002D40" Offset="0x2D40"/>
+        <DList Name="Z2_IKANA_room_03DL_002D50" Offset="0x2D50"/>
     </File>
     <File Name="Z2_IKANA_room_04" Segment="3" Game="MM">
         <Room Name="Z2_IKANA_room_04" Offset="0x0"/>
+        <DList Name="Z2_IKANA_room_04DL_000550" Offset="0x550"/>
+        <DList Name="Z2_IKANA_room_04DL_002A70" Offset="0x2A70"/>
+        <DList Name="Z2_IKANA_room_04DL_007CD0" Offset="0x7CD0"/>
+        <DList Name="Z2_IKANA_room_04DL_008840" Offset="0x8840"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_IKANAMAE/Z2_IKANAMAE.xml
+++ b/assets/xml/scenes/Z2_IKANAMAE/Z2_IKANAMAE.xml
@@ -4,5 +4,9 @@
     </File>
     <File Name="Z2_IKANAMAE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_IKANAMAE_room_00" Offset="0x0"/>
+        <DList Name="Z2_IKANAMAE_room_00DL_004510" Offset="0x4510"/>
+        <DList Name="Z2_IKANAMAE_room_00DL_000650" Offset="0x650"/>
+        <DList Name="Z2_IKANAMAE_room_00DL_004498" Offset="0x4498"/>
+        <DList Name="Z2_IKANAMAE_room_00DL_004BC0" Offset="0x4BC0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_IKNINSIDE/Z2_IKNINSIDE.xml
+++ b/assets/xml/scenes/Z2_IKNINSIDE/Z2_IKNINSIDE.xml
@@ -4,8 +4,12 @@
     </File>
     <File Name="Z2_IKNINSIDE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_IKNINSIDE_room_00" Offset="0x0"/>
+        <DList Name="Z2_IKNINSIDE_room_00DL_002988" Offset="0x2988"/>
+        <DList Name="Z2_IKNINSIDE_room_00DL_0029C8" Offset="0x29C8"/>
     </File>
     <File Name="Z2_IKNINSIDE_room_01" Segment="3" Game="MM">
         <Room Name="Z2_IKNINSIDE_room_01" Offset="0x0"/>
+        <DList Name="Z2_IKNINSIDE_room_01DL_0061F0" Offset="0x61F0"/>
+        <DList Name="Z2_IKNINSIDE_room_01DL_007828" Offset="0x7828"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_INISIE_BS/Z2_INISIE_BS.xml
+++ b/assets/xml/scenes/Z2_INISIE_BS/Z2_INISIE_BS.xml
@@ -4,5 +4,6 @@
     </File>
     <File Name="Z2_INISIE_BS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_BS_room_00" Offset="0x0"/>
+        <DList Name="Z2_INISIE_BS_room_00DL_000198" Offset="0x198"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_INISIE_N/Z2_INISIE_N.xml
+++ b/assets/xml/scenes/Z2_INISIE_N/Z2_INISIE_N.xml
@@ -4,38 +4,59 @@
     </File>
     <File Name="Z2_INISIE_N_room_00" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_00" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_00DL_009D48" Offset="0x9D48"/>
+        <DList Name="Z2_INISIE_N_room_00DL_00EA18" Offset="0xEA18"/>
     </File>
     <File Name="Z2_INISIE_N_room_01" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_01" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_01DL_006E18" Offset="0x6E18"/>
+        <DList Name="Z2_INISIE_N_room_01DL_00A4E8" Offset="0xA4E8"/>
     </File>
     <File Name="Z2_INISIE_N_room_02" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_02" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_02DL_006C70" Offset="0x6C70"/>
+        <DList Name="Z2_INISIE_N_room_02DL_0076D8" Offset="0x76D8"/>
     </File>
     <File Name="Z2_INISIE_N_room_03" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_03" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_03DL_007978" Offset="0x7978"/>
+        <DList Name="Z2_INISIE_N_room_03DL_00A410" Offset="0xA410"/>
     </File>
     <File Name="Z2_INISIE_N_room_04" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_04" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_04DL_0050C0" Offset="0x50C0"/>
+        <DList Name="Z2_INISIE_N_room_04DL_007518" Offset="0x7518"/>
     </File>
     <File Name="Z2_INISIE_N_room_05" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_05" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_05DL_000198" Offset="0x198"/>
     </File>
     <File Name="Z2_INISIE_N_room_06" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_06" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_06DL_000198" Offset="0x198"/>
     </File>
     <File Name="Z2_INISIE_N_room_07" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_07" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_07DL_002F38" Offset="0x2F38"/>
+        <DList Name="Z2_INISIE_N_room_07DL_003300" Offset="0x3300"/>
     </File>
     <File Name="Z2_INISIE_N_room_08" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_08" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_08DL_003AD8" Offset="0x3AD8"/>
+        <DList Name="Z2_INISIE_N_room_08DL_004C38" Offset="0x4C38"/>
     </File>
     <File Name="Z2_INISIE_N_room_09" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_09" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_09DL_004DD0" Offset="0x4DD0"/>
+        <DList Name="Z2_INISIE_N_room_09DL_008270" Offset="0x8270"/>
     </File>
     <File Name="Z2_INISIE_N_room_10" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_10" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_10DL_0029F8" Offset="0x29F8"/>
+        <DList Name="Z2_INISIE_N_room_10DL_004A20" Offset="0x4A20"/>
     </File>
     <File Name="Z2_INISIE_N_room_11" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_N_room_11" Offset="0x0"/>
+        <DList Name="Z2_INISIE_N_room_11DL_0001B8" Offset="0x1B8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_INISIE_R/Z2_INISIE_R.xml
+++ b/assets/xml/scenes/Z2_INISIE_R/Z2_INISIE_R.xml
@@ -4,38 +4,58 @@
     </File>
     <File Name="Z2_INISIE_R_room_00" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_00" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_00DL_009F70" Offset="0x9F70"/>
+        <DList Name="Z2_INISIE_R_room_00DL_00D448" Offset="0xD448"/>
     </File>
     <File Name="Z2_INISIE_R_room_01" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_01" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_01DL_006D98" Offset="0x6D98"/>
+        <DList Name="Z2_INISIE_R_room_01DL_009638" Offset="0x9638"/>
     </File>
     <File Name="Z2_INISIE_R_room_02" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_02" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_02DL_006D80" Offset="0x6D80"/>
+        <DList Name="Z2_INISIE_R_room_02DL_0083F8" Offset="0x83F8"/>
     </File>
     <File Name="Z2_INISIE_R_room_03" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_03" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_03DL_007B78" Offset="0x7B78"/>
+        <DList Name="Z2_INISIE_R_room_03DL_00AA48" Offset="0xAA48"/>
     </File>
     <File Name="Z2_INISIE_R_room_04" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_04" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_04DL_004E38" Offset="0x4E38"/>
+        <DList Name="Z2_INISIE_R_room_04DL_006688" Offset="0x6688"/>
     </File>
     <File Name="Z2_INISIE_R_room_05" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_05" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_05DL_000250" Offset="0x250"/>
     </File>
     <File Name="Z2_INISIE_R_room_06" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_06" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_06DL_000230" Offset="0x230"/>
     </File>
     <File Name="Z2_INISIE_R_room_07" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_07" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_07DL_0001B8" Offset="0x1B8"/>
     </File>
     <File Name="Z2_INISIE_R_room_08" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_08" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_08DL_003AB8" Offset="0x3AB8"/>
+        <DList Name="Z2_INISIE_R_room_08DL_004418" Offset="0x4418"/>
     </File>
     <File Name="Z2_INISIE_R_room_09" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_09" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_09DL_0001B8" Offset="0x1B8"/>
     </File>
     <File Name="Z2_INISIE_R_room_10" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_10" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_10DL_002DA8" Offset="0x2DA8"/>
+        <DList Name="Z2_INISIE_R_room_10DL_0047C0" Offset="0x47C0"/>
     </File>
     <File Name="Z2_INISIE_R_room_11" Segment="3" Game="MM">
         <Room Name="Z2_INISIE_R_room_11" Offset="0x0"/>
+        <DList Name="Z2_INISIE_R_room_11DL_002EA0" Offset="0x2EA0"/>
+        <DList Name="Z2_INISIE_R_room_11DL_0042E8" Offset="0x42E8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_INSIDETOWER/Z2_INSIDETOWER.xml
+++ b/assets/xml/scenes/Z2_INSIDETOWER/Z2_INSIDETOWER.xml
@@ -4,8 +4,11 @@
     </File>
     <File Name="Z2_INSIDETOWER_room_00" Segment="3" Game="MM">
         <Room Name="Z2_INSIDETOWER_room_00" Offset="0x0"/>
+        <DList Name="Z2_INSIDETOWER_room_00DL_006B10" Offset="0x6B10"/>
+        <DList Name="Z2_INSIDETOWER_room_00DL_00C9E0" Offset="0xC9E0"/>
     </File>
     <File Name="Z2_INSIDETOWER_room_01" Segment="3" Game="MM">
         <Room Name="Z2_INSIDETOWER_room_01" Offset="0x0"/>
+        <DList Name="Z2_INSIDETOWER_room_01DL_000198" Offset="0x198"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KAIZOKU/Z2_KAIZOKU.xml
+++ b/assets/xml/scenes/Z2_KAIZOKU/Z2_KAIZOKU.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_KAIZOKU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KAIZOKU_room_00" Offset="0x0"/>
+        <DList Name="Z2_KAIZOKU_room_00DL_013F30" Offset="0x13F30"/>
+        <DList Name="Z2_KAIZOKU_room_00DL_013E78" Offset="0x13E78"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KAJIYA/Z2_KAJIYA.xml
+++ b/assets/xml/scenes/Z2_KAJIYA/Z2_KAJIYA.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_KAJIYA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KAJIYA_room_00" Offset="0x0"/>
+        <DList Name="Z2_KAJIYA_room_00DL_00D478" Offset="0xD478"/>
+        <DList Name="Z2_KAJIYA_room_00DL_00D8D0" Offset="0xD8D0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KINDAN2/Z2_KINDAN2.xml
+++ b/assets/xml/scenes/Z2_KINDAN2/Z2_KINDAN2.xml
@@ -4,20 +4,32 @@
     </File>
     <File Name="Z2_KINDAN2_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_00" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_00DL_004288" Offset="0x4288"/>
+        <DList Name="Z2_KINDAN2_room_00DL_006A28" Offset="0x6A28"/>
     </File>
     <File Name="Z2_KINDAN2_room_01" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_01" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_01DL_00ADB8" Offset="0xADB8"/>
+        <DList Name="Z2_KINDAN2_room_01DL_00C2D8" Offset="0xC2D8"/>
     </File>
     <File Name="Z2_KINDAN2_room_02" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_02" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_02DL_007FC8" Offset="0x7FC8"/>
+        <DList Name="Z2_KINDAN2_room_02DL_00A328" Offset="0xA328"/>
     </File>
     <File Name="Z2_KINDAN2_room_03" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_03" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_03DL_007610" Offset="0x7610"/>
+        <DList Name="Z2_KINDAN2_room_03DL_0093F0" Offset="0x93F0"/>
     </File>
     <File Name="Z2_KINDAN2_room_04" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_04" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_04DL_003E30" Offset="0x3E30"/>
+        <DList Name="Z2_KINDAN2_room_04DL_004AA8" Offset="0x4AA8"/>
     </File>
     <File Name="Z2_KINDAN2_room_05" Segment="3" Game="MM">
         <Room Name="Z2_KINDAN2_room_05" Offset="0x0"/>
+        <DList Name="Z2_KINDAN2_room_05DL_006B20" Offset="0x6B20"/>
+        <DList Name="Z2_KINDAN2_room_05DL_007DD0" Offset="0x7DD0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KINSTA1/Z2_KINSTA1.xml
+++ b/assets/xml/scenes/Z2_KINSTA1/Z2_KINSTA1.xml
@@ -4,20 +4,31 @@
     </File>
     <File Name="Z2_KINSTA1_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_00" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_00DL_001FC8" Offset="0x1FC8"/>
+        <DList Name="Z2_KINSTA1_room_00DL_002210" Offset="0x2210"/>
     </File>
     <File Name="Z2_KINSTA1_room_01" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_01" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_01DL_008610" Offset="0x8610"/>
+        <DList Name="Z2_KINSTA1_room_01DL_0098E8" Offset="0x98E8"/>
     </File>
     <File Name="Z2_KINSTA1_room_02" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_02" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_02DL_0035B0" Offset="0x35B0"/>
+        <DList Name="Z2_KINSTA1_room_02DL_005610" Offset="0x5610"/>
     </File>
     <File Name="Z2_KINSTA1_room_03" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_03" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_03DL_003B28" Offset="0x3B28"/>
+        <DList Name="Z2_KINSTA1_room_03DL_0046B8" Offset="0x46B8"/>
     </File>
     <File Name="Z2_KINSTA1_room_04" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_04" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_04DL_0083D0" Offset="0x83D0"/>
+        <DList Name="Z2_KINSTA1_room_04DL_009040" Offset="0x9040"/>
     </File>
     <File Name="Z2_KINSTA1_room_05" Segment="3" Game="MM">
         <Room Name="Z2_KINSTA1_room_05" Offset="0x0"/>
+        <DList Name="Z2_KINSTA1_room_05DL_001A08" Offset="0x1A08"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KOEPONARACE/Z2_KOEPONARACE.xml
+++ b/assets/xml/scenes/Z2_KOEPONARACE/Z2_KOEPONARACE.xml
@@ -4,5 +4,9 @@
     </File>
     <File Name="Z2_KOEPONARACE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KOEPONARACE_room_00" Offset="0x0"/>
+        <DList Name="Z2_KOEPONARACE_room_00DL_007A20" Offset="0x7A20"/>
+        <DList Name="Z2_KOEPONARACE_room_00DL_000600" Offset="0x600"/>
+        <DList Name="Z2_KOEPONARACE_room_00DL_0079B8" Offset="0x79B8"/>
+        <DList Name="Z2_KOEPONARACE_room_00DL_008408" Offset="0x8408"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KONPEKI_ENT/Z2_KONPEKI_ENT.xml
+++ b/assets/xml/scenes/Z2_KONPEKI_ENT/Z2_KONPEKI_ENT.xml
@@ -6,5 +6,7 @@
     </File>
     <File Name="Z2_KONPEKI_ENT_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KONPEKI_ENT_room_00" Offset="0x0"/>
+        <DList Name="Z2_KONPEKI_ENT_room_00DL_006210" Offset="0x6210"/>
+        <DList Name="Z2_KONPEKI_ENT_room_00DL_006390" Offset="0x6390"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_KYOJINNOMA/Z2_KYOJINNOMA.xml
+++ b/assets/xml/scenes/Z2_KYOJINNOMA/Z2_KYOJINNOMA.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_KYOJINNOMA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_KYOJINNOMA_room_00" Offset="0x0"/>
+        <DList Name="Z2_KYOJINNOMA_room_00DL_000EF8" Offset="0xEF8"/>
+        <DList Name="Z2_KYOJINNOMA_room_00DL_001A10" Offset="0x1A10"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LABO/Z2_LABO.xml
+++ b/assets/xml/scenes/Z2_LABO/Z2_LABO.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_LABO_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LABO_room_00" Offset="0x0"/>
+        <DList Name="Z2_LABO_room_00DL_005CA8" Offset="0x5CA8"/>
+        <DList Name="Z2_LABO_room_00DL_008638" Offset="0x8638"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LAST_BS/Z2_LAST_BS.xml
+++ b/assets/xml/scenes/Z2_LAST_BS/Z2_LAST_BS.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_LAST_BS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LAST_BS_room_00" Offset="0x0"/>
+        <DList Name="Z2_LAST_BS_room_00DL_008A50" Offset="0x8A50"/>
+        <DList Name="Z2_LAST_BS_room_00DL_008980" Offset="0x8980"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LAST_DEKU/Z2_LAST_DEKU.xml
+++ b/assets/xml/scenes/Z2_LAST_DEKU/Z2_LAST_DEKU.xml
@@ -4,8 +4,10 @@
     </File>
     <File Name="Z2_LAST_DEKU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LAST_DEKU_room_00" Offset="0x0"/>
+        <DList Name="Z2_LAST_DEKU_room_00DL_005A00" Offset="0x5A00"/>
     </File>
     <File Name="Z2_LAST_DEKU_room_01" Segment="3" Game="MM">
         <Room Name="Z2_LAST_DEKU_room_01" Offset="0x0"/>
+        <DList Name="Z2_LAST_DEKU_room_01DL_0016F0" Offset="0x16F0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LAST_GORON/Z2_LAST_GORON.xml
+++ b/assets/xml/scenes/Z2_LAST_GORON/Z2_LAST_GORON.xml
@@ -4,8 +4,11 @@
     </File>
     <File Name="Z2_LAST_GORON_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LAST_GORON_room_00" Offset="0x0"/>
+        <DList Name="Z2_LAST_GORON_room_00DL_00D3C8" Offset="0xD3C8"/>
+        <DList Name="Z2_LAST_GORON_room_00DL_015E78" Offset="0x15E78"/>
     </File>
     <File Name="Z2_LAST_GORON_room_01" Segment="3" Game="MM">
         <Room Name="Z2_LAST_GORON_room_01" Offset="0x0"/>
+        <DList Name="Z2_LAST_GORON_room_01DL_001438" Offset="0x1438"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LAST_LINK/Z2_LAST_LINK.xml
+++ b/assets/xml/scenes/Z2_LAST_LINK/Z2_LAST_LINK.xml
@@ -4,26 +4,34 @@
     </File>
     <File Name="Z2_LAST_LINK_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_00" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_00DL_001990" Offset="0x1990"/>
     </File>
     <File Name="Z2_LAST_LINK_room_01" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_01" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_01DL_0015D0" Offset="0x15D0"/>
     </File>
     <File Name="Z2_LAST_LINK_room_02" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_02" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_02DL_0016C0" Offset="0x16C0"/>
     </File>
     <File Name="Z2_LAST_LINK_room_03" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_03" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_03DL_001B20" Offset="0x1B20"/>
     </File>
     <File Name="Z2_LAST_LINK_room_04" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_04" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_04DL_001168" Offset="0x1168"/>
     </File>
     <File Name="Z2_LAST_LINK_room_05" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_05" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_05DL_0016A0" Offset="0x16A0"/>
     </File>
     <File Name="Z2_LAST_LINK_room_06" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_06" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_06DL_000B18" Offset="0xB18"/>
     </File>
     <File Name="Z2_LAST_LINK_room_07" Segment="3" Game="MM">
         <Room Name="Z2_LAST_LINK_room_07" Offset="0x0"/>
+        <DList Name="Z2_LAST_LINK_room_07DL_000B18" Offset="0xB18"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LAST_ZORA/Z2_LAST_ZORA.xml
+++ b/assets/xml/scenes/Z2_LAST_ZORA/Z2_LAST_ZORA.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_LAST_ZORA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LAST_ZORA_room_00" Offset="0x0"/>
+        <DList Name="Z2_LAST_ZORA_room_00DL_00DF40" Offset="0xDF40"/>
+        <DList Name="Z2_LAST_ZORA_room_00DL_00E750" Offset="0xE750"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_LOST_WOODS/Z2_LOST_WOODS.xml
+++ b/assets/xml/scenes/Z2_LOST_WOODS/Z2_LOST_WOODS.xml
@@ -6,11 +6,17 @@
     </File>
     <File Name="Z2_LOST_WOODS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_LOST_WOODS_room_00" Offset="0x0"/>
+        <DList Name="Z2_LOST_WOODS_room_00DL_0049D0" Offset="0x49D0"/>
+        <DList Name="Z2_LOST_WOODS_room_00DL_0080D8" Offset="0x80D8"/>
     </File>
     <File Name="Z2_LOST_WOODS_room_01" Segment="3" Game="MM">
         <Room Name="Z2_LOST_WOODS_room_01" Offset="0x0"/>
+        <DList Name="Z2_LOST_WOODS_room_01DL_005658" Offset="0x5658"/>
+        <DList Name="Z2_LOST_WOODS_room_01DL_009D08" Offset="0x9D08"/>
     </File>
     <File Name="Z2_LOST_WOODS_room_02" Segment="3" Game="MM">
         <Room Name="Z2_LOST_WOODS_room_02" Offset="0x0"/>
+        <DList Name="Z2_LOST_WOODS_room_02DL_000B48" Offset="0xB48"/>
+        <DList Name="Z2_LOST_WOODS_room_02DL_001498" Offset="0x1498"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_MAP_SHOP/Z2_MAP_SHOP.xml
+++ b/assets/xml/scenes/Z2_MAP_SHOP/Z2_MAP_SHOP.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_MAP_SHOP_room_00" Segment="3" Game="MM">
         <Room Name="Z2_MAP_SHOP_room_00" Offset="0x0"/>
+        <DList Name="Z2_MAP_SHOP_room_00DL_005738" Offset="0x5738"/>
+        <DList Name="Z2_MAP_SHOP_room_00DL_005810" Offset="0x5810"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_MILK_BAR/Z2_MILK_BAR.xml
+++ b/assets/xml/scenes/Z2_MILK_BAR/Z2_MILK_BAR.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_MILK_BAR_room_00" Segment="3" Game="MM">
         <Room Name="Z2_MILK_BAR_room_00" Offset="0x0"/>
+        <DList Name="Z2_MILK_BAR_room_00DL_0093C0" Offset="0x93C0"/>
+        <DList Name="Z2_MILK_BAR_room_00DL_00AF48" Offset="0xAF48"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_MITURIN/Z2_MITURIN.xml
+++ b/assets/xml/scenes/Z2_MITURIN/Z2_MITURIN.xml
@@ -4,41 +4,66 @@
     </File>
     <File Name="Z2_MITURIN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_00" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_00DL_007490" Offset="0x7490"/>
+        <DList Name="Z2_MITURIN_room_00DL_009430" Offset="0x9430"/>
     </File>
     <File Name="Z2_MITURIN_room_01" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_01" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_01DL_006BF0" Offset="0x6BF0"/>
+        <DList Name="Z2_MITURIN_room_01DL_008860" Offset="0x8860"/>
     </File>
     <File Name="Z2_MITURIN_room_02" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_02" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_02DL_004B58" Offset="0x4B58"/>
+        <DList Name="Z2_MITURIN_room_02DL_006CC8" Offset="0x6CC8"/>
     </File>
     <File Name="Z2_MITURIN_room_03" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_03" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_03DL_006BF8" Offset="0x6BF8"/>
+        <DList Name="Z2_MITURIN_room_03DL_009DA8" Offset="0x9DA8"/>
     </File>
     <File Name="Z2_MITURIN_room_04" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_04" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_04DL_0019E0" Offset="0x19E0"/>
+        <DList Name="Z2_MITURIN_room_04DL_002438" Offset="0x2438"/>
     </File>
     <File Name="Z2_MITURIN_room_05" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_05" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_05DL_004230" Offset="0x4230"/>
+        <DList Name="Z2_MITURIN_room_05DL_006028" Offset="0x6028"/>
     </File>
     <File Name="Z2_MITURIN_room_06" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_06" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_06DL_002158" Offset="0x2158"/>
+        <DList Name="Z2_MITURIN_room_06DL_002FF8" Offset="0x2FF8"/>
     </File>
     <File Name="Z2_MITURIN_room_07" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_07" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_07DL_002828" Offset="0x2828"/>
+        <DList Name="Z2_MITURIN_room_07DL_003750" Offset="0x3750"/>
     </File>
     <File Name="Z2_MITURIN_room_08" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_08" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_08DL_002CB0" Offset="0x2CB0"/>
+        <DList Name="Z2_MITURIN_room_08DL_006718" Offset="0x6718"/>
     </File>
     <File Name="Z2_MITURIN_room_09" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_09" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_09DL_009F70" Offset="0x9F70"/>
+        <DList Name="Z2_MITURIN_room_09DL_00ADD0" Offset="0xADD0"/>
     </File>
     <File Name="Z2_MITURIN_room_10" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_10" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_10DL_004A18" Offset="0x4A18"/>
+        <DList Name="Z2_MITURIN_room_10DL_004EA0" Offset="0x4EA0"/>
     </File>
     <File Name="Z2_MITURIN_room_11" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_11" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_11DL_003510" Offset="0x3510"/>
+        <DList Name="Z2_MITURIN_room_11DL_006D88" Offset="0x6D88"/>
     </File>
     <File Name="Z2_MITURIN_room_12" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_room_12" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_room_12DL_001450" Offset="0x1450"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_MITURIN_BS/Z2_MITURIN_BS.xml
+++ b/assets/xml/scenes/Z2_MITURIN_BS/Z2_MITURIN_BS.xml
@@ -4,5 +4,6 @@
     </File>
     <File Name="Z2_MITURIN_BS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_MITURIN_BS_room_00" Offset="0x0"/>
+        <DList Name="Z2_MITURIN_BS_room_00DL_001C68" Offset="0x1C68"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_MUSICHOUSE/Z2_MUSICHOUSE.xml
+++ b/assets/xml/scenes/Z2_MUSICHOUSE/Z2_MUSICHOUSE.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_MUSICHOUSE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_MUSICHOUSE_room_00" Offset="0x0"/>
+        <DList Name="Z2_MUSICHOUSE_room_00DL_00C770" Offset="0xC770"/>
+        <DList Name="Z2_MUSICHOUSE_room_00DL_00CA48" Offset="0xCA48"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_OKUJOU/Z2_OKUJOU.xml
+++ b/assets/xml/scenes/Z2_OKUJOU/Z2_OKUJOU.xml
@@ -4,5 +4,6 @@
     </File>
     <File Name="Z2_OKUJOU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_OKUJOU_room_00" Offset="0x0"/>
+        <DList Name="Z2_OKUJOU_room_00DL_002F50" Offset="0x2F50"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_OMOYA/Z2_OMOYA.xml
+++ b/assets/xml/scenes/Z2_OMOYA/Z2_OMOYA.xml
@@ -4,11 +4,17 @@
     </File>
     <File Name="Z2_OMOYA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_OMOYA_room_00" Offset="0x0"/>
+        <DList Name="Z2_OMOYA_room_00DL_007B88" Offset="0x7B88"/>
+        <DList Name="Z2_OMOYA_room_00DL_0095B8" Offset="0x95B8"/>
     </File>
     <File Name="Z2_OMOYA_room_01" Segment="3" Game="MM">
         <Room Name="Z2_OMOYA_room_01" Offset="0x0"/>
+        <DList Name="Z2_OMOYA_room_01DL_00CE88" Offset="0xCE88"/>
+        <DList Name="Z2_OMOYA_room_01DL_00F690" Offset="0xF690"/>
     </File>
     <File Name="Z2_OMOYA_room_02" Segment="3" Game="MM">
         <Room Name="Z2_OMOYA_room_02" Offset="0x0"/>
+        <DList Name="Z2_OMOYA_room_02DL_007278" Offset="0x7278"/>
+        <DList Name="Z2_OMOYA_room_02DL_009778" Offset="0x9778"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_OPENINGDAN/Z2_OPENINGDAN.xml
+++ b/assets/xml/scenes/Z2_OPENINGDAN/Z2_OPENINGDAN.xml
@@ -4,8 +4,12 @@
     </File>
     <File Name="Z2_OPENINGDAN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_OPENINGDAN_room_00" Offset="0x0"/>
+        <DList Name="Z2_OPENINGDAN_room_00DL_006B10" Offset="0x6B10"/>
+        <DList Name="Z2_OPENINGDAN_room_00DL_00B0C0" Offset="0xB0C0"/>
     </File>
     <File Name="Z2_OPENINGDAN_room_01" Segment="3" Game="MM">
         <Room Name="Z2_OPENINGDAN_room_01" Offset="0x0"/>
+        <DList Name="Z2_OPENINGDAN_room_01DL_005640" Offset="0x5640"/>
+        <DList Name="Z2_OPENINGDAN_room_01DL_0066A0" Offset="0x66A0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_PIRATE/Z2_PIRATE.xml
+++ b/assets/xml/scenes/Z2_PIRATE/Z2_PIRATE.xml
@@ -4,47 +4,70 @@
     </File>
     <File Name="Z2_PIRATE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_00" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_00DL_001DA8" Offset="0x1DA8"/>
     </File>
     <File Name="Z2_PIRATE_room_01" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_01" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_01DL_0039D0" Offset="0x39D0"/>
     </File>
     <File Name="Z2_PIRATE_room_02" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_02" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_02DL_004850" Offset="0x4850"/>
     </File>
     <File Name="Z2_PIRATE_room_03" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_03" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_03DL_011D80" Offset="0x11D80"/>
+        <DList Name="Z2_PIRATE_room_03DL_017948" Offset="0x17948"/>
     </File>
     <File Name="Z2_PIRATE_room_04" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_04" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_04DL_001F40" Offset="0x1F40"/>
     </File>
     <File Name="Z2_PIRATE_room_05" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_05" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_05DL_00ECE8" Offset="0xECE8"/>
     </File>
     <File Name="Z2_PIRATE_room_06" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_06" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_06DL_002420" Offset="0x2420"/>
+        <DList Name="Z2_PIRATE_room_06DL_003CE8" Offset="0x3CE8"/>
     </File>
     <File Name="Z2_PIRATE_room_07" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_07" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_07DL_00E478" Offset="0xE478"/>
     </File>
     <File Name="Z2_PIRATE_room_08" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_08" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_08DL_002308" Offset="0x2308"/>
+        <DList Name="Z2_PIRATE_room_08DL_0037C8" Offset="0x37C8"/>
     </File>
     <File Name="Z2_PIRATE_room_09" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_09" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_09DL_006770" Offset="0x6770"/>
+        <DList Name="Z2_PIRATE_room_09DL_009D08" Offset="0x9D08"/>
     </File>
     <File Name="Z2_PIRATE_room_10" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_10" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_10DL_007938" Offset="0x7938"/>
+        <DList Name="Z2_PIRATE_room_10DL_00AC40" Offset="0xAC40"/>
     </File>
     <File Name="Z2_PIRATE_room_11" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_11" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_11DL_006F30" Offset="0x6F30"/>
+        <DList Name="Z2_PIRATE_room_11DL_009C60" Offset="0x9C60"/>
     </File>
     <File Name="Z2_PIRATE_room_12" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_12" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_12DL_00A5E0" Offset="0xA5E0"/>
+        <DList Name="Z2_PIRATE_room_12DL_00D610" Offset="0xD610"/>
     </File>
     <File Name="Z2_PIRATE_room_13" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_13" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_13DL_002918" Offset="0x2918"/>
+        <DList Name="Z2_PIRATE_room_13DL_0041D8" Offset="0x41D8"/>
     </File>
     <File Name="Z2_PIRATE_room_14" Segment="3" Game="MM">
         <Room Name="Z2_PIRATE_room_14" Offset="0x0"/>
+        <DList Name="Z2_PIRATE_room_14DL_000B28" Offset="0xB28"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_POSTHOUSE/Z2_POSTHOUSE.xml
+++ b/assets/xml/scenes/Z2_POSTHOUSE/Z2_POSTHOUSE.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_POSTHOUSE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_POSTHOUSE_room_00" Offset="0x0"/>
+        <DList Name="Z2_POSTHOUSE_room_00DL_007C90" Offset="0x7C90"/>
+        <DList Name="Z2_POSTHOUSE_room_00DL_0088B8" Offset="0x88B8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_RANDOM/Z2_RANDOM.xml
+++ b/assets/xml/scenes/Z2_RANDOM/Z2_RANDOM.xml
@@ -4,20 +4,32 @@
     </File>
     <File Name="Z2_RANDOM_room_00" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_00" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_00DL_0024E8" Offset="0x24E8"/>
+        <DList Name="Z2_RANDOM_room_00DL_002B10" Offset="0x2B10"/>
     </File>
     <File Name="Z2_RANDOM_room_01" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_01" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_01DL_008C90" Offset="0x8C90"/>
+        <DList Name="Z2_RANDOM_room_01DL_009728" Offset="0x9728"/>
     </File>
     <File Name="Z2_RANDOM_room_02" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_02" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_02DL_004B50" Offset="0x4B50"/>
+        <DList Name="Z2_RANDOM_room_02DL_0071B0" Offset="0x71B0"/>
     </File>
     <File Name="Z2_RANDOM_room_03" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_03" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_03DL_004B88" Offset="0x4B88"/>
+        <DList Name="Z2_RANDOM_room_03DL_0072D0" Offset="0x72D0"/>
     </File>
     <File Name="Z2_RANDOM_room_04" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_04" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_04DL_002548" Offset="0x2548"/>
+        <DList Name="Z2_RANDOM_room_04DL_0035A8" Offset="0x35A8"/>
     </File>
     <File Name="Z2_RANDOM_room_05" Segment="3" Game="MM">
         <Room Name="Z2_RANDOM_room_05" Offset="0x0"/>
+        <DList Name="Z2_RANDOM_room_05DL_002988" Offset="0x2988"/>
+        <DList Name="Z2_RANDOM_room_05DL_003BE0" Offset="0x3BE0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_REDEAD/Z2_REDEAD.xml
+++ b/assets/xml/scenes/Z2_REDEAD/Z2_REDEAD.xml
@@ -4,44 +4,66 @@
     </File>
     <File Name="Z2_REDEAD_room_00" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_00" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_00DL_0052C0" Offset="0x52C0"/>
     </File>
     <File Name="Z2_REDEAD_room_01" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_01" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_01DL_0087C0" Offset="0x87C0"/>
+        <DList Name="Z2_REDEAD_room_01DL_008B78" Offset="0x8B78"/>
     </File>
     <File Name="Z2_REDEAD_room_02" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_02" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_02DL_007D90" Offset="0x7D90"/>
+        <DList Name="Z2_REDEAD_room_02DL_008070" Offset="0x8070"/>
     </File>
     <File Name="Z2_REDEAD_room_03" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_03" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_03DL_007920" Offset="0x7920"/>
+        <DList Name="Z2_REDEAD_room_03DL_0078F0" Offset="0x78F0"/>
     </File>
     <File Name="Z2_REDEAD_room_04" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_04" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_04DL_006A38" Offset="0x6A38"/>
+        <DList Name="Z2_REDEAD_room_04DL_007430" Offset="0x7430"/>
     </File>
     <File Name="Z2_REDEAD_room_05" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_05" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_05DL_009390" Offset="0x9390"/>
+        <DList Name="Z2_REDEAD_room_05DL_009358" Offset="0x9358"/>
     </File>
     <File Name="Z2_REDEAD_room_06" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_06" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_06DL_006E78" Offset="0x6E78"/>
     </File>
     <File Name="Z2_REDEAD_room_07" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_07" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_07DL_0060B0" Offset="0x60B0"/>
+        <DList Name="Z2_REDEAD_room_07DL_006078" Offset="0x6078"/>
     </File>
     <File Name="Z2_REDEAD_room_08" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_08" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_08DL_002638" Offset="0x2638"/>
     </File>
     <File Name="Z2_REDEAD_room_09" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_09" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_09DL_002800" Offset="0x2800"/>
     </File>
     <File Name="Z2_REDEAD_room_10" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_10" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_10DL_0029D0" Offset="0x29D0"/>
     </File>
     <File Name="Z2_REDEAD_room_11" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_11" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_11DL_0044E8" Offset="0x44E8"/>
+        <DList Name="Z2_REDEAD_room_11DL_007F50" Offset="0x7F50"/>
     </File>
     <File Name="Z2_REDEAD_room_12" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_12" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_12DL_000F60" Offset="0xF60"/>
     </File>
     <File Name="Z2_REDEAD_room_13" Segment="3" Game="MM">
         <Room Name="Z2_REDEAD_room_13" Offset="0x0"/>
+        <DList Name="Z2_REDEAD_room_13DL_001548" Offset="0x1548"/>
+        <DList Name="Z2_REDEAD_room_13DL_001878" Offset="0x1878"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_ROMANYMAE/Z2_ROMANYMAE.xml
+++ b/assets/xml/scenes/Z2_ROMANYMAE/Z2_ROMANYMAE.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_ROMANYMAE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_ROMANYMAE_room_00" Offset="0x0"/>
+        <DList Name="Z2_ROMANYMAE_room_00DL_003010" Offset="0x3010"/>
+        <DList Name="Z2_ROMANYMAE_room_00DL_003338" Offset="0x3338"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SEA/Z2_SEA.xml
+++ b/assets/xml/scenes/Z2_SEA/Z2_SEA.xml
@@ -4,50 +4,79 @@
     </File>
     <File Name="Z2_SEA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_00" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_00DL_00CB08" Offset="0xCB08"/>
+        <DList Name="Z2_SEA_room_00DL_00EA40" Offset="0xEA40"/>
     </File>
     <File Name="Z2_SEA_room_01" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_01" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_01DL_007D18" Offset="0x7D18"/>
+        <DList Name="Z2_SEA_room_01DL_008390" Offset="0x8390"/>
     </File>
     <File Name="Z2_SEA_room_02" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_02" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_02DL_001C90" Offset="0x1C90"/>
     </File>
     <File Name="Z2_SEA_room_03" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_03" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_03DL_002218" Offset="0x2218"/>
+        <DList Name="Z2_SEA_room_03DL_002430" Offset="0x2430"/>
     </File>
     <File Name="Z2_SEA_room_04" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_04" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_04DL_006CC8" Offset="0x6CC8"/>
+        <DList Name="Z2_SEA_room_04DL_008B68" Offset="0x8B68"/>
     </File>
     <File Name="Z2_SEA_room_05" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_05" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_05DL_003EB0" Offset="0x3EB0"/>
+        <DList Name="Z2_SEA_room_05DL_0052E0" Offset="0x52E0"/>
     </File>
     <File Name="Z2_SEA_room_06" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_06" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_06DL_008EE0" Offset="0x8EE0"/>
+        <DList Name="Z2_SEA_room_06DL_00BD70" Offset="0xBD70"/>
     </File>
     <File Name="Z2_SEA_room_07" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_07" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_07DL_003C78" Offset="0x3C78"/>
+        <DList Name="Z2_SEA_room_07DL_0050B0" Offset="0x50B0"/>
     </File>
     <File Name="Z2_SEA_room_08" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_08" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_08DL_008110" Offset="0x8110"/>
+        <DList Name="Z2_SEA_room_08DL_00A3E8" Offset="0xA3E8"/>
     </File>
     <File Name="Z2_SEA_room_09" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_09" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_09DL_004878" Offset="0x4878"/>
+        <DList Name="Z2_SEA_room_09DL_004AD8" Offset="0x4AD8"/>
     </File>
     <File Name="Z2_SEA_room_10" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_10" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_10DL_006A78" Offset="0x6A78"/>
+        <DList Name="Z2_SEA_room_10DL_008B00" Offset="0x8B00"/>
     </File>
     <File Name="Z2_SEA_room_11" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_11" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_11DL_007888" Offset="0x7888"/>
+        <DList Name="Z2_SEA_room_11DL_00AAD0" Offset="0xAAD0"/>
     </File>
     <File Name="Z2_SEA_room_12" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_12" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_12DL_006948" Offset="0x6948"/>
+        <DList Name="Z2_SEA_room_12DL_008548" Offset="0x8548"/>
     </File>
     <File Name="Z2_SEA_room_13" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_13" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_13DL_002D28" Offset="0x2D28"/>
+        <DList Name="Z2_SEA_room_13DL_003778" Offset="0x3778"/>
     </File>
     <File Name="Z2_SEA_room_14" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_14" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_14DL_001320" Offset="0x1320"/>
     </File>
     <File Name="Z2_SEA_room_15" Segment="3" Game="MM">
         <Room Name="Z2_SEA_room_15" Offset="0x0"/>
+        <DList Name="Z2_SEA_room_15DL_001958" Offset="0x1958"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SEA_BS/Z2_SEA_BS.xml
+++ b/assets/xml/scenes/Z2_SEA_BS/Z2_SEA_BS.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_SEA_BS_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SEA_BS_room_00" Offset="0x0"/>
+        <DList Name="Z2_SEA_BS_room_00DL_005518" Offset="0x5518"/>
+        <DList Name="Z2_SEA_BS_room_00DL_0058C0" Offset="0x58C0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SECOM/Z2_SECOM.xml
+++ b/assets/xml/scenes/Z2_SECOM/Z2_SECOM.xml
@@ -6,8 +6,11 @@
     </File>
     <File Name="Z2_SECOM_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SECOM_room_00" Offset="0x0"/>
+        <DList Name="Z2_SECOM_room_00DL_0026A0" Offset="0x26A0"/>
     </File>
     <File Name="Z2_SECOM_room_01" Segment="3" Game="MM">
         <Room Name="Z2_SECOM_room_01" Offset="0x0"/>
+        <DList Name="Z2_SECOM_room_01DL_00BCE8" Offset="0xBCE8"/>
+        <DList Name="Z2_SECOM_room_01DL_00F360" Offset="0xF360"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SINKAI/Z2_SINKAI.xml
+++ b/assets/xml/scenes/Z2_SINKAI/Z2_SINKAI.xml
@@ -5,5 +5,7 @@
     </File>
     <File Name="Z2_SINKAI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SINKAI_room_00" Offset="0x0"/>
+        <DList Name="Z2_SINKAI_room_00DL_007550" Offset="0x7550"/>
+        <DList Name="Z2_SINKAI_room_00DL_007C20" Offset="0x7C20"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SONCHONOIE/Z2_SONCHONOIE.xml
+++ b/assets/xml/scenes/Z2_SONCHONOIE/Z2_SONCHONOIE.xml
@@ -5,14 +5,30 @@
     </File>
     <File Name="Z2_SONCHONOIE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SONCHONOIE_room_00" Offset="0x0"/>
+        <DList Name="Z2_SONCHONOIE_room_00DL_000160" Offset="0x160"/>
+        <DList Name="Z2_SONCHONOIE_room_00DL_008520" Offset="0x8520"/>
+        <DList Name="Z2_SONCHONOIE_room_00DL_009560" Offset="0x9560"/>
+        <DList Name="Z2_SONCHONOIE_room_00DL_0095B8" Offset="0x95B8"/>
     </File>
     <File Name="Z2_SONCHONOIE_room_01" Segment="3" Game="MM">
         <Room Name="Z2_SONCHONOIE_room_01" Offset="0x0"/>
+        <DList Name="Z2_SONCHONOIE_room_01DL_000180" Offset="0x180"/>
+        <DList Name="Z2_SONCHONOIE_room_01DL_005510" Offset="0x5510"/>
+        <DList Name="Z2_SONCHONOIE_room_01DL_005DD0" Offset="0x5DD0"/>
+        <DList Name="Z2_SONCHONOIE_room_01DL_005F68" Offset="0x5F68"/>
     </File>
     <File Name="Z2_SONCHONOIE_room_02" Segment="3" Game="MM">
         <Room Name="Z2_SONCHONOIE_room_02" Offset="0x0"/>
+        <DList Name="Z2_SONCHONOIE_room_02DL_000160" Offset="0x160"/>
+        <DList Name="Z2_SONCHONOIE_room_02DL_0084F8" Offset="0x84F8"/>
+        <DList Name="Z2_SONCHONOIE_room_02DL_009540" Offset="0x9540"/>
+        <DList Name="Z2_SONCHONOIE_room_02DL_009940" Offset="0x9940"/>
     </File>
     <File Name="Z2_SONCHONOIE_room_03" Segment="3" Game="MM">
         <Room Name="Z2_SONCHONOIE_room_03" Offset="0x0"/>
+        <DList Name="Z2_SONCHONOIE_room_03DL_000110" Offset="0x110"/>
+        <DList Name="Z2_SONCHONOIE_room_03DL_007FC0" Offset="0x7FC0"/>
+        <DList Name="Z2_SONCHONOIE_room_03DL_0093C0" Offset="0x93C0"/>
+        <DList Name="Z2_SONCHONOIE_room_03DL_009550" Offset="0x9550"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SOUGEN/Z2_SOUGEN.xml
+++ b/assets/xml/scenes/Z2_SOUGEN/Z2_SOUGEN.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_SOUGEN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SOUGEN_room_00" Offset="0x0"/>
+        <DList Name="Z2_SOUGEN_room_00DL_0051F0" Offset="0x51F0"/>
+        <DList Name="Z2_SOUGEN_room_00DL_007A88" Offset="0x7A88"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SYATEKI_MIZU/Z2_SYATEKI_MIZU.xml
+++ b/assets/xml/scenes/Z2_SYATEKI_MIZU/Z2_SYATEKI_MIZU.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_SYATEKI_MIZU_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SYATEKI_MIZU_room_00" Offset="0x0"/>
+        <DList Name="Z2_SYATEKI_MIZU_room_00DL_005130" Offset="0x5130"/>
+        <DList Name="Z2_SYATEKI_MIZU_room_00DL_006128" Offset="0x6128"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_SYATEKI_MORI/Z2_SYATEKI_MORI.xml
+++ b/assets/xml/scenes/Z2_SYATEKI_MORI/Z2_SYATEKI_MORI.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_SYATEKI_MORI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_SYATEKI_MORI_room_00" Offset="0x0"/>
+        <DList Name="Z2_SYATEKI_MORI_room_00DL_005560" Offset="0x5560"/>
+        <DList Name="Z2_SYATEKI_MORI_room_00DL_005FE8" Offset="0x5FE8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TAKARAKUJI/Z2_TAKARAKUJI.xml
+++ b/assets/xml/scenes/Z2_TAKARAKUJI/Z2_TAKARAKUJI.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_TAKARAKUJI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TAKARAKUJI_room_00" Offset="0x0"/>
+        <DList Name="Z2_TAKARAKUJI_room_00DL_002E00" Offset="0x2E00"/>
+        <DList Name="Z2_TAKARAKUJI_room_00DL_002E38" Offset="0x2E38"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TAKARAYA/Z2_TAKARAYA.xml
+++ b/assets/xml/scenes/Z2_TAKARAYA/Z2_TAKARAYA.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_TAKARAYA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TAKARAYA_room_00" Offset="0x0"/>
+        <DList Name="Z2_TAKARAYA_room_00DL_0077B0" Offset="0x77B0"/>
+        <DList Name="Z2_TAKARAYA_room_00DL_007E68" Offset="0x7E68"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TENMON_DAI/Z2_TENMON_DAI.xml
+++ b/assets/xml/scenes/Z2_TENMON_DAI/Z2_TENMON_DAI.xml
@@ -4,8 +4,12 @@
     </File>
     <File Name="Z2_TENMON_DAI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TENMON_DAI_room_00" Offset="0x0"/>
+        <DList Name="Z2_TENMON_DAI_room_00DL_00BCF8" Offset="0xBCF8"/>
+        <DList Name="Z2_TENMON_DAI_room_00DL_011AF8" Offset="0x11AF8"/>
     </File>
     <File Name="Z2_TENMON_DAI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_TENMON_DAI_room_01" Offset="0x0"/>
+        <DList Name="Z2_TENMON_DAI_room_01DL_00C848" Offset="0xC848"/>
+        <DList Name="Z2_TENMON_DAI_room_01DL_017580" Offset="0x17580"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TORIDE/Z2_TORIDE.xml
+++ b/assets/xml/scenes/Z2_TORIDE/Z2_TORIDE.xml
@@ -5,5 +5,9 @@
     </File>
     <File Name="Z2_TORIDE_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TORIDE_room_00" Offset="0x0"/>
+        <DList Name="Z2_TORIDE_room_00DL_00C9E0" Offset="0xC9E0"/>
+        <DList Name="Z2_TORIDE_room_00DL_0007B0" Offset="0x7B0"/>
+        <DList Name="Z2_TORIDE_room_00DL_00C900" Offset="0xC900"/>
+        <DList Name="Z2_TORIDE_room_00DL_00D1D0" Offset="0xD1D0"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TOUGITES/Z2_TOUGITES.xml
+++ b/assets/xml/scenes/Z2_TOUGITES/Z2_TOUGITES.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_TOUGITES_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TOUGITES_room_00" Offset="0x0"/>
+        <DList Name="Z2_TOUGITES_room_00DL_004030" Offset="0x4030"/>
+        <DList Name="Z2_TOUGITES_room_00DL_0045A8" Offset="0x45A8"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_TOWN/Z2_TOWN.xml
+++ b/assets/xml/scenes/Z2_TOWN/Z2_TOWN.xml
@@ -4,5 +4,8 @@
     </File>
     <File Name="Z2_TOWN_room_00" Segment="3" Game="MM">
         <Room Name="Z2_TOWN_room_00" Offset="0x0"/>
+        <DList Name="Z2_TOWN_room_00DL_000960" Offset="0x960"/>
+        <DList Name="Z2_TOWN_room_00DL_012D98" Offset="0x12D98"/>
+        <DList Name="Z2_TOWN_room_00DL_017668" Offset="0x17668"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_WITCH_SHOP/Z2_WITCH_SHOP.xml
+++ b/assets/xml/scenes/Z2_WITCH_SHOP/Z2_WITCH_SHOP.xml
@@ -4,5 +4,7 @@
     </File>
     <File Name="Z2_WITCH_SHOP_room_00" Segment="3" Game="MM">
         <Room Name="Z2_WITCH_SHOP_room_00" Offset="0x0"/>
+        <DList Name="Z2_WITCH_SHOP_room_00DL_009838" Offset="0x9838"/>
+        <DList Name="Z2_WITCH_SHOP_room_00DL_009A40" Offset="0x9A40"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_YADOYA/Z2_YADOYA.xml
+++ b/assets/xml/scenes/Z2_YADOYA/Z2_YADOYA.xml
@@ -5,17 +5,37 @@
     </File>
     <File Name="Z2_YADOYA_room_00" Segment="3" Game="MM">
         <Room Name="Z2_YADOYA_room_00" Offset="0x0"/>
+        <DList Name="Z2_YADOYA_room_00DL_000490" Offset="0x490"/>
+        <DList Name="Z2_YADOYA_room_00DL_014778" Offset="0x14778"/>
+        <DList Name="Z2_YADOYA_room_00DL_016EA0" Offset="0x16EA0"/>
+        <DList Name="Z2_YADOYA_room_00DL_017478" Offset="0x17478"/>
     </File>
     <File Name="Z2_YADOYA_room_01" Segment="3" Game="MM">
         <Room Name="Z2_YADOYA_room_01" Offset="0x0"/>
+        <DList Name="Z2_YADOYA_room_01DL_000260" Offset="0x260"/>
+        <DList Name="Z2_YADOYA_room_01DL_007060" Offset="0x7060"/>
+        <DList Name="Z2_YADOYA_room_01DL_0082F0" Offset="0x82F0"/>
+        <DList Name="Z2_YADOYA_room_01DL_008318" Offset="0x8318"/>
     </File>
     <File Name="Z2_YADOYA_room_02" Segment="3" Game="MM">
         <Room Name="Z2_YADOYA_room_02" Offset="0x0"/>
+        <DList Name="Z2_YADOYA_room_02DL_000270" Offset="0x270"/>
+        <DList Name="Z2_YADOYA_room_02DL_005D78" Offset="0x5D78"/>
+        <DList Name="Z2_YADOYA_room_02DL_005EB0" Offset="0x5EB0"/>
+        <DList Name="Z2_YADOYA_room_02DL_005ED0" Offset="0x5ED0"/>
     </File>
     <File Name="Z2_YADOYA_room_03" Segment="3" Game="MM">
         <Room Name="Z2_YADOYA_room_03" Offset="0x0"/>
+        <DList Name="Z2_YADOYA_room_03DL_000230" Offset="0x230"/>
+        <DList Name="Z2_YADOYA_room_03DL_005008" Offset="0x5008"/>
+        <DList Name="Z2_YADOYA_room_03DL_005090" Offset="0x5090"/>
+        <DList Name="Z2_YADOYA_room_03DL_0050A8" Offset="0x50A8"/>
     </File>
     <File Name="Z2_YADOYA_room_04" Segment="3" Game="MM">
         <Room Name="Z2_YADOYA_room_04" Offset="0x0"/>
+        <DList Name="Z2_YADOYA_room_04DL_0002F0" Offset="0x2F0"/>
+        <DList Name="Z2_YADOYA_room_04DL_006FD0" Offset="0x6FD0"/>
+        <DList Name="Z2_YADOYA_room_04DL_007500" Offset="0x7500"/>
+        <DList Name="Z2_YADOYA_room_04DL_007518" Offset="0x7518"/>
     </File>
 </Root>

--- a/assets/xml/scenes/Z2_YOUSEI_IZUMI/Z2_YOUSEI_IZUMI.xml
+++ b/assets/xml/scenes/Z2_YOUSEI_IZUMI/Z2_YOUSEI_IZUMI.xml
@@ -4,17 +4,27 @@
     </File>
     <File Name="Z2_YOUSEI_IZUMI_room_00" Segment="3" Game="MM">
         <Room Name="Z2_YOUSEI_IZUMI_room_00" Offset="0x0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_00DL_003DF0" Offset="0x3DF0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_00DL_0050B0" Offset="0x50B0"/>
     </File>
     <File Name="Z2_YOUSEI_IZUMI_room_01" Segment="3" Game="MM">
         <Room Name="Z2_YOUSEI_IZUMI_room_01" Offset="0x0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_01DL_003D68" Offset="0x3D68"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_01DL_005030" Offset="0x5030"/>
     </File>
     <File Name="Z2_YOUSEI_IZUMI_room_02" Segment="3" Game="MM">
         <Room Name="Z2_YOUSEI_IZUMI_room_02" Offset="0x0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_02DL_003D90" Offset="0x3D90"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_02DL_005050" Offset="0x5050"/>
     </File>
     <File Name="Z2_YOUSEI_IZUMI_room_03" Segment="3" Game="MM">
         <Room Name="Z2_YOUSEI_IZUMI_room_03" Offset="0x0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_03DL_003D68" Offset="0x3D68"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_03DL_005030" Offset="0x5030"/>
     </File>
     <File Name="Z2_YOUSEI_IZUMI_room_04" Segment="3" Game="MM">
         <Room Name="Z2_YOUSEI_IZUMI_room_04" Offset="0x0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_04DL_003DA0" Offset="0x3DA0"/>
+        <DList Name="Z2_YOUSEI_IZUMI_room_04DL_005060" Offset="0x5060"/>
     </File>
 </Root>


### PR DESCRIPTION
There was a discussion in [the discord](https://discord.com/channels/688807550715560050/760279084851920977/1254849923095199785) where we discussed how for certain rooms, not all of their displaylists were being extracted. I did some more digging, and it turns out that this applies for almost every room in the game. We're missing out on hundreds of DLs because these DLs are not referenced by anything, so I don't think ZAPD is even aware of their existence.

This PR manually extracts all of these missing room DLs by updating the various scene XMLs. I wrote a script to detect unextracted DLs in the `unaccounted` sections of a room's C file, so I'm fairly sure I got all of them. These DLs actually comprise a *massive* chunk of the unaccounted bytes in our repo, so it seemed worthwhile to do.

Before:
![image](https://github.com/zeldaret/mm/assets/12245827/448558cb-6347-4a01-9d4e-937a94266a2f)

After:
![image](https://github.com/zeldaret/mm/assets/12245827/fd3a3b2f-9b8b-435a-9955-41c0267ebec0)
