### PR TITLE
Add original asset names to all `object_y*` and `object_z*` files

### DIFF
--- a/assets/xml/objects/object_yado_obj.xml
+++ b/assets/xml/objects/object_yado_obj.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_yado_obj" Segment="6">
         <DList Name="object_yado_obj_DL_000320" Offset="0x320" />
-        <DList Name="object_yado_obj_DL_000430" Offset="0x430" />
+        <DList Name="object_yado_obj_DL_000430" Offset="0x430" /> <!-- Original name might be "w2_yad_win_model" -->
         <Texture Name="object_yado_obj_Tex_0005D8" OutName="tex_0005D8" Format="ia16" Width="16" Height="32" Offset="0x5D8" />
         <Texture Name="object_yado_obj_Tex_0009D8" OutName="tex_0009D8" Format="rgba16" Width="32" Height="16" Offset="0x9D8" />
         <Texture Name="object_yado_obj_Tex_000DD8" OutName="tex_000DD8" Format="i8" Width="16" Height="16" Offset="0xDD8" />

--- a/assets/xml/objects/object_yb.xml
+++ b/assets/xml/objects/object_yb.xml
@@ -1,11 +1,13 @@
 ﻿<Root>
     <File Name="object_yb" Segment="6">
-        <!-- animation wont play in z64utils, attempts to play in game are crash -->
-        <!-- actor uses link animation so this might be reading incorrectly -->
-        <Animation Name="object_yb_Anim_000200" Offset="0x200" />
-        <!-- since these blobs are right after the animation, and that animation doesnt work... assume this is part of why -->
-        <!-- <Blob Name="object_yb_Blob_002080" Size="0x30" Offset="0x2080" /> -->
-        <!-- <Blob Name="object_yb_Blob_002D50" Size="0x30" Offset="0x2D50" /> -->
+        <Animation Name="object_yb_Anim_000200" Offset="0x200" /> <!-- Original name is "yb_kihon" -->
+        <!-- These 2 vtx were likely grouped with the rest of Kamaro's vertices, but they are separated out here for the used and unused sections -->
+        <Array Name="object_yb_Vtx_002080" Count="3" Offset="0x2080">
+            <Vtx/>
+        </Array>
+        <Array Name="object_yb_Vtx_002D50" Count="3" Offset="0x2D50">
+            <Vtx/>
+        </Array>
         <DList Name="gYbPantsAndBellyButtonDL" Offset="0x3400" />
         <DList Name="gYbRightThighDL" Offset="0x3610" />
         <DList Name="gYbRightShinDL" Offset="0x37B0" />

--- a/assets/xml/objects/object_yukimura_obj.xml
+++ b/assets/xml/objects/object_yukimura_obj.xml
@@ -8,7 +8,7 @@
         <Texture Name="object_yukimura_obj_Tex_0008D8" OutName="tex_0008D8" Format="rgba16" Width="16" Height="8" Offset="0x8D8" />
         <Texture Name="object_yukimura_obj_Tex_0009D8" OutName="tex_0009D8" Format="rgba16" Width="32" Height="16" Offset="0x9D8" />
         <DList Name="object_yukimura_obj_DL_000EB0" Offset="0xEB0" />
-        <DList Name="object_yukimura_obj_DL_000F98" Offset="0xF98" />
+        <DList Name="object_yukimura_obj_DL_000F98" Offset="0xF98" /> <!-- Orignal name might be "z2_10_kemuri01_model" -->
         <Texture Name="object_yukimura_obj_Tex_001078" OutName="tex_001078" Format="rgba16" Width="32" Height="32" Offset="0x1078" />
         <Texture Name="object_yukimura_obj_Tex_001878" OutName="tex_001878" Format="i4" Width="64" Height="64" Offset="0x1878" />
         <TextureAnimation Name="object_yukimura_obj_Matanimheader_002090" Offset="0x2090" />

--- a/assets/xml/objects/object_yukiyama.xml
+++ b/assets/xml/objects/object_yukiyama.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_yukiyama" Segment="6">
-        <DList Name="object_yukiyama_DL_001250" Offset="0x1250" />
-        <DList Name="object_yukiyama_DL_0013A8" Offset="0x13A8" />
+        <DList Name="object_yukiyama_DL_001250" Offset="0x1250" /> <!-- Original name is "z2_10yukiyamanomura3_modelT" -->
+        <DList Name="object_yukiyama_DL_0013A8" Offset="0x13A8" /> <!-- Original name is "z2_10yukiyamanomura3_model" -->
         <Texture Name="object_yukiyama_Tex_001A60" OutName="tex_001A60" Format="ia16" Width="32" Height="8" Offset="0x1A60" />
         <Texture Name="object_yukiyama_Tex_001C60" OutName="tex_001C60" Format="i8" Width="32" Height="128" Offset="0x1C60" />
         <Texture Name="object_yukiyama_Tex_002C60" OutName="tex_002C60" Format="rgba16" Width="16" Height="128" Offset="0x2C60" />

--- a/assets/xml/objects/object_zg.xml
+++ b/assets/xml/objects/object_zg.xml
@@ -2,7 +2,7 @@
     <File Name="object_zg" Segment="6">
         <Texture Name="gTowerCollapseBarMetalTex" OutName="tower_collapse_bar_metal" Format="rgba16" Width="32" Height="32" Offset="0x0"/>
         <Texture Name="gTowerCollapseBarFlameTex" OutName="tower_collapse_bar_flame" Format="rgba16" Width="32" Height="32" Offset="0x800"/>
-        <DList Name="gTowerCollapseBarsDL" Offset="0x1080"/>
-        <Collision Name="gTowerCollapseBarsCol" Offset="0x11D4"/>
+        <DList Name="gTowerCollapseBarsDL" Offset="0x1080"/> <!-- Original name is "zeldoor_model" -->
+        <Collision Name="gTowerCollapseBarsCol" Offset="0x11D4"/> <!-- Original name is "zeldoor_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zl1.xml
+++ b/assets/xml/objects/object_zl1.xml
@@ -2,7 +2,7 @@
     <!-- Object for Child Zelda 1 -->
     <File Name="object_zl1" Segment="6">
         <!-- Animation -->
-        <Animation Name="gChildZelda1Anim_00438" Offset="0x438" />
+        <Animation Name="gChildZelda1Anim_00438" Offset="0x438" /> <!-- Original name is "anim_matsu" -->
 
         <!-- Palette -->
         <Texture Name="gChildZelda1TLUT_0450" OutName="child_zelda_1_tlut_0450" Format="rgba16" Width="16" Height="16" Offset="0x450" />
@@ -101,16 +101,16 @@
         <Skeleton Name="gChildZelda1Skel" Type="Flex" LimbType="Standard" LimbNone="CHILD_ZELDA_1_LIMB_NONE" LimbMax="CHILD_ZELDA_1_LIMB_MAX" EnumName="ChildZelda1Limb" Offset="0xF5D8" />
         
         <!-- Animations -->
