### PR TITLE
Add original asset names to all `object_t*` files

### DIFF
--- a/assets/xml/objects/object_tab.xml
+++ b/assets/xml/objects/object_tab.xml
@@ -1,7 +1,7 @@
 <Root>
     <!-- Assets for Barten, the Milk Bar Bartender -->
     <File Name="object_tab" Segment="6">
-        <Animation Name="gBartenIdleAnim" Offset="0x758" />
+        <Animation Name="gBartenIdleAnim" Offset="0x758" /> <!-- Original name is "tab_wait01" -->
         <DList Name="gBartenPelvisDL" Offset="0x3E10" />
         <DList Name="gBartenLeftHandDL" Offset="0x3EF0" />
         <DList Name="gBartenLeftBroomDL" Offset="0x4270" />
@@ -59,6 +59,6 @@
         <Limb Name="gBartenLeftBroomLimb" Type="Standard" EnumName="BARTEN_LIMB_LEFT_BROOM" Offset="0x7F14" />
         <Limb Name="gBartenLeftHandLimb" Type="Standard" EnumName="BARTEN_LIMB_LEFT_HAND" Offset="0x7F20" />
         <Skeleton Name="gBartenSkel" Type="Flex" LimbType="Standard" LimbNone="BARTEN_LIMB_NONE" LimbMax="BARTEN_LIMB_MAX" EnumName="BartenLimb" Offset="0x7F78" />
-        <Animation Name="gBartenIdleBarCounterAnim" Offset="0x86AC" />
+        <Animation Name="gBartenIdleBarCounterAnim" Offset="0x86AC" /> <!-- Original name is "tab_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_taisou.xml
+++ b/assets/xml/objects/object_taisou.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <!-- Animations for Gorons at the Racetrack -->
     <File Name="object_taisou" Segment="6">
-        <Animation Name="gGoronAthleticsSquatSideToSideAnim" Offset="0x16C8" />
-        <Animation Name="gGoronAthleticsShakeLimbsAnim" Offset="0x283C" />
-        <Animation Name="gGoronAthleticsCheerAnim" Offset="0x2C48" />
-        <Animation Name="gGoronAthleticsShoutAnim" Offset="0x31D8" />
-        <Animation Name="gGoronAthleticsDoubleArmSideBendAnim" Offset="0x4DD4" />
-        <Animation Name="gGoronAthleticsHamstringStretchStandingAnim" Offset="0x5790" />
-        <Animation Name="gGoronAthleticsHamstringStretchSittingAnim" Offset="0x5EE0" />
-        <Animation Name="gGoronAthleticsSingleArmSideBendAnim" Offset="0x7764" />
+        <Animation Name="gGoronAthleticsSquatSideToSideAnim" Offset="0x16C8" /> <!-- Original name is "asinobasi" -->
+        <Animation Name="gGoronAthleticsShakeLimbsAnim" Offset="0x283C" /> <!-- Original name is "buruburu" -->
+        <Animation Name="gGoronAthleticsCheerAnim" Offset="0x2C48" /> <!-- Original name is "kansyu_1" -->
+        <Animation Name="gGoronAthleticsShoutAnim" Offset="0x31D8" /> <!-- Original name is "kansyu_2" -->
+        <Animation Name="gGoronAthleticsDoubleArmSideBendAnim" Offset="0x4DD4" /> <!-- Original name is "nobi" -->
+        <Animation Name="gGoronAthleticsHamstringStretchStandingAnim" Offset="0x5790" /> <!-- Original name is "taisou1_osi" -->
+        <Animation Name="gGoronAthleticsHamstringStretchSittingAnim" Offset="0x5EE0" /> <!-- Original name is "taisou1_zenkutu" -->
+        <Animation Name="gGoronAthleticsSingleArmSideBendAnim" Offset="0x7764" /> <!-- Original name is "taisou2" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_takaraya_objects.xml
+++ b/assets/xml/objects/object_takaraya_objects.xml
@@ -4,7 +4,7 @@
         <Texture Name="gTreasureChestShopWallWhiteTLUT" OutName="treasure_chest_shop_wall_white_tlut" Format="rgba16" Width="4" Height="4" Offset="0x0" />
         <Texture Name="gTreasureChestShopWallBlackTex" OutName="treasure_chest_shop_wall_black" Format="rgba16" Width="32" Height="32" Offset="0x20" />
         <Texture Name="gTreasureChestShopWallWhiteTex" OutName="treasure_chest_shop_wall_white" Format="ci4" Width="32" Height="32" Offset="0x820" />
