### PR TITLE
Extract sFaultDrawerFont as blob

### DIFF
--- a/assets/xml/boot/fault_drawer.xml
+++ b/assets/xml/boot/fault_drawer.xml
@@ -1,0 +1,6 @@
+<Root>
+    <File Name="boot" OutName="fault_drawer_font" BaseAddress="0x80080060" RangeStart="0x18BF0" RangeEnd="0x18FF0" >
+        <!-- The real version is const and found in fault_drawer.c, though shares the same name -->
+        <Blob Name="sFaultDrawerFont" Size="0x400" Offset="0x18BF0"/>
+    </File>
+</Root>

--- a/src/boot/fault_drawer.c
+++ b/src/boot/fault_drawer.c
@@ -34,7 +34,10 @@ typedef struct {
     /* 0x38 */ FaultDrawerCallback inputCallback;
 } FaultDrawer; // size = 0x3C
 
-extern const u32 sFaultDrawerFont[];
+//! TODO: Extract the font data properly so we don't have to cast in sFaultDrawerDefault below
+const u8 sFaultDrawerFont[] = {
+#include "assets/boot/fault_drawer/sFaultDrawerFont.bin.inc.c"
+};
 
 FaultDrawer sFaultDrawer;
 
@@ -55,7 +58,7 @@ FaultDrawer sFaultDrawerDefault = {
     GPACK_RGBA5551(0, 0, 0, 0),                // backColor
     FAULT_DRAWER_CURSOR_X,                     // cursorX
     FAULT_DRAWER_CURSOR_Y,                     // cursorY
-    sFaultDrawerFont,                          // fontData
+    (const u32*)sFaultDrawerFont,              // fontData
     8,                                         // charW
     8,                                         // charH
     0,                                         // charWPad
@@ -77,9 +80,6 @@ FaultDrawer sFaultDrawerDefault = {
     false, // osSyncPrintfEnabled
     NULL,  // inputCallback
 };
-
-//! TODO: Needs to be extracted
-#pragma GLOBAL_ASM("asm/non_matchings/boot/fault_drawer/sFaultDrawerFont.s")
 
 void FaultDrawer_SetOsSyncPrintfEnabled(u32 enabled) {
     sFaultDrawerInstance->osSyncPrintfEnabled = enabled;


### PR DESCRIPTION
This extracts sFaultDrawerFont as a blob using ZAPD (at least for a temporary stop gap for now). This allows removing the `GLOBAL_ASM` `#pragma` from `fault_drawer.c`.