-        <Animation Name="gChildZelda1Anim_10B38" Offset="0x10B38" />
-        <Animation Name="gChildZelda1Anim_11348" Offset="0x11348" />
-        <Animation Name="gChildZelda1Anim_116E4" Offset="0x116E4" />
-        <Animation Name="gChildZelda1Anim_12B88" Offset="0x11B88" />
-        <Animation Name="gChildZelda1Anim_12118" Offset="0x12118" />
-        <Animation Name="gChildZelda1Anim_12B04" Offset="0x12B04" />
-        <Animation Name="gChildZelda1Anim_12F80" Offset="0x12F80" />
-        <Animation Name="gChildZelda1Anim_132D8" Offset="0x132D8" />
-        <Animation Name="gChildZelda1Anim_138E0" Offset="0x138E0" />
-        <Animation Name="gChildZelda1Anim_13F10" Offset="0x13F10" />
-        <Animation Name="gChildZelda1Anim_143A8" Offset="0x143A8" />
+        <Animation Name="gChildZelda1Anim_10B38" Offset="0x10B38" /> <!-- Original name is "demo_furimuki" -->
+        <Animation Name="gChildZelda1Anim_11348" Offset="0x11348" /> <!-- Original name is "demo_furimuki_wait" -->
+        <Animation Name="gChildZelda1Anim_116E4" Offset="0x116E4" /> <!-- Original name is "demo_kasige" -->
+        <Animation Name="gChildZelda1Anim_11B88" Offset="0x11B88" /> <!-- Original name is "demo_kasige_wait" -->
+        <Animation Name="gChildZelda1Anim_12118" Offset="0x12118" /> <!-- Original name is "demo_nozoki_wait" -->
+        <Animation Name="gChildZelda1Anim_12B04" Offset="0x12B04" /> <!-- Original name is "demo_slide" -->
+        <Animation Name="gChildZelda1Anim_12F80" Offset="0x12F80" /> <!-- Original name is "demo_slide_wait" -->
+        <Animation Name="gChildZelda1Anim_132D8" Offset="0x132D8" /> <!-- Original name is "demo_tesage" -->
+        <Animation Name="gChildZelda1Anim_138E0" Offset="0x138E0" /> <!-- Original name is "demo_tetataki_1" -->
+        <Animation Name="gChildZelda1Anim_13F10" Offset="0x13F10" /> <!-- Original name is "demo_tetataki_2" -->
+        <Animation Name="gChildZelda1Anim_143A8" Offset="0x143A8" /> <!-- Original name is "demo_tetataki_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zl4.xml
+++ b/assets/xml/objects/object_zl4.xml
@@ -2,7 +2,7 @@
     <!-- Child Zelda: from the cutscene where Deku Link recalls how to play Song of Time after getting his Ocarina back -->
     <File Name="object_zl4" Segment="6">
         <!-- Everything up to and including the skeleton is retained from the beginning of OoT's object_zl4 -->
-        <Animation Name="gDmZl4IdleAnim" Offset="0x654" />
+        <Animation Name="gDmZl4IdleAnim" Offset="0x654" /> <!-- Original name is "anim_matsu" -->
         <Texture Name="gDmZl4DressTLUT" OutName="dress_tlut" Format="rgba16" Width="16" Height="16" Offset="0x670" />
         <Texture Name="gDmZl4EyeTLUT" OutName="eye_tlut" Format="rgba16" Width="16" Height="16" Offset="0x870" />
         <Texture Name="gDmZl4MouthTLUT" OutName="mouth_tlut" Format="rgba16" Width="16" Height="16" Offset="0xA70" />
@@ -74,7 +74,7 @@
 
         <!-- Ocarina, drawn to right hand in OverrideLimbDraw -->
         <Texture Name="gDmZl4OcarinaTex" OutName="ocarina" Format="rgba16" Width="32" Height="16" Offset="0xD8B8" />
-        <DList Name="gDmZl4OcarinaDL" Offset="0xDE08" />
+        <DList Name="gDmZl4OcarinaDL" Offset="0xDE08" /> <!-- Original name is "zl4_okarina_model" -->
 
         <Limb Name="gDmZl4RootLimb" Type="Standard" EnumName="ZL4_LIMB_ROOT" Offset="0xDF28" />
         <Limb Name="gDmZl4WaistLimb" Type="Standard" EnumName="ZL4_LIMB_WAIST" Offset="0xDF34" />
@@ -95,64 +95,65 @@
         <Limb Name="gDmZl4HeadLimb" Type="Standard" EnumName="ZL4_LIMB_HEAD" Offset="0xDFE8" />
         <Skeleton Name="gZl4Skel" Type="Flex" LimbType="Standard" LimbNone="ZL4_LIMB_NONE" LimbMax="ZL4_LIMB_MAX" EnumName="Zl4Limb" Offset="0xE038" />
 
+        <!-- Used in MM -->
+        <Animation Name="gDmZl4TurningAroundAnim" Offset="0xF250" /> <!-- Original name is probably "cze_fue_furimuki" -->
         
         <!-- Unused Flute Animations -->
-        <Animation Name="gDmZl4HoldingFluteInFrontAnim" Offset="0xFDC8" />
-        <Animation Name="gDmZl4RaiseFluteToPlayAnim" Offset="0x10334" />
-        <Animation Name="gDmZl4LowerFluteAfterPlayAnim" Offset="0x105C8" />
-        <Animation Name="gDmZl4PlayingFluteAnim" Offset="0x10D50" />
+        <Animation Name="gDmZl4HoldingFluteInFrontAnim" Offset="0xFDC8" /> <!-- Original name is probably "cze_fue_furimuki_wait" -->
+        <Animation Name="gDmZl4RaiseFluteToPlayAnim" Offset="0x10334" /> <!-- Original name is probably "cze_fue_kamae" -->
+        <Animation Name="gDmZl4LowerFluteAfterPlayAnim" Offset="0x105C8" /> <!-- Original name is probably "cze_fue_niyari" -->
+        <Animation Name="gDmZl4PlayingFluteAnim" Offset="0x10D50" /> <!-- Original name is probably "cze_fue_play" -->
 
         <!-- Used in MM -->
-        <Animation Name="gDmZl4TurningAroundAnim" Offset="0xF250" />
-        <Animation Name="gDmZl4FacingAwayIdleAnim" Offset="0x11294" />
-        <Animation Name="gDmZl4GivingItemStartAnim" Offset="0x11BB8" />
-        <Animation Name="gDmZl4GivingItemLoopAnim" Offset="0x122E0" />
-        <Animation Name="gDmZl4RaisingOcarinaToPlayAnim" Offset="0x12A84" />
-        <Animation Name="gDmZl4PlayingOcarinaAnim" Offset="0x1303C" />
+        <Animation Name="gDmZl4FacingAwayIdleAnim" Offset="0x11294" /> <!-- Original name is probably "cze_fue_wait" -->
+        <Animation Name="gDmZl4GivingItemStartAnim" Offset="0x11BB8" /> <!-- Original name is "cze_okarina_dasu" -->
+        <Animation Name="gDmZl4GivingItemLoopAnim" Offset="0x122E0" /> <!-- Original name is "cze_okarina_dasu_loop" -->
+        <Animation Name="gDmZl4RaisingOcarinaToPlayAnim" Offset="0x12A84" /> <!-- Original name is "cze_okarina_fuku" -->
+        <Animation Name="gDmZl4PlayingOcarinaAnim" Offset="0x1303C" /> <!-- Original name is "cze_okarina_fuku_loop" -->
 
         <!-- Unused Backflipping Animation -->
