### PR TITLE
Add original asset names to all `object_u*`, `object_v*`, and `object_w*` files

### DIFF
--- a/assets/xml/objects/object_um.xml
+++ b/assets/xml/objects/object_um.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_um" Segment="6">
-        <DList Name="object_um_DL_000040" Offset="0x40" />
+        <DList Name="object_um_DL_000040" Offset="0x40" /> <!-- Original name is "kak_hahen01_model" -->
         <Texture Name="object_um_Tex_0000C8" OutName="tex_0000C8" Format="rgba16" Width="32" Height="32" Offset="0xC8" />
-        <DList Name="object_um_DL_000910" Offset="0x910" />
+        <DList Name="object_um_DL_000910" Offset="0x910" /> <!-- Original name is "kak_hahen02_model" -->
         <Texture Name="object_um_Tex_000998" OutName="tex_000998" Format="rgba16" Width="32" Height="32" Offset="0x998" />
-        <DList Name="object_um_DL_0011E0" Offset="0x11E0" />
+        <DList Name="object_um_DL_0011E0" Offset="0x11E0" /> <!-- Original name is "kak_hahen03_model" -->
         <Texture Name="object_um_Tex_001268" OutName="tex_001268" Format="rgba16" Width="32" Height="32" Offset="0x1268" />
         <DList Name="object_um_DL_001EE0" Offset="0x1EE0" />
         <Texture Name="object_um_Tex_002148" OutName="tex_002148" Format="rgba16" Width="32" Height="32" Offset="0x2148" />
@@ -32,8 +32,8 @@
 
         <TextureAnimation Name="object_um_Matanimheader_007D10" Offset="0x7D10" /> <!-- Empty TexAnim -->
 
-        <Collision Name="object_um_Colheader_007E20" Offset="0x7E20" />
-        <Collision Name="object_um_Colheader_007F50" Offset="0x7F50" />
+        <Collision Name="object_um_Colheader_007E20" Offset="0x7E20" /> <!-- Original name is "um_atari_bgdatainfo" -->
+        <Collision Name="object_um_Colheader_007F50" Offset="0x7F50" /> <!-- Original name is "um_atari2_bgdatainfo" -->
 
         <DList Name="object_um_DL_00DF20" Offset="0xDF20" />
         <DList Name="object_um_DL_00E2F0" Offset="0xE2F0" />
@@ -79,9 +79,9 @@
 
         <Skeleton Name="gUmSkel" Type="Flex" LimbType="Standard" LimbNone="UM_LIMB_NONE" LimbMax="UM_LIMB_MAX" EnumName="ObjectUmLimb" Offset="0x11DF8" />
 
-        <Animation Name="gUmGallopAnim" Offset="0x1213C" />
-        <Animation Name="gUmLookBackAnim" Offset="0x126C4" />
-        <Animation Name="gUmTrotAnim" Offset="0x12CC0" />
+        <Animation Name="gUmGallopAnim" Offset="0x1213C" /> <!-- Original name is "um_fastrun" -->
+        <Animation Name="gUmLookBackAnim" Offset="0x126C4" /> <!-- Original name is "um_furimuku" -->
+        <Animation Name="gUmTrotAnim" Offset="0x12CC0" /> <!-- Original name is "um_slowrun" -->
 
         <Texture Name="object_um_TLUT_012CD0" OutName="tlut_012CD0" Format="rgba16" Width="16" Height="16" Offset="0x12CD0" />
         <Texture Name="object_um_TLUT_012ED0" OutName="tlut_012ED0" Format="rgba16" Width="16" Height="16" Offset="0x12ED0" />
@@ -121,6 +121,6 @@
         <Texture Name="object_um_Tex_019210" OutName="tex_019210" Format="ci8" Width="16" Height="16" Offset="0x19210" />
         <Texture Name="object_um_Tex_019310" OutName="tex_019310" Format="ci8" Width="16" Height="32" Offset="0x19310" />
         <Texture Name="object_um_Tex_019510" OutName="tex_019510" Format="ci8" Width="64" Height="16" Offset="0x19510" />
-        <Animation Name="gUmIdleAnim" Offset="0x19E10" />
+        <Animation Name="gUmIdleAnim" Offset="0x19E10" /> <!-- Original name is "um_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_umajump.xml
+++ b/assets/xml/objects/object_umajump.xml
@@ -2,8 +2,8 @@
     <File Name="object_umajump" Segment="6">
         <Texture Name="object_umajump_Tex_000000" OutName="tex_000000" Format="rgba16" Width="16" Height="64" Offset="0x0" />
         <Texture Name="object_umajump_Tex_000800" OutName="tex_000800" Format="rgba16" Width="16" Height="64" Offset="0x800" />