-        <DList Name="gTreasureChestShopWallBlackDL" Offset="0xB70" />
-        <DList Name="gTreasureChestShopWallWhiteDL" Offset="0xD60" />
+        <DList Name="gTreasureChestShopWallBlackDL" Offset="0xB70" /> <!-- Original name is "z2_takara_box_b_model" -->
+        <DList Name="gTreasureChestShopWallWhiteDL" Offset="0xD60" /> <!-- Original name is "z2_takara_box_w_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tanron4.xml
+++ b/assets/xml/objects/object_tanron4.xml
@@ -2,8 +2,8 @@
     <!-- Assets for seagulls -->
     <File Name="object_tanron4" Segment="6">
         <!-- The glide animation goes unused, instead the flap animation is frozen while it glides -->
-        <Animation Name="gSeagullGlideAnim" Offset="0x58" />
-        <Animation Name="gSeagullFlapAnim" Offset="0x168" />
+        <Animation Name="gSeagullGlideAnim" Offset="0x58" /> <!-- Original name is "kamome" -->
+        <Animation Name="gSeagullFlapAnim" Offset="0x168" /> <!-- Original name is "kamome_fly" -->
 
         <DList Name="gSeagullBodyDL" Offset="0x300" />
         <DList Name="gSeagullRightWingEndDL" Offset="0x3A0" />

--- a/assets/xml/objects/object_taru.xml
+++ b/assets/xml/objects/object_taru.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_taru" Segment="6">
-        <DList Name="gObjTaruBarrelDL" Offset="0x420" />
+        <DList Name="gObjTaruBarrelDL" Offset="0x420" /> <!-- Original name is "Y2_taru_model" -->
         <Texture Name="gObjTaruBarrelSideTex" OutName="obj_taru_barrel_side" Format="rgba16" Width="16" Height="32" Offset="0x670" />
         <Texture Name="gObjTaruBarrelTopTex" OutName="obj_taru_barrel_top" Format="rgba16" Width="32" Height="16" Offset="0xA70" />
-        <Collision Name="object_taru_Colheader_000FC8" Offset="0xFC8" />
-        <DList Name="gObjTaruBreakablePiratePanelDL" Offset="0x1140" />
+        <Collision Name="object_taru_Colheader_000FC8" Offset="0xFC8" /> <!-- Original name is "Y2_taru_bgdatainfo" -->
+        <DList Name="gObjTaruBreakablePiratePanelDL" Offset="0x1140" /> <!-- Original name is "Y2_woodpanel_model" -->
         <Texture Name="gObjTaruBreakablePiratePanelSkullTex" OutName="obj_taru_breakable_pirate_panel_skull" Format="rgba16" Width="32" Height="32" Offset="0x1230" />
         <Texture Name="gObjTaruBreakablePiratePanelWoodTex" OutName="obj_taru_breakable_pirate_panel_wood" Format="i4" Width="32" Height="32" Offset="0x1A30" />
-        <Collision Name="object_taru_Colheader_001CB0" Offset="0x1CB0" />
+        <Collision Name="object_taru_Colheader_001CB0" Offset="0x1CB0" /> <!-- Original name is "Y2_woodpanel_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tite.xml
+++ b/assets/xml/objects/object_tite.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_tite" Segment="6">
-        <Animation Name="object_tite_Anim_0001D4" Offset="0x1D4" />
-        <Animation Name="object_tite_Anim_0004F8" Offset="0x4F8" />
-        <Animation Name="object_tite_Anim_00069C" Offset="0x69C" />
-        <Animation Name="object_tite_Anim_00083C" Offset="0x83C" />
-        <Animation Name="object_tite_Anim_000A14" Offset="0xA14" />
-        <Animation Name="object_tite_Anim_000C70" Offset="0xC70" />
+        <Animation Name="object_tite_Anim_0001D4" Offset="0x1D4" /> <!-- Original name might be "tt_dmg" -->
+        <Animation Name="object_tite_Anim_0004F8" Offset="0x4F8" /> <!-- Original name is "tt_jump" -->
+        <Animation Name="object_tite_Anim_00069C" Offset="0x69C" /> <!-- Original name is "tt_jump_end" -->
+        <Animation Name="object_tite_Anim_00083C" Offset="0x83C" /> <!-- Original name is "tt_jump_start" -->
+        <Animation Name="object_tite_Anim_000A14" Offset="0xA14" /> <!-- Original name is "tt_move" -->
+        <Animation Name="object_tite_Anim_000C70" Offset="0xC70" /> <!-- Original name is "tt_smalljump"-->
         <Animation Name="object_tite_Anim_000F50" Offset="0xF50" />
-        <Animation Name="object_tite_Anim_0012E4" Offset="0x12E4" />
+        <Animation Name="object_tite_Anim_0012E4" Offset="0x12E4" /> <!-- Original name is "tt_wait" -->
         <Texture Name="object_tite_Tex_001300" OutName="tex_001300" Format="rgba16" Width="16" Height="32" Offset="0x1300" />
         <Texture Name="object_tite_Tex_001700" OutName="tex_001700" Format="rgba16" Width="16" Height="16" Offset="0x1700" />
         <Texture Name="object_tite_Tex_001900" OutName="tex_001900" Format="rgba16" Width="8" Height="16" Offset="0x1900" />