-        <Animation Name="gDmZl4BackflipAnim" Offset="0x13934" />
-        <Animation Name="gDmZl4BackflipPrepareAnim" Offset="0x13F2C" />
-        <Animation Name="gDmZl4BackflipPrepareHoldingReadyAnim" Offset="0x14558" />
+        <Animation Name="gDmZl4BackflipAnim" Offset="0x13934" /> <!-- Original name is probably "cze_op_bakutyu" -->
+        <Animation Name="gDmZl4BackflipPrepareAnim" Offset="0x13F2C" /> <!-- Original name is probably "cze_op_suihei" -->
+        <Animation Name="gDmZl4BackflipPrepareHoldingReadyAnim" Offset="0x14558" /> <!-- Original name is probably "cze_op_suihei_wait" -->
 
         <!-- Used in MM --> 
-        <Animation Name="gDmZl4TurningAround2Anim" Offset="0x15494" />
-        <Animation Name="gDmZl4HandsOverEmblemLoopAnim" Offset="0x15A4C" />
-        <Animation Name="gDmZl4FacingAwayHandsOverEmblemLoopAnim" Offset="0x15DA0" />
+        <Animation Name="gDmZl4TurningAround2Anim" Offset="0x15494" /> <!-- Original name is "cze_usiro_furimuki" -->
+        <Animation Name="gDmZl4HandsOverEmblemLoopAnim" Offset="0x15A4C" /> <!-- Original name is "cze_usiro_furimuki_roop" -->
+        <Animation Name="gDmZl4FacingAwayHandsOverEmblemLoopAnim" Offset="0x15DA0" /> <!-- Original name is "cze_usiro_roop" -->
 
         <!-- Unused in MM, copy of OoT Animations in object_zl4:(0xE050 -> End) --> 
-        <Animation Name="gDmZl4Anim_016328" Offset="0x16328" />
-        <Animation Name="gDmZl4Anim_016924" Offset="0x16924" />
-        <Animation Name="gDmZl4Anim_016E04" Offset="0x16E04" />
-        <Animation Name="gDmZl4Anim_0175F4" Offset="0x175F4" />
-        <Animation Name="gDmZl4Anim_018B58" Offset="0x18B58" />
-        <Animation Name="gDmZl4Anim_018FA8" Offset="0x18FA8" />
-        <Animation Name="gDmZl4Anim_0193F8" Offset="0x193F8" />
-        <Animation Name="gDmZl4Anim_019894" Offset="0x19894" />
-        <Animation Name="gDmZl4Anim_01A344" Offset="0x1A344" />
-        <Animation Name="gDmZl4Anim_01ABB8" Offset="0x1ABB8" />
-        <Animation Name="gDmZl4Anim_01AFE0" Offset="0x1AFE0" />
-        <Animation Name="gDmZl4Anim_01B388" Offset="0x1B388" />
-        <Animation Name="gDmZl4Anim_01B7B0" Offset="0x1B7B0" />
-        <Animation Name="gDmZl4Anim_01BC00" Offset="0x1BC00" />
-        <Animation Name="gDmZl4Anim_01DC74" Offset="0x1DC74" />
-        <Animation Name="gDmZl4Anim_01E714" Offset="0x1E714" />
-        <Animation Name="gDmZl4Anim_01EA68" Offset="0x1EA68" />
-        <Animation Name="gDmZl4Anim_01EFCC" Offset="0x1EFCC" />
-        <Animation Name="gDmZl4Anim_01F578" Offset="0x1F578" />
-        <Animation Name="gDmZl4Anim_01FDBC" Offset="0x1FDBC" />
-        <Animation Name="gDmZl4Anim_0205F8" Offset="0x205F8" />
-        <Animation Name="gDmZl4Anim_020E6C" Offset="0x20E6C" />
-        <Animation Name="gDmZl4Anim_021360" Offset="0x21360" />
-        <Animation Name="gDmZl4Anim_02167C" Offset="0x2167C" />
-        <Animation Name="gDmZl4Anim_02205C" Offset="0x2205C" />
-        <Animation Name="gDmZl4Anim_022840" Offset="0x22840" />
-        <Animation Name="gDmZl4Anim_022BE8" Offset="0x22BE8" />
-        <Animation Name="gDmZl4Anim_0235D4" Offset="0x235D4" />
-        <Animation Name="gDmZl4Anim_023A50" Offset="0x23A50" />
-        <Animation Name="gDmZl4Anim_0241F4" Offset="0x241F4" />
-        <Animation Name="gDmZl4Anim_024510" Offset="0x24510" />
-        <Animation Name="gDmZl4Anim_024B68" Offset="0x24B68" />
+        <Animation Name="gDmZl4Anim_016328" Offset="0x16328" /> <!-- Original name is "demo_aisatu" -->
+        <Animation Name="gDmZl4Anim_016924" Offset="0x16924" /> <!-- Original name is "demo_aisatu_wait" -->
+        <Animation Name="gDmZl4Anim_016E04" Offset="0x16E04" /> <!-- Original name is "demo_arigato" -->
+        <Animation Name="gDmZl4Anim_0175F4" Offset="0x175F4" /> <!-- Original name is "demo_arigato_wait" -->
+        <Animation Name="gDmZl4Anim_018B58" Offset="0x18B58" /> <!-- Seems like a modified form of "gChildZelda1Anim_10B38" from object_zl1. Original name is probably "demo_furimuki" -->
+        <Animation Name="gDmZl4Anim_018FA8" Offset="0x18FA8" /> <!-- Seems like a modified form of "gChildZelda1Anim_11348" from object_zl1. Original name is probably "demo_furimuki_wait" -->
+        <Animation Name="gDmZl4Anim_0193F8" Offset="0x193F8" /> <!-- Original name is "demo_gomen" -->
+        <Animation Name="gDmZl4Anim_019894" Offset="0x19894" /> <!-- Original name is "demo_himitu" -->
+        <Animation Name="gDmZl4Anim_01A344" Offset="0x1A344" /> <!-- Original name is "demo_kaku" -->
+        <Animation Name="gDmZl4Anim_01ABB8" Offset="0x1ABB8" /> <!-- Original name is "demo_kaku_wait" -->
+        <Animation Name="gDmZl4Anim_01AFE0" Offset="0x1AFE0" /> <!-- Seems like a modified form of "gChildZelda1Anim_116E4" from object_zl1. Original name is probably "demo_kasige" -->
+        <Animation Name="gDmZl4Anim_01B388" Offset="0x1B388" /> <!-- Seems like a modified form of "gChildZelda1Anim_11B88" from object_zl1. Original name is probably "demo_kasige_wait" -->
+        <Animation Name="gDmZl4Anim_01B7B0" Offset="0x1B7B0" /> <!-- Original name is "demo_kirai" -->
+        <Animation Name="gDmZl4Anim_01BC00" Offset="0x1BC00" /> <!-- Original name is "demo_kirai_wait" -->
+        <Animation Name="gDmZl4Anim_01DC74" Offset="0x1DC74" /> <!-- Original name is "demo_modoru" -->
+        <Animation Name="gDmZl4Anim_01E714" Offset="0x1E714" /> <!-- Original name is "demo_modoru_to_omegai2" -->
+        <Animation Name="gDmZl4Anim_01EA68" Offset="0x1EA68" /> <!-- Original name is "demo_modoru_wait" -->
+        <Animation Name="gDmZl4Anim_01EFCC" Offset="0x1EFCC" /> <!-- Original name is "demo_namae" -->
+        <Animation Name="gDmZl4Anim_01F578" Offset="0x1F578" /> <!-- Original name is "demo_namae_wait" -->
+        <Animation Name="gDmZl4Anim_01FDBC" Offset="0x1FDBC" /> <!-- Original name is "demo_naname_wait" -->
+        <Animation Name="gDmZl4Anim_0205F8" Offset="0x205F8" /> <!-- Original name is "demo_noridasi" -->
+        <Animation Name="gDmZl4Anim_020E6C" Offset="0x20E6C" /> <!-- Original name is "demo_noridasi_wait" -->
+        <Animation Name="gDmZl4Anim_021360" Offset="0x21360" /> <!-- Seems like a modified form of "gChildZelda1Anim_12118" from object_zl1. Original name is probably "demo_nozoki_wait" -->
+        <Animation Name="gDmZl4Anim_02167C" Offset="0x2167C" /> <!-- Original name is "demo_onegai" -->
+        <Animation Name="gDmZl4Anim_02205C" Offset="0x2205C" /> <!-- Original name is "demo_onegai2" -->
+        <Animation Name="gDmZl4Anim_022840" Offset="0x22840" /> <!-- Original name is "demo_onegai2_wait" -->
+        <Animation Name="gDmZl4Anim_022BE8" Offset="0x22BE8" /> <!-- Original name is "demo_onegai_wait" -->
+        <Animation Name="gDmZl4Anim_0235D4" Offset="0x235D4" /> <!-- Duplicate of "gChildZelda1Anim_12B04" from object_zl1. Original name is "demo_slide" -->
+        <Animation Name="gDmZl4Anim_023A50" Offset="0x23A50" /> <!-- Duplicate of "gChildZelda1Anim_12F80" from object_zl1. Original name is "demo_slide_wait" -->
+        <Animation Name="gDmZl4Anim_0241F4" Offset="0x241F4" /> <!-- Seems like a modified form of "gChildZelda1Anim_138E0" from object_zl1. Original name is probably "demo_tetataki_1" -->
+        <Animation Name="gDmZl4Anim_024510" Offset="0x24510" /> <!-- Seems like a modified form of "gChildZelda1Anim_143A8" from object_zl1. Original name is probably "demo_tetataki_wait" -->
+        <Animation Name="gDmZl4Anim_024B68" Offset="0x24B68" /> <!-- Original name is probably "demo_usiro_ude_wait" -->
 
         <!-- Unused Flute -->
         <DList Name="gDmZl4FluteDL" Offset="0x24D80" />