-        <DList Name="gHorseJumpFenceDL" Offset="0x1220" />
-        <Collision Name="object_umajump_Colheader_001438" Offset="0x1438" />
-        <Collision Name="object_umajump_Colheader_001558" Offset="0x1558" />
+        <DList Name="gHorseJumpFenceDL" Offset="0x1220" /> <!-- Original name is "c_uma_jump_160_model" -->
+        <Collision Name="object_umajump_Colheader_001438" Offset="0x1438" /> <!-- Original name is "c_uma_jump_160_bgdatainfo" -->
+        <Collision Name="object_umajump_Colheader_001558" Offset="0x1558" /> <!-- Original name is "c_uma_jump_160_bgdatainfo2" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_visiblock.xml
+++ b/assets/xml/objects/object_visiblock.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <!-- Object for Lens of Truth Platform -->
     <File Name="object_visiblock" Segment="6">
-        <DList Name="gLensOfTruthPlatformDL" Offset="0x140" />
-        <DList Name="gLensOfTruthPlatformEmptyDL" Offset="0x1E8" />
+        <DList Name="gLensOfTruthPlatformDL" Offset="0x140" /> <!-- Original name is "z2_11_brick01_modelT" -->
+        <DList Name="gLensOfTruthPlatformEmptyDL" Offset="0x1E8" /> <!-- Original name is "z2_11_brick01_model" -->
         <Texture Name="gLensOfTruthPlatformTex" OutName="lens_of_truth_platform" Format="rgba16" Width="32" Height="32" Offset="0x1F0" />
-        <Collision Name="gLensOfTruthPlatformCol" Offset="0xAD0" />
+        <Collision Name="gLensOfTruthPlatformCol" Offset="0xAD0" /> <!-- Original name is "z2_11_brick01_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_vm.xml
+++ b/assets/xml/objects/object_vm.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_vm" Segment="6">
         <!-- Beamos Animations -->
-        <Animation Name="gBeamosAnim" Offset="0x68" />
+        <Animation Name="gBeamosAnim" Offset="0x68" /> <!-- Original name is "vm_akesime" -->
         
         <!-- Beamos Limb DisplayLists -->
         <DList Name="gBeamosBodyDL" Offset="0x1E00" />

--- a/assets/xml/objects/object_warp_uzu.xml
+++ b/assets/xml/objects/object_warp_uzu.xml
@@ -1,6 +1,6 @@
 ﻿<Root>
     <File Name="object_warp_uzu" Segment="6">
-        <DList Name="object_warp_uzu_DL_000EC0" Offset="0xEC0" />
+        <DList Name="object_warp_uzu_DL_000EC0" Offset="0xEC0" /> <!-- Original name is "Y2_telescope_model" -->
         <Texture Name="object_warp_uzu_TLUT_0019D0" OutName="tlut_0019D0" Format="rgba16" Width="16" Height="16" Offset="0x19D0" />
         <Texture Name="object_warp_uzu_Tex_001BD0" OutName="tex_001BD0" Format="rgba16" Width="16" Height="32" Offset="0x1BD0" />
         <Texture Name="object_warp_uzu_Tex_001FD0" OutName="tex_001FD0" Format="ci8" Width="8" Height="8" Offset="0x1FD0" />

--- a/assets/xml/objects/object_water_effect.xml
+++ b/assets/xml/objects/object_water_effect.xml
@@ -1,10 +1,10 @@
 ﻿<Root>
     <File Name="object_water_effect" Segment="6">
-        <DList Name="object_water_effect_DL_000180" Offset="0x180" />
-        <DList Name="object_water_effect_DL_000420" Offset="0x420" />
-        <DList Name="object_water_effect_DL_000730" Offset="0x730" />
-        <DList Name="object_water_effect_DL_000A48" Offset="0xA48" />
-        <DList Name="object_water_effect_DL_000CD8" Offset="0xCD8" />
+        <DList Name="object_water_effect_DL_000180" Offset="0x180" /> <!-- Original name is "spl_hasira_model" -->
+        <DList Name="object_water_effect_DL_000420" Offset="0x420" /> <!-- Original name is "spl_sibuki01_model" -->
+        <DList Name="object_water_effect_DL_000730" Offset="0x730" /> <!-- Original name is "spl_sibuki02_model" -->
+        <DList Name="object_water_effect_DL_000A48" Offset="0xA48" /> <!-- Original name is "spl_sibuki03_model" -->
+        <DList Name="object_water_effect_DL_000CD8" Offset="0xCD8" /> <!-- Original name is "spl_hamon_model" -->
         <TextureAnimation Name="object_water_effect_Matanimheader_000DD0" Offset="0xDD0" />
         <TextureAnimation Name="object_water_effect_Matanimheader_000DE0" Offset="0xDE0" />
         <TextureAnimation Name="object_water_effect_Matanimheader_000E0C" Offset="0xE0C" />