--- a/assets/xml/objects/object_tk.xml
+++ b/assets/xml/objects/object_tk.xml
@@ -1,12 +1,12 @@
 ﻿<Root>
     <File Name="object_tk" Segment="6">
-        <Animation Name="object_tk_Anim_001144" Offset="0x1144" />
-        <Animation Name="object_tk_Anim_001FA8" Offset="0x1FA8" />
-        <Animation Name="object_tk_Anim_0020C8" Offset="0x20C8" />
-        <Animation Name="object_tk_Anim_0030A4" Offset="0x30A4" />
-        <Animation Name="object_tk_Anim_003724" Offset="0x3724" />
-        <Animation Name="object_tk_Anim_003B10" Offset="0x3B10" />
-        <Animation Name="object_tk_Anim_003FB8" Offset="0x3FB8" />
+        <Animation Name="object_tk_Anim_001144" Offset="0x1144" /> <!-- Original name is "tk_ana_hori" -->
+        <Animation Name="object_tk_Anim_001FA8" Offset="0x1FA8" /> <!-- Original name is "tk_aruku" -->
+        <Animation Name="object_tk_Anim_0020C8" Offset="0x20C8" /> <!-- Original name is "tk_furueru" -->
+        <Animation Name="object_tk_Anim_0030A4" Offset="0x30A4" /> <!-- Original name is "tk_matsu" -->
+        <Animation Name="object_tk_Anim_003724" Offset="0x3724" /> <!-- Original name is "tk_odoroku" -->
+        <Animation Name="object_tk_Anim_003B10" Offset="0x3B10" /> <!-- Original name is "tk_odorokuloop" -->
+        <Animation Name="object_tk_Anim_003FB8" Offset="0x3FB8" /> <!-- Original name is "tk_run" -->
         <Texture Name="object_tk_TLUT_003FD0" OutName="tlut_003FD0" Format="rgba16" Width="16" Height="16" Offset="0x3FD0" />
         <Texture Name="object_tk_Tex_0041D0" OutName="tex_0041D0" Format="ci8" Width="8" Height="8" Offset="0x41D0" />
         <Texture Name="object_tk_Tex_004210" OutName="tex_004210" Format="ci8" Width="8" Height="8" Offset="0x4210" />
@@ -17,7 +17,8 @@
         <Texture Name="object_tk_Tex_005390" OutName="tex_005390" Format="rgba16" Width="32" Height="32" Offset="0x5390" />
         <Texture Name="object_tk_Tex_005B90" OutName="tex_005B90" Format="ci8" Width="16" Height="16" Offset="0x5B90" />
         <Texture Name="object_tk_Tex_005C90" OutName="tex_005C90" Format="ci8" Width="16" Height="16" Offset="0x5C90" />
-        <!-- <Blob Name="object_tk_Blob_005D90" Size="0x180" Offset="0x5D90" /> -->
+        <Texture Name="object_tk_Tex_005D90" OutName="tex_005D90" Format="ci8" Width="16" Height="16" Offset="0x5D90" TlutOffset="0x3FD0" />
+        <Texture Name="object_tk_Tex_005E90" OutName="tex_005E90" Format="ci8" Width="8" Height="16" Offset="0x5E90" TlutOffset="0x3FD0" />
         <Texture Name="object_tk_Tex_005F10" OutName="tex_005F10" Format="ci8" Width="16" Height="16" Offset="0x5F10" />
         <DList Name="object_tk_DL_008870" Offset="0x8870" />
         <DList Name="object_tk_DL_0089B0" Offset="0x89B0" />
@@ -34,7 +35,7 @@
         <DList Name="object_tk_DL_009F88" Offset="0x9F88" />
         <DList Name="object_tk_DL_00A068" Offset="0xA068" />
         <DList Name="object_tk_DL_00A220" Offset="0xA220" />
-        <!-- <Blob Name="object_tk_Blob_00A300" Size="0x50" Offset="0xA300" /> -->
+        <Texture Name="object_tk_TLUT_00A300" OutName="tlut_00A300" Format="rgba16" Width="40" Height="1" Offset="0xA300" />
         <Texture Name="object_tk_Tex_00A350" OutName="tex_00A350" Format="ci8" Width="16" Height="16" Offset="0xA350" />
         <Texture Name="object_tk_Tex_00A450" OutName="tex_00A450" Format="ci8" Width="8" Height="16" Offset="0xA450" />
         <Texture Name="object_tk_Tex_00A4D0" OutName="tex_00A4D0" Format="i8" Width="8" Height="8" Offset="0xA4D0" />

--- a/assets/xml/objects/object_tokei_step.xml
+++ b/assets/xml/objects/object_tokei_step.xml
@@ -2,8 +2,8 @@
     <!-- Assets for the Clock Tower steps -->
     <File Name="object_tokei_step" Segment="6">
         <DList Name="gClocktowerPanelEmptyDL" Offset="0x80" />