--- a/assets/xml/objects/object_zm.xml
+++ b/assets/xml/objects/object_zm.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_zm" Segment="6">
-        <Animation Name="object_zm_Anim_000C80" Offset="0xC80" />
-        <Animation Name="object_zm_Anim_001324" Offset="0x1324" />
-        <Animation Name="object_zm_Anim_0016A4" Offset="0x16A4" />
-        <Animation Name="object_zm_Anim_001DF0" Offset="0x1DF0" />
-        <Animation Name="object_zm_Anim_0022C8" Offset="0x22C8" />
-        <Animation Name="object_zm_Anim_0028B8" Offset="0x28B8" />
-        <Animation Name="object_zm_Anim_002F20" Offset="0x2F20" />
-        <Animation Name="object_zm_Anim_003AA8" Offset="0x3AA8" />
+        <Animation Name="object_zm_Anim_000C80" Offset="0xC80" /> <!-- Original name is "zM_aisatsu" -->
+        <Animation Name="object_zm_Anim_001324" Offset="0x1324" /> <!-- Original name is "zM_furimuki" -->
+        <Animation Name="object_zm_Anim_0016A4" Offset="0x16A4" /> <!-- Original name is "zM_furimuki2wait" -->
+        <Animation Name="object_zm_Anim_001DF0" Offset="0x1DF0" /> <!-- Original name is "zM_maru" -->
+        <Animation Name="object_zm_Anim_0022C8" Offset="0x22C8" /> <!-- Original name is "zM_ok2furimuki" -->
+        <Animation Name="object_zm_Anim_0028B8" Offset="0x28B8" /> <!-- Original name is "zM_suwaritalk01" -->
+        <Animation Name="object_zm_Anim_002F20" Offset="0x2F20" /> <!-- Original name is "zM_suwaritalk02" -->
+        <Animation Name="object_zm_Anim_003AA8" Offset="0x3AA8" /> <!-- Original name is "zM_suwariwait" -->
         <DList Name="object_zm_DL_0063A0" Offset="0x63A0" />
         <DList Name="object_zm_DL_0066D0" Offset="0x66D0" />
         <DList Name="object_zm_DL_006898" Offset="0x6898" />
@@ -56,9 +56,9 @@
         <Limb Name="object_zm_Standardlimb_00A91C" Type="Standard" EnumName="OBJECT_ZM_LIMB_10" Offset="0xA91C" />
         <Limb Name="object_zm_Standardlimb_00A928" Type="Standard" EnumName="OBJECT_ZM_LIMB_11" Offset="0xA928" />
         <Skeleton Name="object_zm_Skel_00A978" Type="Flex" LimbType="Standard" LimbNone="OBJECT_ZM_LIMB_NONE" LimbMax="OBJECT_ZM_LIMB_MAX" EnumName="ObjectZmLimb" Offset="0xA978" />
-        <Animation Name="object_zm_Anim_00B3E0" Offset="0xB3E0" />
-        <Animation Name="object_zm_Anim_00B894" Offset="0xB894" />
-        <Animation Name="object_zm_Anim_00BC08" Offset="0xBC08" />
-        <Animation Name="object_zm_Anim_00C880" Offset="0xC880" />
+        <Animation Name="object_zm_Anim_00B3E0" Offset="0xB3E0" /> <!-- Original name is "zM_talk" -->
+        <Animation Name="object_zm_Anim_00B894" Offset="0xB894" /> <!-- Original name is "zM_talk01TOtalk02" -->
+        <Animation Name="object_zm_Anim_00BC08" Offset="0xBC08" /> <!-- Original name is "zM_talk02TOtalk01" -->
+        <Animation Name="object_zm_Anim_00C880" Offset="0xC880" /> <!-- Original name is "zM_wait" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zo.xml
+++ b/assets/xml/objects/object_zo.xml
@@ -2,10 +2,10 @@
     <!-- Object for the Zoras -->
     <File Name="object_zo" Segment="6">
         <!-- Animations -->
