### PR TITLE
Update website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [jenkins]: https://jenkins.deco.mp/job/MM/job/main
 [jenkins-badge]: https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fjenkins.deco.mp%2Fjob%2FMM%2Fjob%2Fmain
 
-[progress]: https://zelda64.dev/games/mm
-[progress-badge]: https://img.shields.io/endpoint?url=https://zelda64.dev/assets/csv/progress-mm-shield.json
+[progress]: https://zelda.deco.mp/games/mm
+[progress-badge]: https://img.shields.io/endpoint?url=https://zelda.deco.mp/assets/csv/progress-mm-shield.json
 
 [contributors]: https://github.com/zeldaret/mm/graphs/contributors
 [contributors-badge]: https://img.shields.io/github/contributors/zeldaret/mm
 
-[discord]: https://discord.zelda64.dev
+[discord]: https://discord.zelda.deco.mp
 [discord-badge]: https://img.shields.io/discord/688807550715560050?color=%237289DA&logo=discord&logoColor=%23FFFFFF
 
 ```diff
@@ -23,7 +23,7 @@ please be aware that the codebase could drastically change at any time. Also not
 parts of the ROM may not be 'shiftable' yet, so modifying them could currently be difficult.
 ```
 
-This is a WIP **decompilation** of ***The Legend of Zelda: Majora's Mask***. The purpose of the project is to recreate a source code base for the game from scratch, using information found inside the game along with static and/or dynamic analysis. **It is not, and will not, produce a PC port.** For frequently asked questions, you can visit [our website](https://zelda64.dev/games/mm), and for more information you can get in touch with the team on our [Discord server](https://discord.zelda64.dev).
+This is a WIP **decompilation** of ***The Legend of Zelda: Majora's Mask***. The purpose of the project is to recreate a source code base for the game from scratch, using information found inside the game along with static and/or dynamic analysis. **It is not, and will not, produce a PC port.** For frequently asked questions, you can visit [our website](https://zelda.deco.mp/games/mm), and for more information you can get in touch with the team on our [Discord server](https://discord.zelda.deco.mp).
 
 The only version currently supported is N64 US, but we intend to eventually support every retail version of the original game (i.e. not versions of MM3D, which is a totally different game).
 
@@ -36,8 +36,8 @@ It currently builds the following ROM and compressed ROM:
 
 Please refer to the following for more information:
 