@@ -19,8 +19,8 @@
         <Texture Name="object_water_effect_Tex_003A60" OutName="tex_003A60" Format="i4" Width="64" Height="64" Offset="0x3A60" />
         <DList Name="object_water_effect_DL_004260" Offset="0x4260" />
         <DList Name="object_water_effect_DL_0042B0" Offset="0x42B0" />
-        <DList Name="object_water_effect_DL_0042F8" Offset="0x42F8" />
+        <DList Name="object_water_effect_DL_0042F8" Offset="0x42F8" /> <!-- Original name is "we_water2_modelT" -->
         <DList Name="object_water_effect_DL_004340" Offset="0x4340" />
-        <DList Name="object_water_effect_DL_0043E8" Offset="0x43E8" />
+        <DList Name="object_water_effect_DL_0043E8" Offset="0x43E8" /> <!-- Original name might be "torch_model" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_wdhand.xml
+++ b/assets/xml/objects/object_wdhand.xml
@@ -1,9 +1,9 @@
 ﻿<Root>
     <File Name="object_wdhand" Segment="6">
-        <Animation Name="gDexihandCloseAnim" Offset="0xF4" />
-        <Animation Name="object_wdhand_Anim_000364" Offset="0x364" />
-        <Animation Name="gDexihandOpenAnim" Offset="0x534" />
-        <Animation Name="gDexihandIdleAnim" Offset="0x854" />
+        <Animation Name="gDexihandCloseAnim" Offset="0xF4" /> <!-- Original name is "wd_closeH" -->
+        <Animation Name="object_wdhand_Anim_000364" Offset="0x364" /> <!-- Original name is "wd_hanasuH" -->
+        <Animation Name="gDexihandOpenAnim" Offset="0x534" /> <!-- Original name is "wd_openH" -->
+        <Animation Name="gDexihandIdleAnim" Offset="0x854" /> <!-- Original name is "wd_waitH" -->
         <Texture Name="object_wdhand_Tex_000870" OutName="tex_000870" Format="rgba16" Width="16" Height="32" Offset="0x870" />
         <Texture Name="object_wdhand_Tex_000C70" OutName="tex_000C70" Format="rgba16" Width="16" Height="32" Offset="0xC70" />
         <Texture Name="object_wdhand_Tex_001070" OutName="tex_001070" Format="rgba16" Width="16" Height="32" Offset="0x1070" />

--- a/assets/xml/objects/object_wdor01.xml
+++ b/assets/xml/objects/object_wdor01.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <!-- Object for Lottery Shop / Curiosity Shop / Mayor's House Door -->
     <File Name="object_wdor01" Segment="6">
-        <DList Name="gLotteryCuriosityShopMayorHouseDoorEmptyDL" Offset="0x540" />
-        <DList Name="gLotteryCuriosityShopMayorHouseDoorDL" Offset="0x548" />
+        <DList Name="gLotteryCuriosityShopMayorHouseDoorEmptyDL" Offset="0x540" /> <!-- Original name is "w2_door1_modelT" -->
+        <DList Name="gLotteryCuriosityShopMayorHouseDoorDL" Offset="0x548" /> <!-- Original name is "w2_door1_model" -->
         <Texture Name="gLotteryCuriosityShopMayorHouseDoorTex" OutName="lottery_curiosity_shop_mayor_house_door" Format="rgba16" Width="32" Height="64" Offset="0x6B0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_wdor02.xml
+++ b/assets/xml/objects/object_wdor02.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <!-- Object for Post Office / Trading Post Door -->
     <File Name="object_wdor02" Segment="6">
-        <DList Name="gPostOfficeTradingPostDoorEmptyDL" Offset="0x540" />
-        <DList Name="gPostOfficeTradingPostDoorDL" Offset="0x548" />
+        <DList Name="gPostOfficeTradingPostDoorEmptyDL" Offset="0x540" /> <!-- Original name is "w2_door2_modelT" -->
+        <DList Name="gPostOfficeTradingPostDoorDL" Offset="0x548" /> <!-- Original name is "w2_door2_model" -->
         <Texture Name="gPostOfficeTradingPostDoorTex" OutName="post_office_trading_post_door" Format="rgba16" Width="32" Height="64" Offset="0x6B0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_wdor03.xml