-        <Animation Name="gZoraHandsOnHipsTappingFootAnim" Offset="0x598" />
-        <Animation Name="gZoraArmsOpenAnim" Offset="0xD48" />
-        <Animation Name="gZoraThrowRupeeAnim" Offset="0x219C" />
-        <Animation Name="gZoraWalkAnim" Offset="0x2898" />
+        <Animation Name="gZoraHandsOnHipsTappingFootAnim" Offset="0x598" /> <!-- Original name is "ZS_z1" -->
+        <Animation Name="gZoraArmsOpenAnim" Offset="0xD48" /> <!-- Original name is "ZS_z2" -->
+        <Animation Name="gZoraThrowRupeeAnim" Offset="0x219C" /> <!-- Original name is "Zola_maku" -->
+        <Animation Name="gZoraWalkAnim" Offset="0x2898" /> <!-- Original name is "zo_aruku" -->
 
         <!-- Effects -->
         <Texture Name="gZoraBubbleTex" OutName="zora_bubble" Format="ia8" Width="16" Height="16" Offset="0x28B0" />
@@ -17,9 +17,9 @@
         <DList Name="gZoraSplashModelDL" Offset="0x2C10" />
 
         <!-- Animations -->
-        <Animation Name="gZoraSurfacingAnim" Offset="0x3610" />
-        <Animation Name="gZoraTreadingWaterAnim" Offset="0x4168" />
-        <Animation Name="gZoraIdleAnim" Offset="0x4248" />
+        <Animation Name="gZoraSurfacingAnim" Offset="0x3610" /> <!-- Original name is "zo_mizu_talk" -->
+        <Animation Name="gZoraTreadingWaterAnim" Offset="0x4168" /> <!-- Original name is "zo_mizuwait" -->
+        <Animation Name="gZoraIdleAnim" Offset="0x4248" /> <!-- Original name is "zo_riku_matsu" -->
 
         <!-- Textures -->
         <Texture Name="gZoraTLUT" OutName="zora_tlut" Format="rgba16" Width="16" Height="16" Offset="0x4260" />
@@ -84,13 +84,13 @@
         <DList Name="object_zo_DL_00D2B8" Offset="0xD2B8" />
 
         <!-- Animations -->
-        <Animation Name="gZoraStandAnim" Offset="0xDE20" />
-        <Animation Name="gZoraListenAnim" Offset="0xDF54" />
-        <Animation Name="gZoraRunAnim" Offset="0xE400" />
-        <Animation Name="gZoraBobHandAnim" Offset="0xEDF0" />
-        <Animation Name="gZoraSitAnim" Offset="0xF4E8" />
-        <Animation Name="gZoraFixSpeakerStartAnim" Offset="0xFDF0" />
-        <Animation Name="gZoraFixSpeakerLoopAnim" Offset="0x10B18" />
-        <Animation Name="gZoraFixSpeakerEndAnim" Offset="0x11424" />
+        <Animation Name="gZoraStandAnim" Offset="0xDE20" /> <!-- Original name is "zo_wait02" -->
+        <Animation Name="gZoraListenAnim" Offset="0xDF54" /> <!-- Original name is "zora_kiku" -->
+        <Animation Name="gZoraRunAnim" Offset="0xE400" /> <!-- Original name is "zora_run" -->
+        <Animation Name="gZoraBobHandAnim" Offset="0xEDF0" /> <!-- Original name is "zora_rythm_loop" -->
+        <Animation Name="gZoraSitAnim" Offset="0xF4E8" /> <!-- Original name is "zora_suwari_wait" -->
+        <Animation Name="gZoraFixSpeakerStartAnim" Offset="0xFDF0" /> <!-- Original name is "zora_syagami" -->
+        <Animation Name="gZoraFixSpeakerLoopAnim" Offset="0x10B18" /> <!-- Original name is "zora_syagami_loop" -->
+        <Animation Name="gZoraFixSpeakerEndAnim" Offset="0x11424" /> <!-- Original name is "zora_syagami_modori" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zob.xml
+++ b/assets/xml/objects/object_zob.xml
@@ -1,13 +1,13 @@
 ﻿<Root>
     <File Name="object_zob" Segment="6">
-        <Animation Name="object_zob_Anim_001FD4" Offset="0x1FD4" />
-        <Animation Name="object_zob_Anim_0027D0" Offset="0x27D0" />
-        <Animation Name="object_zob_Anim_002B38" Offset="0x2B38" />
-        <Animation Name="object_zob_Anim_0037A0" Offset="0x37A0" />
-        <Animation Name="object_zob_Anim_0043C4" Offset="0x43C4" />
-        <Animation Name="object_zob_Anim_005224" Offset="0x5224" />
-        <Animation Name="object_zob_Anim_005E90" Offset="0x5E90" />
-        <Animation Name="object_zob_Anim_006998" Offset="0x6998" />
+        <Animation Name="object_zob_Anim_001FD4" Offset="0x1FD4" /> <!-- Original name is "jb_ensou_loop" -->
+        <Animation Name="object_zob_Anim_0027D0" Offset="0x27D0" /> <!-- Original name is "zB_play01" -->
+        <Animation Name="object_zob_Anim_002B38" Offset="0x2B38" /> <!-- Original name is "zB_play02" -->
+        <Animation Name="object_zob_Anim_0037A0" Offset="0x37A0" /> <!-- Original name is "zB_talk01" -->
+        <Animation Name="object_zob_Anim_0043C4" Offset="0x43C4" /> <!-- Original name is "zB_talk02" -->
+        <Animation Name="object_zob_Anim_005224" Offset="0x5224" /> <!-- Original name is "zB_talk03" -->
+        <Animation Name="object_zob_Anim_005E90" Offset="0x5E90" /> <!-- Original name is "zB_talk04" -->
+        <Animation Name="object_zob_Anim_006998" Offset="0x6998" /> <!-- Original name is "zB_wait01" -->
         <DList Name="object_zob_DL_00A700" Offset="0xA700" />
         <DList Name="object_zob_DL_00A880" Offset="0xA880" />
         <DList Name="object_zob_DL_00AA58" Offset="0xAA58" />
@@ -68,6 +68,6 @@
         <Limb Name="object_zob_Standardlimb_01079C" Type="Standard" EnumName="OBJECT_ZOB_LIMB_16" Offset="0x1079C" />
         <Limb Name="object_zob_Standardlimb_0107A8" Type="Standard" EnumName="OBJECT_ZOB_LIMB_17" Offset="0x107A8" />
         <Skeleton Name="object_zob_Skel_010810" Type="Flex" LimbType="Standard" LimbNone="OBJECT_ZOB_LIMB_NONE" LimbMax="OBJECT_ZOB_LIMB_MAX" EnumName="ObjectZobLimb" Offset="0x10810" />