-        <DList Name="gClocktowerPanelDL" Offset="0x88" />
+        <DList Name="gClocktowerPanelDL" Offset="0x88" /> <!-- Original name is "z2_towerkabe_model" -->
         <Texture Name="gClocktowerPanelTex" OutName="clocktower_panel" Format="rgba16" Width="32" Height="32" Offset="0x120" />
-        <Collision Name="gClocktowerPanelCol" Offset="0x968" />
+        <Collision Name="gClocktowerPanelCol" Offset="0x968" /> <!-- Original name is "z2_towerwall_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tokei_tobira.xml
+++ b/assets/xml/objects/object_tokei_tobira.xml
@@ -2,11 +2,11 @@
     <File Name="object_tokei_tobira" Segment="6">
         <Texture Name="object_tokei_tobira_Tex_000000" OutName="tex_000000" Format="rgba16" Width="32" Height="32" Offset="0x0" />
         <Texture Name="object_tokei_tobira_Tex_000800" OutName="tex_000800" Format="i4" Width="64" Height="64" Offset="0x800" />
-        <DList Name="object_tokei_tobira_DL_001100" Offset="0x1100" />
-        <DList Name="object_tokei_tobira_DL_001108" Offset="0x1108" />
-        <Collision Name="object_tokei_tobira_Colheader_0012B0" Offset="0x12B0" />
-        <DList Name="object_tokei_tobira_DL_0013E0" Offset="0x13E0" />
-        <DList Name="object_tokei_tobira_DL_0013E8" Offset="0x13E8" />
-        <Collision Name="object_tokei_tobira_Colheader_001590" Offset="0x1590" />
+        <DList Name="object_tokei_tobira_DL_001100" Offset="0x1100" /> <!-- Original name is "z2_tobira_h_modelT" -->
+        <DList Name="object_tokei_tobira_DL_001108" Offset="0x1108" /> <!-- Original name is "z2_tobira_h_model" -->
+        <Collision Name="object_tokei_tobira_Colheader_0012B0" Offset="0x12B0" /> <!-- Original name is "z2_tobira_h_bgdatainfo" -->
+        <DList Name="object_tokei_tobira_DL_0013E0" Offset="0x13E0" /> <!-- Original name is "z2_tobira_m_modelT" -->
+        <DList Name="object_tokei_tobira_DL_0013E8" Offset="0x13E8" /> <!-- Original name is "z2_tobira_m_model" -->
+        <Collision Name="object_tokei_tobira_Colheader_001590" Offset="0x1590" /> <!-- Original name is "z2_tobira_m_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tokei_turret.xml
+++ b/assets/xml/objects/object_tokei_turret.xml
@@ -8,10 +8,10 @@
         <Texture Name="gClockTownFlagsTex" OutName="clock_town_flags" Format="rgba16" Width="128" Height="16" Offset="0x1420" />
         <DList Name="gClockTownTurretEmpty0DL" Offset="0x2500" />
         <DList Name="gClockTownTurretPlatformBaseDL" Offset="0x2508" />
-        <Collision Name="gClockTownTurretBaseCol" Offset="0x26A0" />
+        <Collision Name="gClockTownTurretBaseCol" Offset="0x26A0" /> <!-- Original name is "z2_yagura01_bgdatainfo" -->
         <DList Name="gClockTownTurretEmpty1DL" Offset="0x2A80" />
         <DList Name="gClockTownTurretPlatformTopDL" Offset="0x2A88" />
-        <Collision Name="gClockTownTurretPlatformCol" Offset="0x2D80" />
+        <Collision Name="gClockTownTurretPlatformCol" Offset="0x2D80" /> <!-- Original name is "z2_yagura02_bgdatainfo" -->
         <DList Name="gClockTownTurretEmpty2DL" Offset="0x3030" />
         <DList Name="gClockTownFlagsDL" Offset="0x3038" />
     </File>

--- a/assets/xml/objects/object_toryo.xml
+++ b/assets/xml/objects/object_toryo.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_toryo" Segment="6">
-        <Animation Name="object_toryo_Anim_000E50" Offset="0xE50" />
+        <Animation Name="object_toryo_Anim_000E50" Offset="0xE50" /> <!-- Original name is "dk1_matsu" -->
         <Texture Name="object_toryo_TLUT_000E60" OutName="tlut_000E60" Format="rgba16" Width="16" Height="16" Offset="0xE60" />
         <Texture Name="object_toryo_Tex_001060" OutName="tex_001060" Format="ci8" Width="16" Height="16" Offset="0x1060" />
         <Texture Name="object_toryo_Tex_001160" OutName="tex_001160" Format="ci8" Width="8" Height="4" Offset="0x1160" />

