### PR TITLE
Fix ocarina start UB for Japas jam session

### DIFF
--- a/src/code/z_message.c
+++ b/src/code/z_message.c
@@ -4338,7 +4338,10 @@ void Message_DrawMain(PlayState* play, Gfx** gfxP) {
                     if ((msgCtx->ocarinaAction == OCARINA_ACTION_PROMPT_EVAN_PART1_SECOND_HALF) ||
                         (msgCtx->ocarinaAction == OCARINA_ACTION_PROMPT_EVAN_PART2_SECOND_HALF)) {
                         AudioOcarina_StartForSongCheck(
-                            (1 << (OCARINA_ACTION_PROMPT_SONATA + msgCtx->ocarinaAction)) | 0x80000000, 4);
+                            (1 << ((msgCtx->ocarinaAction - OCARINA_ACTION_PROMPT_EVAN_PART1_SECOND_HALF) +
+                                   OCARINA_SONG_EVAN_PART1)) |
+                                0x80000000,
+                            4);
                         msgCtx->msgMode = MSGMODE_SONG_PROMPT;
                     } else {
                         if ((msgCtx->ocarinaAction >= OCARINA_ACTION_PROMPT_WIND_FISH_HUMAN) &&


### PR DESCRIPTION
When playing the zora guitar jam session with Japas, this expression would eval as `1 << (18 + 65)` leading to a left shift of 83, which is UB for u32. Rewriting this to use enums for `EVAN_PART` and matching the surround expressions for `AudioOcarina_Start` produces a matching rom without UB.

The new expression will eval as `1 << ((65 - 65) + 19)` leading to a left shift of 19. I'm guessing the previous shift of 83 was rolling over twice (`83-32-32 == 19`)