-        <Animation Name="object_zob_Anim_011144" Offset="0x11144" />
+        <Animation Name="object_zob_Anim_011144" Offset="0x11144" /> <!-- Original name is "zB_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zod.xml
+++ b/assets/xml/objects/object_zod.xml
@@ -2,10 +2,10 @@
     <!-- Assets for Tijo, the drummer of The Indigo-Go's. -->
     <File Name="object_zod" Segment="6">
         <!-- Tijo Animations -->
-        <Animation Name="gTijoPlayingVivaceAnim" Offset="0x2E8" />
-        <Animation Name="gTijoReadyToPlayAnim" Offset="0x894" />
-        <Animation Name="gTijoArmsFoldedAnim" Offset="0xA9C" />
-        <Animation Name="gTijoPlayingLentoAnim" Offset="0xD94" />
+        <Animation Name="gTijoPlayingVivaceAnim" Offset="0x2E8" /> <!-- Original name is "zD_jitabata" -->
+        <Animation Name="gTijoReadyToPlayAnim" Offset="0x894" /> <!-- Original name is "zD_tokuige" -->
+        <Animation Name="gTijoArmsFoldedAnim" Offset="0xA9C" /> <!-- Original name is "zD_udegumi" -->
+        <Animation Name="gTijoPlayingLentoAnim" Offset="0xD94" /> <!-- Original name is "zD_wait01" -->
 
         <!-- Tijo DisplayLists -->
         <DList Name="gTijoLowerBodyChairDL" Offset="0x39A0" />
@@ -65,6 +65,6 @@
         <Skeleton Name="gTijoSkel" Type="Flex" LimbType="Standard" LimbNone="TIJO_LIMB_NONE" LimbMax="TIJO_LIMB_MAX" EnumName="TijoLimb" Offset="0xD658" />
 
         <!-- Tijo Andantino Animation -->
-        <Animation Name="gTijoPlayingAndantinoAnim" Offset="0xD9B0" />
+        <Animation Name="gTijoPlayingAndantinoAnim" Offset="0xD9B0" /> <!-- Original name is "zD_wait02" -->
     </File>
 </Root>

--- a/assets/xml/objects/object_zog.xml
+++ b/assets/xml/objects/object_zog.xml
@@ -1,16 +1,16 @@
 ﻿<Root>
     <File Name="object_zog" Segment="6">
-        <Animation Name="object_zog_Anim_001000" Offset="0x1000" />
-        <Animation Name="object_zog_Anim_001970" Offset="0x1970" />
-        <Animation Name="object_zog_Anim_002344" Offset="0x2344" />
-        <Animation Name="object_zog_Anim_002894" Offset="0x2894" />
-        <Animation Name="object_zog_Anim_0030E0" Offset="0x30E0" />
-        <Animation Name="object_zog_Anim_0037F8" Offset="0x37F8" />
-        <Animation Name="object_zog_Anim_0041D0" Offset="0x41D0" />
-        <Animation Name="object_zog_Anim_004BDC" Offset="0x4BDC" />
-        <Animation Name="object_zog_Anim_0055B4" Offset="0x55B4" />
+        <Animation Name="object_zog_Anim_001000" Offset="0x1000" /> <!-- Original name is "mikau_aruku" -->
+        <Animation Name="object_zog_Anim_001970" Offset="0x1970" /> <!-- Original name is "mikau_aruku_loop" -->
+        <Animation Name="object_zog_Anim_002344" Offset="0x2344" /> <!-- Original name is "mikau_dream_loop" -->
+        <Animation Name="object_zog_Anim_002894" Offset="0x2894" /> <!-- Original name is "mikau_oya" -->
+        <Animation Name="object_zog_Anim_0030E0" Offset="0x30E0" /> <!-- Original name is "mikau_oya_loop" -->
+        <Animation Name="object_zog_Anim_0037F8" Offset="0x37F8" /> <!-- Original name is "mikau_ruru" -->
+        <Animation Name="object_zog_Anim_0041D0" Offset="0x41D0" /> <!-- Original name is "mikau_ruru_loop" -->
+        <Animation Name="object_zog_Anim_004BDC" Offset="0x4BDC" /> <!-- Original name is "mikau_tyakuchi" -->
+        <Animation Name="object_zog_Anim_0055B4" Offset="0x55B4" /> <!-- Original name is "mikau_tyakuchi_loop" -->
         <DList Name="gMikauGraveDirtDL" Offset="0x69F0" />
-        <DList Name="gMikauGraveDL" Offset="0x6AA0" />
+        <DList Name="gMikauGraveDL" Offset="0x6AA0" /> <!-- Original name is "z2_30_haka_model" -->
         <Texture Name="gMikauGraveDirtTex" OutName="mikau_grave_dirt" Format="rgba16" Width="16" Height="32" Offset="0x6FD0" />
         <Texture Name="gMikauGraveJawTex" OutName="mikau_grave_jaw" Format="rgba16" Width="16" Height="16" Offset="0x73D0" />
         <Texture Name="gMikauGraveEyeTex" OutName="mikau_grave_eye" Format="rgba16" Width="16" Height="16" Offset="0x75D0" />
@@ -19,29 +19,29 @@
         <Texture Name="gMikauGraveBoneTex" OutName="mikau_grave_bone" Format="rgba16" Width="16" Height="32" Offset="0x7DD0" />
         <Texture Name="gMikauGraveWoodenStickTex" OutName="mikau_grave_wooden_stick" Format="rgba16" Width="32" Height="8" Offset="0x81D0" />
         <Texture Name="gMikauGraveCordTex" OutName="mikau_grave_cord" Format="rgba16" Width="16" Height="8" Offset="0x83D0" />
