### PR TITLE
Rename gBuildTeam to gBuildCreator

### DIFF
--- a/include/build.h
+++ b/include/build.h
@@ -1,7 +1,7 @@
 #ifndef BUILD_H
 #define BUILD_H
 
-extern char gBuildTeam[];
+extern char gBuildCreator[];
 extern char gBuildDate[];
 extern char gBuildMakeOption[];
 

--- a/src/boot/CIC6105.c
+++ b/src/boot/CIC6105.c
@@ -16,7 +16,7 @@ void CIC6105_Noop2(void) {
 
 void CIC6105_PrintRomInfo(void) {
     FaultDrawer_DrawText(80, 200, "SP_STATUS %08x", IO_READ(SP_STATUS_REG));
-    FaultDrawer_DrawText(40, 184, "ROM_F [Creator:%s]", gBuildTeam);
+    FaultDrawer_DrawText(40, 184, "ROM_F [Creator:%s]", gBuildCreator);
     FaultDrawer_DrawText(56, 192, "[Date:%s]", gBuildDate);
 }
 

--- a/src/boot/build.c
+++ b/src/boot/build.c
@@ -1,3 +1,3 @@
-const char gBuildTeam[] = "zelda@srd44";
+const char gBuildCreator[] = "zelda@srd44";
 const char gBuildDate[] = "00-07-31 17:04:16";
 const char gBuildMakeOption[] = "";


### PR DESCRIPTION
See here for the motivation of this rename:
https://github.com/zeldaret/oot/pull/2160