### PR TITLE
Clean up gitignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,56 +7,28 @@ __pycache__/
 .vscode/
 .vs/
 .idea/
-CMakeLists.txt
-cmake-build-debug
-venv/
-.venv/
-tags
+.cache/
+compile_commands.json
 
 # Project-specific ignores
+.make_options.mk
+extracted/
+build/
+expected/
+asm/
+data/
+docs/doxygen/
 *.z64
 *.n64
 *.v64
-*.sra
-*.bin
-*.elf
-*.flash
-archive/
-build/
-baserom/
-decomp/
-asm/
-data/
-extracted/
-expected/
-nonmatchings/
 
-# Tool artifacts
-tools/ido5.3_compiler/
-tools/ido7.1_compiler/
-tools/qemu-mips
-tools/ido_recomp/* binary
+# Tools
+.venv/
 ctx.c
+tools/*dSYM/
 graphs/
-*.c.m2c
-tools/**/*dSYM/
-tools/decomp-permuter/
-tools/mips_to_c/
-*.schl.inc
-
-# Assets
-*.png
-*.jpg
-!*_custom*
-.extracted-assets.json
-
-# Docs
-!docs/**/*.png
-docs/doxygen/
-!.vscode/extensions.json
 
 # Per-user configuration
-.python-version
-.make_options
-.make_options.mk
-.*env
+# If you want to use your own gitignore rules without modifying this file:
+# - use `git config core.excludesFile path/to/my_gitignore_file`
+# - or edit `.git/info/exclude`

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ docs/doxygen/
 # Tools
 .venv/
 ctx.c
+*.c.m2c
 tools/*dSYM/
 graphs/
 

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,9 +1,6 @@
 # Output files
-!ido_recomp/**
 *.exe
-yaz0
-makeromfs
-elf2rom
 mkdmadata
 mkldscript
+reloc_prereq
 vtxdis

--- a/tools/buildtools/.gitignore
+++ b/tools/buildtools/.gitignore
@@ -1,8 +1,0 @@
-# tool binaries
-
-elf2rom
-makeromfs
-mkldscript
-reloc_prereq
-yaz0
-makeyar


### PR DESCRIPTION
Cleans up some gitignore files.
Highly recommended to checkout the PR and see what it no longer ignores for you to see if we need to add something back.