-        <Collision Name="gMikauGraveCol" Offset="0x8670" />
-        <Animation Name="object_zog_Anim_008EB8" Offset="0x8EB8" />
-        <Animation Name="object_zog_Anim_00931C" Offset="0x931C" />
-        <Animation Name="object_zog_Anim_0099A4" Offset="0x99A4" />
-        <Animation Name="object_zog_Anim_009EC4" Offset="0x9EC4" />
-        <Animation Name="object_zog_Anim_00B01C" Offset="0xB01C" />
-        <Animation Name="object_zog_Anim_00BF38" Offset="0xBF38" />
-        <Animation Name="object_zog_Anim_00CA94" Offset="0xCA94" />
-        <Animation Name="object_zog_Anim_00ECBC" Offset="0xECBC" />
-        <Animation Name="object_zog_Anim_00F110" Offset="0xF110" />
-        <Animation Name="object_zog_Anim_00FC0C" Offset="0xFC0C" />
-        <Animation Name="object_zog_Anim_0106B0" Offset="0x106B0" />
-        <Animation Name="object_zog_Anim_014B10" Offset="0x14B10" />
-        <Animation Name="object_zog_Anim_01579C" Offset="0x1579C" />
-        <Animation Name="object_zog_Anim_015B80" Offset="0x15B80" />
-        <Animation Name="object_zog_Anim_0166F4" Offset="0x166F4" />
-        <Animation Name="object_zog_Anim_017170" Offset="0x17170" />
-        <Animation Name="object_zog_Anim_018600" Offset="0x18600" />
-        <Animation Name="object_zog_Anim_01A06C" Offset="0x1A06C" />
-        <Animation Name="object_zog_Anim_01A990" Offset="0x1A990" />
-        <Animation Name="object_zog_Anim_01AD58" Offset="0x1AD58" />
-        <Animation Name="object_zog_Anim_01B72C" Offset="0x1B72C" />
-        <Animation Name="object_zog_Anim_01BC88" Offset="0x1BC88" />
+        <Collision Name="gMikauGraveCol" Offset="0x8670" /> <!-- Original name is "z2_30_haka_bgdatainfo" -->
+        <Animation Name="object_zog_Anim_008EB8" Offset="0x8EB8" /> <!-- Original name is "zG_guiter1L" -->
+        <Animation Name="object_zog_Anim_00931C" Offset="0x931C" /> <!-- Original name is "zG_guiter2L" -->
+        <Animation Name="object_zog_Anim_0099A4" Offset="0x99A4" /> <!-- Original name is "zG_guter1L2guiter2L" -->
+        <Animation Name="object_zog_Anim_009EC4" Offset="0x9EC4" /> <!-- Original name is "zG_guter2L2guiter1L" -->
+        <Animation Name="object_zog_Anim_00B01C" Offset="0xB01C" /> <!-- Original name is "zG_jya_n" -->
+        <Animation Name="object_zog_Anim_00BF38" Offset="0xBF38" /> <!-- Original name is "zG_jya_n2neruL" -->
+        <Animation Name="object_zog_Anim_00CA94" Offset="0xCA94" /> <!-- Original name is "zG_neruL" -->
+        <Animation Name="object_zog_Anim_00ECBC" Offset="0xECBC" /> <!-- Original name is "zG_neruL2guiter1L" -->
+        <Animation Name="object_zog_Anim_00F110" Offset="0xF110" /> <!-- Original name is "zG_neruL2talkinlandL" -->
+        <Animation Name="object_zog_Anim_00FC0C" Offset="0xFC0C" /> <!-- Original name is "zG_oboreL" -->
+        <Animation Name="object_zog_Anim_0106B0" Offset="0x106B0" /> <!-- Original name is "zG_oboreL2talkinwater" -->
+        <Animation Name="object_zog_Anim_014B10" Offset="0x14B10" /> <!-- Original name is "zG_standup" -->
+        <Animation Name="object_zog_Anim_01579C" Offset="0x1579C" /> <!-- Original name is "zG_talkinlandL" -->
+        <Animation Name="object_zog_Anim_015B80" Offset="0x15B80" /> <!-- Original name is "zG_talkinlandL2neruL" -->
+        <Animation Name="object_zog_Anim_0166F4" Offset="0x166F4" /> <!-- Original name is "zG_talkinwaterL" -->
+        <Animation Name="object_zog_Anim_017170" Offset="0x17170" /> <!-- Original name is "zG_talkinwaterL2obore" -->
+        <Animation Name="object_zog_Anim_018600" Offset="0x18600" /> <!-- Original name is "zG_walkL" -->
+        <Animation Name="object_zog_Anim_01A06C" Offset="0x1A06C" /> <!-- Original name is "zG_walkL2neruL" -->
+        <Animation Name="object_zog_Anim_01A990" Offset="0x1A990" /> <!-- Original name is "zG_yuurei_talk" -->
+        <Animation Name="object_zog_Anim_01AD58" Offset="0x1AD58" /> <!-- Original name is "zG_yuurei_talk2wait" -->
+        <Animation Name="object_zog_Anim_01B72C" Offset="0x1B72C" /> <!-- Original name is "zG_yuurei_wait" -->
+        <Animation Name="object_zog_Anim_01BC88" Offset="0x1BC88" /> <!-- Original name is "zG_yuurei_wait2talk" -->
         <DList Name="object_zog_DL_01F830" Offset="0x1F830" />
         <DList Name="object_zog_DL_01F9A8" Offset="0x1F9A8" />
         <DList Name="object_zog_DL_01FB40" Offset="0x1FB40" />

--- a/assets/xml/objects/object_zoraband.xml
+++ b/assets/xml/objects/object_zoraband.xml
@@ -1,7 +1,7 @@
 ﻿<Root>
     <File Name="object_zoraband" Segment="6">
-        <DList Name="object_zoraband_DL_000180" Offset="0x180" />
-        <DList Name="object_zoraband_DL_0002A8" Offset="0x2A8" />
+        <DList Name="object_zoraband_DL_000180" Offset="0x180" /> <!-- Original name is "sl_zoraband_modelT" -->
+        <DList Name="object_zoraband_DL_0002A8" Offset="0x2A8" /> <!-- Original name is "sl_zoraband_model" -->
         <Texture Name="object_zoraband_Tex_000330" OutName="tex_000330" Format="i8" Width="32" Height="32" Offset="0x330" />
         <Texture Name="object_zoraband_Tex_000730" OutName="tex_000730" Format="i8" Width="32" Height="32" Offset="0x730" />
         <Texture Name="object_zoraband_Tex_000B30" OutName="tex_000B30" Format="i8" Width="32" Height="32" Offset="0xB30" />

--- a/assets/xml/objects/object_zoraegg.xml
+++ b/assets/xml/objects/object_zoraegg.xml
@@ -2,8 +2,8 @@
     <!-- Object for Zora Baby and Zora Egg -->
     <File Name="object_zoraegg" Segment="6">
         <!-- The animations when all the eggs hatch and the Zora babies swim up -->
-        <Animation Name="gZoraBabySwimUpAnim" Offset="0x5D4" />
-        <Animation Name="gZoraBabyHatchAnim" Offset="0x1E08" />
+        <Animation Name="gZoraBabySwimUpAnim" Offset="0x5D4" /> <!-- Original name is "zb_ebioyogi" -->
+        <Animation Name="gZoraBabyHatchAnim" Offset="0x1E08" /> <!-- Original name is "zb_fuka" -->
         
         <!-- Zora Baby Dlists -->
         <DList Name="gZoraBabyHeadDL" Offset="0x2550" />
@@ -35,10 +35,10 @@
         <Skeleton Name="gZoraBabySkel" Type="Flex" LimbType="Standard" LimbNone="ZORA_BABY_LIMB_NONE" LimbMax="ZORA_BABY_LIMB_MAX" EnumName="ZoraBabyLimb" Offset="0x4C90" />
         
         <!-- Animations -->