-- [Website](https://zelda64.dev/)
-- [Discord](https://discord.zelda64.dev/)
+- [Website](https://zelda.deco.mp/)
+- [Discord](https://discord.zelda.deco.mp/)
 - [How to Contribute](docs/CONTRIBUTING.md)
 
 ## Installation
@@ -162,6 +162,6 @@ Some work also doesn't require much knowledge to get started.
 
 Please note that is is our strict policy that *Anyone who wishes to contribute to the OOT or MM projects **must not have accessed leaked source code at any point in time** for Nintendo 64 SDK, iQue player SDK, libultra, Ocarina of Time, Majora's Mask, Animal Crossing/Animal Forest, or any other game that shares the same game engine or significant portions of code to a Zelda 64 game or any other console similar to the Nintendo 64.*
 
-Most discussions happen on our [Discord Server](https://discord.zelda64.dev), where you are welcome to ask if you need help getting started, or if you have any questions regarding this project or ZeldaRET's other decompilation projects.
+Most discussions happen on our [Discord Server](https://discord.zelda.deco.mp), where you are welcome to ask if you need help getting started, or if you have any questions regarding this project or ZeldaRET's other decompilation projects.
 
 For more information on getting started, see our [Contributing Guide](docs/CONTRIBUTING.md), [Style Guide](docs/STYLE.md) and our [Code Review Guidelines](docs/REVIEWING.md) to see what code quality guidelines we follow.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ All contributions are welcome. This is a group effort, and even small contributi
 This document is meant to be a set of tips and guidelines for contributing to the project.
 For general information about the project, see [our readme](https://github.com/zeldaret/mm/blob/main/README.md).
 
-Most discussions happen on our [Discord Server](https://discord.zelda64.dev) where you are welcome to ask if you need help getting started, or if you have any questions regarding this project and other decompilation projects.
+Most discussions happen on our [Discord Server](https://discord.zelda.deco.mp) where you are welcome to ask if you need help getting started, or if you have any questions regarding this project and other decompilation projects.
 
 ## Useful Links
 
@@ -14,7 +14,7 @@ Most discussions happen on our [Discord Server](https://discord.zelda64.dev) whe
 - [Style Guide](STYLE.md) - Description of the project style that we ask contributors to adhere to.
 - [Code Review Guidelines](REVIEWING.md) - These are the guidelines that reviewers will be using when reviewing your code. Good to be familiar with these before submitting your code.
 
-- [Zelda 64 Reverse Engineering Website](https://zelda64.dev/games/mm) - Our homepage, with FAQ and progress graph :chart_with_upwards_trend:.
+- [Zelda 64 Reverse Engineering Website](https://zelda.deco.mp/games/mm) - Our homepage, with FAQ and progress graph :chart_with_upwards_trend:.
 - [MM decomp tutorial](tutorial/contents.md) Detailed tutorial for learning in general how decomp works and how to decompile a small, simple file.
 - [Introduction to OOT decomp](https://github.com/zeldaret/oot/blob/main/docs/tutorial/contents.md) - The tutorial the MM one was based on. For OOT, but largely applicable to MM as well. Covers slightly different topics, including how to get your data OK with `vbindiff`.
 - The `#resources` channel on the Discord contains many more links on specific details of decompiling IDO MIPS code.
@@ -45,7 +45,7 @@ You should be able to build a matching ROM before you start making any changes.
 Usually, the best place to get started is to decompile an actor overlay.
 An *actor* is any thing in the game that moves or performs actions or interactions. This includes things like Link, enemies, NPCs, doors, pots, etc. Actors are good for a first file because they are generally small, self-contained systems.
 
-We recommend that you [join the Discord](https://discord.zelda64.dev/) to say hello and get suggestions on where to start on the `#mm-decomp` channel.
+We recommend that you [join the Discord](https://discord.zelda.deco.mp/) to say hello and get suggestions on where to start on the `#mm-decomp` channel.
 
 We track who is working on what on some Google Sheets available in the Discord. Once you've decided on or been recommended a good first file, mark it as Reserved.
 

--- a/docs/REVIEWING.md
+++ b/docs/REVIEWING.md
@@ -7,7 +7,7 @@ Every review submitted helps us keep code quality high and code merged in more q
 This document is meant to be a set of tips and guidelines for reviewers of pull requests to the project.
 For general information about the project, see [our readme](https://github.com/zeldaret/mm/blob/main/README.md).
 
-Most discussions happen on our [Discord Server](https://discord.zelda64.dev) where you are welcome to ask if you need help getting started, or if you have any questions regarding this project and other decompilation projects.
+Most discussions happen on our [Discord Server](https://discord.zelda.deco.mp) where you are welcome to ask if you need help getting started, or if you have any questions regarding this project and other decompilation projects.
 
 Other links are available in the [CONTRIBUTING.md](CONTRIBUTING.md)
 

--- a/docs/tutorial/introduction.md
+++ b/docs/tutorial/introduction.md
@@ -55,7 +55,7 @@ which is intended to be as close to the original code as we can get just by look
 
 N.B. We are using only publicly available code. In particular, we are not looking at any of the recent Nintendo source code leaks.
 
-Progress of the project can be found at [https://zelda64.dev]. The long-term goal of this project is to obtain a complete compilable version of the code for every publicly released version of Majora's Mask (in the same way as the Ocarina of Time project and many other Zelda games). *We are not working on a PC Port, and neither this project nor the ZeldaRET organisation will not be making one*, although the resulting code will be very useful if someone does intend to make such a port.
+Progress of the project can be found at [https://zelda.deco.mp]. The long-term goal of this project is to obtain a complete compilable version of the code for every publicly released version of Majora's Mask (in the same way as the Ocarina of Time project and many other Zelda games). *We are not working on a PC Port, and neither this project nor the ZeldaRET organisation will not be making one*, although the resulting code will be very useful if someone does intend to make such a port.
 
 Most of the discussion on the project takes place on the Zelda Decompilation Discord (linked in the [README.md](../../README.md)). We are very welcoming to newcomers and are happy to help you with any problems you might have with the decompilation process.
 


### PR DESCRIPTION
Update link to use the new domain (only place zelda64.dev still exists is in the Jenkinsfile for the folder where we store progress files)

resolves #1689