--- a/assets/xml/objects/object_trap.xml
+++ b/assets/xml/objects/object_trap.xml
@@ -3,8 +3,8 @@
         <Texture Name="object_trap_Tex_000000" OutName="tex_000000" Format="i8" Width="32" Height="32" Offset="0x0" />
         <Texture Name="object_trap_Tex_000400" OutName="tex_000400" Format="i8" Width="32" Height="32" Offset="0x400" />
         <Texture Name="object_trap_Tex_000800" OutName="tex_000800" Format="i8" Width="32" Height="32" Offset="0x800" />
-        <DList Name="object_trap_DL_001400" Offset="0x1400" />
-        <DList Name="object_trap_DL_001630" Offset="0x1630" />
+        <DList Name="object_trap_DL_001400" Offset="0x1400" /> <!-- Original name is "trap_model" -->
+        <DList Name="object_trap_DL_001630" Offset="0x1630" /> <!-- Original name is "trap2_center_model" -->
         <DList Name="object_trap_DL_001710" Offset="0x1710" />
         <Texture Name="object_trap_Tex_001BD8" OutName="tex_001BD8" Format="rgba16" Width="32" Height="32" Offset="0x1BD8" />
     </File>

--- a/assets/xml/objects/object_tree.xml
+++ b/assets/xml/objects/object_tree.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_tree" Segment="6">
-        <DList Name="gTreeBodyDL" Offset="0x680" />
-        <DList Name="gTreeLeavesDL" Offset="0x7C8" />
+        <DList Name="gTreeBodyDL" Offset="0x680" /> <!-- Original name is "tree_miki_model" -->
+        <DList Name="gTreeLeavesDL" Offset="0x7C8" /> <!-- Original name is "tree_haT_model" -->
         <Texture Name="gTreeBodyTex" OutName="tree_body" Format="rgba16" Width="32" Height="32" Offset="0x8B8" />
         <Texture Name="gTreeLeavesTex" OutName="tree_leaves" Format="rgba16" Width="32" Height="32" Offset="0x10B8" />
-        <Collision Name="gTreeTopCol" Offset="0x1B2C" />
+        <Collision Name="gTreeTopCol" Offset="0x1B2C" /> <!-- Original name is "z2_wood_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tro.xml
+++ b/assets/xml/objects/object_tro.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_tro" Segment="6">
-        <Animation Name="gKoumeKioskHeadMovingAnim" Offset="0xA0" />
+        <Animation Name="gKoumeKioskHeadMovingAnim" Offset="0xA0" /> <!-- Original name is "trO_wait" -->
         <DList Name="gKoumeKioskDL" Offset="0x6B0" />
         <Texture Name="gKoumeKioskNoseTLUT" OutName="koume_kiosk_nose_tlut" Format="rgba16" Width="16" Height="16" Offset="0xAE0" />
         <Texture Name="gKoumeKioskNostrilsTLUT" OutName="koume_kiosk_nostrils_tlut" Format="rgba16" Width="16" Height="16" Offset="0xCE0" />

--- a/assets/xml/objects/object_trt.xml
+++ b/assets/xml/objects/object_trt.xml
@@ -2,12 +2,12 @@
     <!-- Assets for Kotake -->
     <File Name="object_trt" Segment="6">
         <!-- Animations -->
-        <Animation Name="gKotakeHoverAnim" Offset="0xA44" />
-        <Animation Name="gKotakeFlyLookAroundAnim" Offset="0x1EF4" />
-        <Animation Name="gKotakeFlyDownAnim" Offset="0x2224" />
-        <Animation Name="gKotakeFlyAnim" Offset="0x2CB0" />
-        <Animation Name="gKotakeWakeUpAnim" Offset="0x30EC" />
-        <Animation Name="gKotakeSurprisedAnim" Offset="0x3D78" />
+        <Animation Name="gKotakeHoverAnim" Offset="0xA44" /> <!-- Original name is "kt_fly_fuwafuwa" -->
+        <Animation Name="gKotakeFlyLookAroundAnim" Offset="0x1EF4" /> <!-- Original name is "kt_fly_kyoro" -->
+        <Animation Name="gKotakeFlyDownAnim" Offset="0x2224" /> <!-- Original name is "kt_kouka_loop" -->
+        <Animation Name="gKotakeFlyAnim" Offset="0x2CB0" /> <!-- Original name is "kt_tati_loop" -->
+        <Animation Name="gKotakeWakeUpAnim" Offset="0x30EC" /> <!-- Original name is "trT_kizuku" -->
+        <Animation Name="gKotakeSurprisedAnim" Offset="0x3D78" /> <!-- Original name is "trT_odoroku" -->
 
         <!-- DLists -->
         <DList Name="gKotakePelvisDL" Offset="0x6380" />
@@ -69,10 +69,10 @@
         <TextureAnimation Name="gKotakeEyesTexAnim" Offset="0xC988" />
 
         <!-- Animations -->
