### PR TITLE
Update vscode doc

### DIFF
--- a/docs/tutorial/vscode.md
+++ b/docs/tutorial/vscode.md
@@ -49,8 +49,9 @@ You can create a `.vscode/c_cpp_properties.json` file with `C/C++: Edit Configur
                 "include",
                 "include/libc",
                 "src",
-                "build/n64-us/",
-                "${workspaceFolder}"
+                "build/n64-us",
+                "${workspaceFolder}",
+                "extracted/n64-us"
             ],
             "defines": [
                 "_LANGUAGE_C" // For gbi.h


### PR DESCRIPTION
Adds the extracted/n64-us include directory to the vscode doc (forgot to do it with the extracted PR).