-        <Animation Name="gZoraBabyFormNoteAnim" Offset="0x4D20" />
-        <Animation Name="gZoraBabySongLearnedAnim" Offset="0x4E04" />
-        <Animation Name="gZoraBabyNoteAnim" Offset="0x4FE4" />
-        <Animation Name="gZoraBabySwimAnim" Offset="0x5098" />
+        <Animation Name="gZoraBabyFormNoteAnim" Offset="0x4D20" /> <!-- Original name is "zb_onpu" -->
+        <Animation Name="gZoraBabySongLearnedAnim" Offset="0x4E04" /> <!-- Original name is "zb_onpuhappy" -->
+        <Animation Name="gZoraBabyNoteAnim" Offset="0x4FE4" /> <!-- Original name is "zb_onpuwait" -->
+        <Animation Name="gZoraBabySwimAnim" Offset="0x5098" /> <!-- Original name is "zb_pichi" -->
         
         <!-- Zora Egg -->
         <DList Name="gZoraEggDL" Offset="0x5250" />

--- a/assets/xml/objects/object_zov.xml
+++ b/assets/xml/objects/object_zov.xml
@@ -3,18 +3,18 @@
     <File Name="object_zov" Segment="6">
 
         <!-- Lulu Animations -->
-        <Animation Name="gLuluTurnAndWalkAnim" Offset="0x17D4" />
-        <Animation Name="gLuluWalkLoopAnim" Offset="0x23F4" />
-        <Animation Name="gLuluSingStartAnim" Offset="0x2B5C" />
-        <Animation Name="gLuluSingLoopAnim" Offset="0x418C" />
-        <Animation Name="gLuluLookForwardAndLeftAnim" Offset="0x5A6C" />
-        <Animation Name="gLuluLookLeftLoopAnim" Offset="0x66A4" />
-        <Animation Name="gLuluPutHandsDownAnim" Offset="0x8120" />
-        <Animation Name="gLuluLookAroundAnim" Offset="0xA888" />
-        <Animation Name="gLuluLookForwardAndDownAnim" Offset="0xB4CC" />
-        <Animation Name="gLuluAngleHeadAnim" Offset="0xC510" />
-        <Animation Name="gLuluNodAnim" Offset="0xCAA8" />
-        <Animation Name="gLuluLookDownAnim" Offset="0xD3EC" />
+        <Animation Name="gLuluTurnAndWalkAnim" Offset="0x17D4" /> <!-- Original name is "ruru_aruku" -->
+        <Animation Name="gLuluWalkLoopAnim" Offset="0x23F4" /> <!-- Original name is "ruru_aruku_loop" -->
+        <Animation Name="gLuluSingStartAnim" Offset="0x2B5C" /> <!-- Original name is "ruru_utau" -->
+        <Animation Name="gLuluSingLoopAnim" Offset="0x418C" /> <!-- Original name is "ruru_utau_loop" -->
+        <Animation Name="gLuluLookForwardAndLeftAnim" Offset="0x5A6C" /> <!-- Original name is "ruru_yokomuku" -->
+        <Animation Name="gLuluLookLeftLoopAnim" Offset="0x66A4" /> <!-- Original name is "ruru_yokomuku_loop" -->
+        <Animation Name="gLuluPutHandsDownAnim" Offset="0x8120" /> <!-- Original name is "zV_hokan2wait02" -->
+        <Animation Name="gLuluLookAroundAnim" Offset="0xA888" /> <!-- Original name is "zV_kyoro2talk02" -->
+        <Animation Name="gLuluLookForwardAndDownAnim" Offset="0xB4CC" /> <!-- Original name is "zV_talk01" -->
+        <Animation Name="gLuluAngleHeadAnim" Offset="0xC510" /> <!-- Original name is "zV_talk03" -->
+        <Animation Name="gLuluNodAnim" Offset="0xCAA8" /> <!-- Original name is "zV_talk04" -->
+        <Animation Name="gLuluLookDownAnim" Offset="0xD3EC" /> <!-- Original name is "zV_wait01" -->
 
         <!-- Lulu Limb DLists -->
         <DList Name="gLuluTorsoDL" Offset="0x107B0" />

--- a/src/overlays/actors/ovl_En_Yb/z_en_yb.c
+++ b/src/overlays/actors/ovl_En_Yb/z_en_yb.c
@@ -64,8 +64,6 @@ static ColliderCylinderInit sCylinderInit = {
     { 20, 40, 0, { 0, 0, 0 } },
 };
 
-// crashes if I try to mod it in to look at it
-//  assumption: draw uses two different skeleton functions, might be incompatible
 static AnimationHeader* gYbUnusedAnimations[] = { &object_yb_Anim_000200 };
 
 static PlayerAnimationHeader* gPlayerAnimations[] = {


### PR DESCRIPTION
This wraps up this type of work for every `object_*` file. There are still the assets in overlays and in the `*_keep` files remaining. Some notes on this PR:
- I saw a note in `object_yb` stating that a particular animation doesn't work in Z64Utils. This was a little strange to me, since it worked fine for me, so I just removed the comment. You can see it load just fine here:
![kihon](https://github.com/user-attachments/assets/2a3c58ac-d5fe-42bd-9f62-7fca7200c8f3)
- Similarly, there was a comment in `z_en_yb.c` saying that loading that animation in-game crashes. Again, this was strange to me, since it worked fine for me, so I again just removed the comment. I just changed `EnYb_ChangeAnim(play, this, 2, ANIMMODE_LOOP, 0.0f)` to `EnYb_ChangeAnim(play, this, 0, ANIMMODE_LOOP, 0.0f)` and it worked as expected. Here's a video of it in action:

https://github.com/user-attachments/assets/dbf58fd5-57ef-493c-9e6c-8c12158039e3
- While I was in `object_yb`, I took a look at the blobs and figured them out. They're just vertices. I copied the comment from `object_bigpo` and slightly tweaked it, because similar to that file, the unused vertices were probably just combined with the rest of Kamaro's vertices.
- For `object_zl1` and `object_zl4`, MM3D combined them both into a single `zelda2_zl.gar.lzs`. I needed to use OoT3D's versions of the same assets to figure out a lot of these.
  - For `object_zl1`, it was easy enough to use OoT3D's `zelda_zl1.zar` to get all the animation names. 
  - For `object_zl4`, a lot of these animations were new to MM; the ones carried over from OoT could be grabbed from OoT3D's `zelda_zl4.zar`. For the ones new to MM, however, we have to use MM3D's object, and unfortunately all the unused animations are just T-poses in `zelda2_zl.gar.lzs`, making it a bit tricky to figure out which animation is which. However, we can be fairly confident that I got the names right, as not only are the animations arranged in alphabetic order (besides `demo_onegai2_wait` coming before `demo_onegai_wait`, not sure what happened there), but the Japanese names are fairly unambiguous ("bakutyu" means "backflip" for example; it's pretty easy to tell which animation that one is associated with).
- While I was in `object_zl1`, I fixed a typo in one of the animation names.
- While I was in `object_zl4`, I noticed one of the animations was out of order, so I moved it back to be in the correct order (it also makes the original animation names alphabetical, which is a secondary but still nice thing).