-        <Animation Name="gKotakeHandsOnCounterAnim" Offset="0xD52C" />
-        <Animation Name="gKotakeIdleAnim" Offset="0xDE68" />
-        <Animation Name="gKotakeHalfAwakeAnim" Offset="0xEE98" />
-        <Animation Name="gKotakeSleepingAnim" Offset="0xFD34" />
+        <Animation Name="gKotakeHandsOnCounterAnim" Offset="0xD52C" /> <!-- Original name is "trT_talk" -->
+        <Animation Name="gKotakeIdleAnim" Offset="0xDE68" /> <!-- Original name is "trT_wait" -->
+        <Animation Name="gKotakeHalfAwakeAnim" Offset="0xEE98" /> <!-- Original name is "trT_wait01" -->
+        <Animation Name="gKotakeSleepingAnim" Offset="0xFD34" /> <!-- Original name is "trT_wait02" -->
 
         <!-- Skeleton -->
         <Limb Name="gKotakePelvisLimb" Type="Standard" EnumName="KOTAKE_LIMB_PELVIS" Offset="0xFD50" />

--- a/assets/xml/objects/object_tru.xml
+++ b/assets/xml/objects/object_tru.xml
@@ -1,22 +1,22 @@
 ﻿<Root>
     <!-- Assets for Koume -->
     <File Name="object_tru" Segment="6">
-        <DList Name="gKoumeTargetDL" Offset="0x390" />
-        <DList Name="gKoumeChainDL" Offset="0x4C8" />
+        <DList Name="gKoumeTargetDL" Offset="0x390" /> <!-- Original name is "tru_mato1_model" -->
+        <DList Name="gKoumeChainDL" Offset="0x4C8" /> <!-- Original name is "tru_kusari1_model" -->
         <Texture Name="gKoumeChainTex" OutName="koume_chain" Format="rgba16" Width="16" Height="32" Offset="0x560" />
         <Texture Name="gKoumeTargetSideTex" OutName="koume_target_side" Format="rgba16" Width="32" Height="32" Offset="0x960" />
         <Texture Name="gKoumeTargetFaceTex" OutName="koume_target_face" Format="rgba16" Width="32" Height="32" Offset="0x1160" />
 
-        <DList Name="gKoumeBottleDL" Offset="0x1F90" />
-        <DList Name="gKoumePotionDL" Offset="0x20C8" />
+        <DList Name="gKoumeBottleDL" Offset="0x1F90" /> <!-- Original name is "trU_bottle_modelT" -->
+        <DList Name="gKoumePotionDL" Offset="0x20C8" /> <!-- Original name is "trU_bottle_aft_modelT" -->
         <DList Name="gKoumeEmptyDL" Offset="0x2160" />
         <Texture Name="gKoumeBottleTex" OutName="koume_bottle" Format="i4" Width="16" Height="16" Offset="0x2168" />
 
-        <Animation Name="gKoumeFlyAnim" Offset="0x2BD8" />
-        <Animation Name="gKoumeTakeOffAnim" Offset="0x3698" />
-        <Animation Name="gKoumeHoverAnim" Offset="0x446C" />
-        <Animation Name="gKoumeDrinkAnim" Offset="0x7FA0" />
-        <Animation Name="gKoumeInjuredRaiseHeadAnim" Offset="0x9348" />
+        <Animation Name="gKoumeFlyAnim" Offset="0x2BD8" /> <!-- Original name is "trU_fly" -->
+        <Animation Name="gKoumeTakeOffAnim" Offset="0x3698" /> <!-- Original name is "trU_flyaway" -->
+        <Animation Name="gKoumeHoverAnim" Offset="0x446C" /> <!-- Original name is "trU_flywait" -->
+        <Animation Name="gKoumeDrinkAnim" Offset="0x7FA0" /> <!-- Original name is "trU_nomu" -->
+        <Animation Name="gKoumeInjuredRaiseHeadAnim" Offset="0x9348" /> <!-- Original name is "trU_okiru" -->
 
         <DList Name="gKoumePelvisDL" Offset="0xB730" />
         <DList Name="gKoumeTorsoDL" Offset="0xB940" />
@@ -45,14 +45,14 @@
         <DList Name="gKoumeLeftShinDL" Offset="0xDE18" />
         <DList Name="gKoumeLeftFootDL" Offset="0xDEC8" />
 
