### PR TITLE
Suppress address warning in en_s_goro

### DIFF
--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -895,8 +895,8 @@ void EnSGoro_UpdateCollider(EnSGoro* this, PlayState* play) {
     this->collider.dim.height = height;
 
     //! @bug: The check is useless. If &this->collider somehow was NULL the above code would have already dereferenced
-    //! it.
-    if (&this->collider != NULL) {
+    //! it. Cast to `intptr_t` to suppress address comparision to NULL warning.
+    if ((intptr_t)&this->collider != (intptr_t)NULL) {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }
 }

--- a/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
+++ b/src/overlays/actors/ovl_En_S_Goro/z_en_s_goro.c
@@ -896,7 +896,7 @@ void EnSGoro_UpdateCollider(EnSGoro* this, PlayState* play) {
 
     //! @bug: The check is useless. If &this->collider somehow was NULL the above code would have already dereferenced
     //! it. Cast to `intptr_t` to suppress address comparision to NULL warning.
-    if ((intptr_t)&this->collider != (intptr_t)NULL) {
+    if ((intptr_t)(&this->collider) != (intptr_t)NULL) {
         CollisionCheck_SetOC(play, &play->colChkCtx, &this->collider.base);
     }
 }


### PR DESCRIPTION
Uses `intptr_t` casts to suppress the address warning in `en_s_goro`. Very ugly, but seems the least of all the evils.