+++ b/assets/xml/objects/object_wdor03.xml
@@ -1,8 +1,8 @@
 ﻿<Root>
     <!-- Object for Stock Pot Inn & Swordsman's School Door -->
     <File Name="object_wdor03" Segment="6">
-        <DList Name="gInnSchoolDoorEmptyDL" Offset="0x540" />
-        <DList Name="gInnSchoolDoorDL" Offset="0x548" />
+        <DList Name="gInnSchoolDoorEmptyDL" Offset="0x540" /> <!-- Original name is "w2_door3_modelT" -->
+        <DList Name="gInnSchoolDoorDL" Offset="0x548" /> <!-- Original name is "w2_door3_model" -->
         <Texture Name="gInnScoolDoorTex" OutName="inn_school_door" Format="rgba16" Width="32" Height="64" Offset="0x6B0" />
     </File>
 </Root>

--- a/assets/xml/objects/object_wdor04.xml
+++ b/assets/xml/objects/object_wdor04.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_wdor04" Segment="6">
-        <DList Name="gMilkBarDoorEndDL" Offset="0x500"/>
-        <DList Name="gMilkBarDoorDL" Offset="0x508"/>
+        <DList Name="gMilkBarDoorEndDL" Offset="0x500"/> <!-- Original name is "w2_door4_modelT" -->
+        <DList Name="gMilkBarDoorDL" Offset="0x508"/> <!-- Original name is "w2_door4_model" -->
         <Texture Name="gMilkBarDoorTex" OutName="milk_bar_door" Format="rgba16" Width="32" Height="64" Offset="0x670"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_wdor05.xml
+++ b/assets/xml/objects/object_wdor05.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_wdor05" Segment="6">
-        <DList Name="gMusicBoxHouseEndDL" Offset="0x500"/>
-        <DList Name="gMusicBoxHouseDoorDL" Offset="0x508"/>
+        <DList Name="gMusicBoxHouseEndDL" Offset="0x500"/> <!-- Original name is "w2_door5_modelT" -->
+        <DList Name="gMusicBoxHouseDoorDL" Offset="0x508"/> <!-- Original name is "w2_door5_model" -->
         <Texture Name="gMusicBoxHouseDoorTex" OutName="music_box_house_door" Format="rgba16" Width="32" Height="64" Offset="0x670"/>
     </File>
 </Root>

--- a/assets/xml/objects/object_wood02.xml
+++ b/assets/xml/objects/object_wood02.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <ExternalFile XmlPath="objects/gameplay_field_keep.xml" OutPath="assets/objects/gameplay_field_keep/"/>
     <File Name="object_wood02" Segment="6">
-        <DList Name="object_wood02_DL_000090" Offset="0x90" />
+        <DList Name="object_wood02_DL_000090" Offset="0x90" /> <!-- Original name might be "grass01_modelT" -->
         <DList Name="object_wood02_DL_000160" Offset="0x160" />
         <DList Name="object_wood02_DL_000340" Offset="0x340" />
         <DList Name="object_wood02_DL_000440" Offset="0x440" />
@@ -20,7 +20,7 @@
         <Texture Name="object_wood02_Tex_006F90" OutName="tex_006F90" Format="ia8" Width="32" Height="64" Offset="0x6F90" />
         <DList Name="object_wood02_DL_0078D0" Offset="0x78D0" />
         <DList Name="object_wood02_DL_007968" Offset="0x7968" />
-        <Collision Name="object_wood02_Colheader_007A70" Offset="0x7A70" />
+        <Collision Name="object_wood02_Colheader_007A70" Offset="0x7A70" /> <!-- Original name is "tree01_bgdatainfo" -->
         <DList Name="object_wood02_DL_007AD0" Offset="0x7AD0" />
         <DList Name="object_wood02_DL_007CA0" Offset="0x7CA0" />
         <DList Name="object_wood02_DL_007D38" Offset="0x7D38" />


### PR DESCRIPTION
Pretty self-explanatory, but take note of how the filenames in `object_water_effect` are not in alphabetic order. In this case, we can be pretty confident in these names, because `spl_hasira_model` in MM3D actually uses the original N64 asset:

![image](https://github.com/user-attachments/assets/f09e488c-d5a1-4e13-87fe-b754b150fb9b)