-        <Animation Name="gKoumeInjuredTalkAnim" Offset="0xEEDC" />
-        <Animation Name="gKoumeInjuredLyingDownAnim" Offset="0xF9A0" />
-        <Animation Name="gKoumeTryGetUpAnim" Offset="0x108AC" />
-        <Animation Name="gKoumeHealedAnim" Offset="0x11F88" />
-        <Animation Name="gKoumeTakeAnim" Offset="0x14728" />
-        <Animation Name="gKoumeIdleAnim" Offset="0x15068" />
-        <Animation Name="gKoumeInjuredHeadUpAnim" Offset="0x15CA0" />
-        <Animation Name="gKoumeFinishedDrinkingAnim" Offset="0x16B4C" />
+        <Animation Name="gKoumeInjuredTalkAnim" Offset="0xEEDC" /> <!-- Original name is "trU_talk" -->
+        <Animation Name="gKoumeInjuredLyingDownAnim" Offset="0xF9A0" /> <!-- Original name is "trU_taore01" -->
+        <Animation Name="gKoumeTryGetUpAnim" Offset="0x108AC" /> <!-- Original name is "trU_taore02" -->
+        <Animation Name="gKoumeHealedAnim" Offset="0x11F88" /> <!-- Original name is "trU_tatu" -->
+        <Animation Name="gKoumeTakeAnim" Offset="0x14728" /> <!-- Original name is "trU_ubau" -->
+        <Animation Name="gKoumeIdleAnim" Offset="0x15068" /> <!-- Original name is "trU_wait" -->
+        <Animation Name="gKoumeInjuredHeadUpAnim" Offset="0x15CA0" /> <!-- Original name is "trU_wait01" -->
+        <Animation Name="gKoumeFinishedDrinkingAnim" Offset="0x16B4C" /> <!-- Original name is "trU_wait02" -->
 
         <Texture Name="gKoumeSkinTLUT" OutName="koume_skin_tlut" Format="rgba16" Width="16" Height="16" Offset="0x16B60" />
         <Texture Name="gKoumeMouthTLUT" OutName="koume_mouth_tlut" Format="rgba16" Width="16" Height="16" Offset="0x16D60" />
@@ -82,7 +82,7 @@
         <Texture Name="gKoumeJewelTex" OutName="koume_jewel" Format="rgba16" Width="8" Height="8" Offset="0x1A7A0" />
 
         <DList Name="gKoumeDustMaterialDL" Offset="0x1A820" />
-        <DList Name="gKoumeDustModelDL" Offset="0x1A830" />
+        <DList Name="gKoumeDustModelDL" Offset="0x1A830" /> <!-- Original name is "tru_flash_model" -->
 
         <Limb Name="gKoumePelvisLimb" Type="Standard" EnumName="KOUME_LIMB_PELVIS" Offset="0x1A8C0" />
         <Limb Name="gKoumeLeftThighLimb" Type="Standard" EnumName="KOUME_LIMB_LEFT_THIGH" Offset="0x1A8CC" />
@@ -112,6 +112,6 @@
         <Limb Name="gKoumeLeftBraidEndLimb" Type="Standard" EnumName="KOUME_LIMB_LEFT_BRAID_END" Offset="0x1A9EC" />
         <Skeleton Name="gKoumeSkel" Type="Flex" LimbType="Standard" LimbNone="KOUME_LIMB_NONE" LimbMax="KOUME_LIMB_MAX" EnumName="KoumeLimb" Offset="0x1AA60" />
 
-        <Animation Name="gKoumeShakeAnim" Offset="0x1B5C4" />
+        <Animation Name="gKoumeShakeAnim" Offset="0x1B5C4" /> <!-- Original name is "trU_yorokobu" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tsn.xml
+++ b/assets/xml/objects/object_tsn.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_tsn" Segment="6">
-        <Animation Name="object_tsn_Anim_000964" Offset="0x964" />
-        <Animation Name="object_tsn_Anim_001198" Offset="0x1198" />
+        <Animation Name="object_tsn_Anim_000964" Offset="0x964" /> <!-- Original name is "tsn_talk02" -->
+        <Animation Name="object_tsn_Anim_001198" Offset="0x1198" /> <!-- Original name is "tsn_talk03" -->
         <DList Name="object_tsn_DL_0043A0" Offset="0x43A0" />
         <DList Name="object_tsn_DL_0044F0" Offset="0x44F0" />
         <DList Name="object_tsn_DL_0047C0" Offset="0x47C0" />
@@ -48,6 +48,6 @@
         <Limb Name="object_tsn_Standardlimb_008A60" Type="Standard" EnumName="OBJECT_TSN_LIMB_0F" Offset="0x8A60" />
         <Limb Name="object_tsn_Standardlimb_008A6C" Type="Standard" EnumName="OBJECT_TSN_LIMB_10" Offset="0x8A6C" />
         <Skeleton Name="object_tsn_Skel_008AB8" Type="Flex" LimbType="Standard" LimbNone="OBJECT_TSN_LIMB_NONE" LimbMax="OBJECT_TSN_LIMB_MAX" EnumName="ObjectTsnLimb" Offset="0x8AB8" />
-        <Animation Name="object_tsn_Anim_0092FC" Offset="0x92FC" />
+        <Animation Name="object_tsn_Anim_0092FC" Offset="0x92FC" /> <!-- Original name is "tsn_waitnew" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_tsubo.xml
+++ b/assets/xml/objects/object_tsubo.xml
@@ -4,7 +4,7 @@
         <Texture Name="gPotWallTex" OutName="pot_wall" Format="rgba16" Width="32" Height="64" Offset="0x0" />
         <Texture Name="gPotRimTex" OutName="pot_rim" Format="rgba16" Width="16" Height="16" Offset="0x1000" />
         <Texture Name="gPotShardTex" OutName="pot_shard" Format="rgba16" Width="16" Height="16" Offset="0x1200" />
-        <DList Name="gPotDL" Offset="0x17C0" />
-        <DList Name="gPotShardDL" Offset="0x1960" />
+        <DList Name="gPotDL" Offset="0x17C0" /> <!-- Original name is "tubo2_model" -->
+        <DList Name="gPotShardDL" Offset="0x1960" /> <!-- Original name is "tubo2_hahen_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_twig.xml
+++ b/assets/xml/objects/object_twig.xml
@@ -4,10 +4,10 @@
         <Texture Name="object_twig_Tex_000800" OutName="tex_000800" Format="rgba16" Width="32" Height="32" Offset="0x800" />
         <Texture Name="object_twig_Tex_001000" OutName="tex_001000" Format="rgba16" Width="16" Height="32" Offset="0x1000" />
         <DList Name="object_twig_DL_0014C0" Offset="0x14C0" />
-        <DList Name="object_twig_DL_0014C8" Offset="0x14C8" />
-        <Collision Name="object_twig_Colheader_0016C0" Offset="0x16C0" />
+        <DList Name="object_twig_DL_0014C8" Offset="0x14C8" /> <!-- Original name is "z2_35_saku01_model" -->
+        <Collision Name="object_twig_Colheader_0016C0" Offset="0x16C0" /> <!-- Original name is "z2_35_saku01_bgdatainfo" -->
         <DList Name="object_twig_DL_001C30" Offset="0x1C30" />
-        <DList Name="object_twig_DL_001C38" Offset="0x1C38" />
-        <Collision Name="object_twig_Colheader_0020A0" Offset="0x20A0" />
+        <DList Name="object_twig_DL_001C38" Offset="0x1C38" /> <!-- Original name is "z2_35_wa01_model" -->
+        <Collision Name="object_twig_Colheader_0020A0" Offset="0x20A0" /> <!-- Original name is "z2_35_wa01_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Tanron1.xml
+++ b/assets/xml/overlays/ovl_En_Tanron1.xml
@@ -2,6 +2,6 @@
     <File Name="ovl_En_Tanron1" BaseAddress="0x80BB4E00" RangeStart="0x1028" RangeEnd="0x1918">
         <Texture Name="ovl_En_Tanron1_DL_001428" OutName="tex_001428" Format="rgba16" Width="16" Height="32" Offset="0x1428"/>
         <DList Name="ovl_En_Tanron1_DL_001888" Offset="0x1888"/>
-        <DList Name="ovl_En_Tanron1_DL_001900" Offset="0x1900"/>
+        <DList Name="ovl_En_Tanron1_DL_001900" Offset="0x1900"/> <!-- Original name might be "tanron1_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Obj_Jgame_Light.xml
+++ b/assets/xml/overlays/ovl_Obj_Jgame_Light.xml
@@ -5,7 +5,7 @@
         <!-- @bug: Based on the DList, this should be an invalid i16 -->
         <Texture Name="sObjJgameLightCorrectTex" OutName="obj_jgamelight_correct" Format="ia16" Width="16" Height="16" Offset="0xAFC"/>
 
-        <DList Name="gObjJgameLightIncorrectDL" Offset="0xD40"/>
-        <DList Name="gObjJgameLightCorrectDL" Offset="0xDC0"/>
+        <DList Name="gObjJgameLightIncorrectDL" Offset="0xD40"/> <!-- Original name is "jgame_maru_model" -->
+        <DList Name="gObjJgameLightCorrectDL" Offset="0xDC0"/> <!-- Original name is "jgame_peke_model" -->
     </File>
 </Root>


### PR DESCRIPTION
Some notes:
- For `object_tite`, there are 8 animation in MM64, but there are only 7 animations in MM3D. Two of the eight animations in MM64 are unused; of the unused ones, I thought the first one is probably the `tt_dmg` animation; it matches the MM3D motion a little better, and it makes sense with the way they typically alphabetize animations
- For `object_tk`, I figured I'd extract the blobs while I was in there. One of the blobs was *already* being extracted automatically by ZAPD; it was being extracted as a 40x1 TLUT, which I just preserved, though I didn't know if there was a more "correct" way of extracting it. The other blob looks like two textures; I gave them dimensions that make the textures make sense, though both textures are unused, so it's hard to figure out their purpose.
- MM3D removed all the various tanron objects that are just full of bee assets, so lots of the `object_tanron*` objects don't have names here.