### PR TITLE
Add original asset names to all assets present in overlays

### DIFF
--- a/assets/xml/overlays/ovl_Arrow_Fire.xml
+++ b/assets/xml/overlays/ovl_Arrow_Fire.xml
@@ -2,11 +2,10 @@
     <File Name="ovl_Arrow_Fire" BaseAddress="0x80920340" RangeStart="0xAB0" RangeEnd="0x1ED0">
         <Texture Name="gFireArrowMaskTex" OutName="fire_arrow_mask" Format="i8" Width="32" Height="64" Offset="0x12B0"/>
         <Texture Name="gFireArrowTex" OutName="fire_arrow" Format="i8" Width="32" Height="64" Offset="0xAB0"/>
-
         <Array Name="gFireArrowVtx" Count="43" Offset="0x1AB0">
             <Vtx/>
         </Array>
         <DList Name="gFireArrowMaterialDL" Offset="0x1D60"/>
-        <DList Name="gFireArrowModelDL" Offset="0x1E10"/>
+        <DList Name="gFireArrowModelDL" Offset="0x1E10"/> <!-- Original name might be "m_arrow_modelT_fire" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Ice.xml
+++ b/assets/xml/overlays/ovl_Arrow_Ice.xml
@@ -7,6 +7,6 @@
             <Vtx/>
         </Array>
         <DList Name="gIceArrowMaterialDL" Offset="0x1C30"/>
-        <DList Name="gIceArrowModelDL" Offset="0x1CE0"/>
+        <DList Name="gIceArrowModelDL" Offset="0x1CE0"/> <!-- Original name might be "m_arrow_modelT_ice" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Arrow_Light.xml
+++ b/assets/xml/overlays/ovl_Arrow_Light.xml
@@ -1,13 +1,11 @@
 <Root>
-  <File Name="ovl_Arrow_Light" BaseAddress="0x80924300" RangeStart="0x960" RangeEnd="0x1D80">
-    
-    <Texture Name="gLightArrowTex" OutName="light_arrow" Format="i8" Width="32" Height="64" Offset="0x960"/>
-    <Texture Name="gLightArrowMaskTex" OutName="light_arrow_mask" Format="i8" Width="32" Height="64" Offset="0x1160"/>
-    <Array Name="gLightArrowVtx" Count="43" Offset="0x1960">
-      <Vtx/>
-    </Array>
-    
-    <DList Name="gLightArrowMaterialDL" Offset="0x1C10"/>
-    <DList Name="gLightArrowModelDL" Offset="0x1CC0"/>
-  </File>
+    <File Name="ovl_Arrow_Light" BaseAddress="0x80924300" RangeStart="0x960" RangeEnd="0x1D80">
+        <Texture Name="gLightArrowTex" OutName="light_arrow" Format="i8" Width="32" Height="64" Offset="0x960"/>
+        <Texture Name="gLightArrowMaskTex" OutName="light_arrow_mask" Format="i8" Width="32" Height="64" Offset="0x1160"/>
+        <Array Name="gLightArrowVtx" Count="43" Offset="0x1960">
+          <Vtx/>
+        </Array>
+        <DList Name="gLightArrowMaterialDL" Offset="0x1C10"/>
+        <DList Name="gLightArrowModelDL" Offset="0x1CC0"/> <!-- Original name might be "m_arrow_modelT_light" -->
+    </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Bom.xml
+++ b/assets/xml/overlays/ovl_En_Bom.xml
@@ -10,11 +10,11 @@
         <!-- Textures and DisplayList for the Powder Keg -->
         <Texture Name="gPowderKegBarrelTLUT" OutName="powder_keg_barrel_tlut" Format="rgba16" Width="16" Height="16" Offset="0x22B0"/>
         <Texture Name="gPowderKegBarrelTex" OutName="powder_keg_barrel" Format="ci8" Width="32" Height="32" Offset="0x24B0"/>
-        <DList Name="gPowderKegBarrelDL" Offset="0x2EF0"/>
+        <DList Name="gPowderKegBarrelDL" Offset="0x2EF0"/> <!-- Original name is "bb_model_model" -->
 
         <!-- Textures and DisplayList for the Goron Skull on the side of the Powder Keg -->
         <Texture Name="gPowderKegGoronSkullTLUT" OutName="powder_keg_goron_skull_tlut" Format="rgba16" Width="16" Height="16" Offset="0x3048"/>
         <Texture Name="gPowderKegGoronSkullTex" OutName="powder_keg_goron_skull" Format="ci8" Width="16" Height="32" Offset="0x3248"/>
-        <DList Name="gPowderKegGoronSkullDL" Offset="0x3548"/>
+        <DList Name="gPowderKegGoronSkullDL" Offset="0x3548"/> <!-- Original name is "bb_relief_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Clear_Tag.xml
+++ b/assets/xml/overlays/ovl_En_Clear_Tag.xml
@@ -13,7 +13,7 @@
         <DList Name="gClearTagFireEffectMaterialDL" Offset="0x37F8"/>
         <Texture Name="gClearTagFireEffectFlickerTex" OutName="clear_tag_fire_effect_flicker" Format="i4" Width="32" Height="64" Offset="0x31C8"/>
         <Texture Name="gClearTagFireEffectBackgroundTex" OutName="clear_tag_fire_effect_background" Format="i4" Width="32" Height="32" Offset="0x35C8"/>
-        <DList Name="gClearTagFireEffectDL" Offset="0x38A0"/>
+        <DList Name="gClearTagFireEffectDL" Offset="0x38A0"/> <!-- Original name might be "a_fireball_model" -->
         <Array Name="gClearTagFireEffectVtx" Count="3" Offset="0x37C8">
             <Vtx/>
         </Array>

--- a/assets/xml/overlays/ovl_En_Gakufu.xml
+++ b/assets/xml/overlays/ovl_En_Gakufu.xml
@@ -3,6 +3,6 @@
         <Array Name="gGakufuButtonIndexVtx" Count="4" Offset="0x8D0">
             <Vtx/>
         </Array>
-        <DList Name="gGakufuButtonIndexDL" Offset="0x910"/>
+        <DList Name="gGakufuButtonIndexDL" Offset="0x910"/> <!-- Original name might be "en_gakufu_draw_common" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Holl.xml
+++ b/assets/xml/overlays/ovl_En_Holl.xml
@@ -4,6 +4,6 @@
             <Vtx/>
         </Array>
 
-        <DList Name="gEnHollCentralPlaneDL" Offset="0x0C30"/>
+        <DList Name="gEnHollCentralPlaneDL" Offset="0x0C30"/> <!-- Original name might be "holl" or "opaque_holl" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Horse_Game_Check.xml
+++ b/assets/xml/overlays/ovl_En_Horse_Game_Check.xml
@@ -1,5 +1,5 @@
 <Root>
     <File Name="ovl_En_Horse_Game_Check" BaseAddress="0x808F8AA0" RangeStart="0x1080" RangeEnd="0x10F4">
-        <Collision Name="ovl_En_Horse_Game_Check_Colheader_0010C8" Offset="0x10C8" />
+        <Collision Name="ovl_En_Horse_Game_Check_Colheader_0010C8" Offset="0x10C8" /> <!-- Original name is "nukarumi_bgdatainfo" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_En_Tru.xml
+++ b/assets/xml/overlays/ovl_En_Tru.xml
@@ -12,7 +12,7 @@
         <Array Name="D_80A8A0C8" Count="4" Offset="0x4AA8">
             <Vtx/>
         </Array>
-        <DList Name="D_80A8A108" Offset="0x4AE8"/>
+        <DList Name="D_80A8A108" Offset="0x4AE8"/> <!-- Original name might be "tru_flash_model" -->
 
         <Texture Name="D_80A8A188" OutName="en_tru_4B68" Format="i8" Width="64" Height="64" Offset="0x4B68"/>
         <Array Name="D_80A8B188" Count="4" Offset="0x5B68">

--- a/assets/xml/overlays/ovl_Oceff_Spot.xml
+++ b/assets/xml/overlays/ovl_Oceff_Spot.xml
@@ -2,6 +2,6 @@
     <File Name="ovl_Oceff_Spot" BaseAddress="0x80972680" RangeStart="0x720" RangeEnd="0xDF8">
         <Texture Name="sSunSongEffectTex" OutName="sun_song_effect" Format="i8" Width="32" Height="32" Offset="0x720"/>
         <DList Name="sSunSongEffectCylinderMaterialDL" Offset="0xCD0"/>
-        <DList Name="sSunSongEffectCylinderModelDL" Offset="0xD68"/>
+        <DList Name="sSunSongEffectCylinderModelDL" Offset="0xD68"/> <!-- Original name might be "efc_ocarina_1_modelT" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Storm.xml
+++ b/assets/xml/overlays/ovl_Oceff_Storm.xml
@@ -7,6 +7,6 @@
             <Vtx/>
         </Array>
         <DList Name="sSongOfStormsCylinderMaterialDL" Offset="0x1A88"/>
-        <DList Name="sSongOfStormsCylinderModelDL" Offset="0x1B30"/>
+        <DList Name="sSongOfStormsCylinderModelDL" Offset="0x1B30"/> <!-- Original name might be "efc_ocarina_2_modelT" or "ocarina_storm_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe.xml
@@ -5,6 +5,6 @@
             <Vtx/>
         </Array>
         <DList Name="sSongOfTimeFrustumMaterialDL" Offset="0xB70"/>
-        <DList Name="sSongOfTimeFrustumModelDL" Offset="0xBF8"/>
+        <DList Name="sSongOfTimeFrustumModelDL" Offset="0xBF8"/> <!-- Original name might be "efc_ocarina_3_modelT" or "ocarina_time_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe2.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe2.xml
@@ -6,6 +6,6 @@
             <Vtx/>
         </Array>
         <DList Name="sEponaSongFrustumMaterialDL" Offset="0x1580"/>
-        <DList Name="sEponaSongFrustumModelDL" Offset="0x1628"/>
+        <DList Name="sEponaSongFrustumModelDL" Offset="0x1628"/> <!-- Original name might be "efc_ocarina_41_modelT" or "ocarina_epona_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe3.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe3.xml
@@ -5,6 +5,6 @@
             <Vtx/>
         </Array>
         <DList Name="sSariaSongFrustrumMaterialDL" Offset="0x1590"/>
-        <DList Name="sSariaSongFrustumModelDL" Offset="0x1618"/>
+        <DList Name="sSariaSongFrustumModelDL" Offset="0x1618"/> <!-- Original name might be "efc_ocarina_42_modelT" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe4.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe4.xml
@@ -7,6 +7,6 @@
         </Array>
         <DList Name="sScarecrowSongMaterialDL" Offset="0xD90"/>
         <DList Name="sScarecrowSongUnusedMaterialDL" Offset="0xDF8"/>
-        <DList Name="sScarecrowSongModelDL" Offset="0xE60"/>
+        <DList Name="sScarecrowSongModelDL" Offset="0xE60"/> <!-- Original name might be "efc_ocarina_5_modelT" or "ocarina_kakashi_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe5.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe5.xml
@@ -4,6 +4,6 @@
         <Array Name="gOceff5Vtx" Count="22" Offset="0x1450"> 
             <Vtx/>
         </Array>
-        <DList Name="gOceff5DL" Offset="0x15B0"/> 
+        <DList Name="gOceff5DL" Offset="0x15B0"/>  <!-- Original name might be "g1T_model" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe6.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe6.xml
@@ -4,6 +4,6 @@
         <Array Name="gOceff6Vtx" Count="22" Offset="0x340">
             <Vtx/>
         </Array>
-        <DList Name="gOceff6DL" Offset="0x4A0"/>
+        <DList Name="gOceff6DL" Offset="0x4A0"/> <!-- Original name might be "ocarina_wing_modelT" -->
     </File>
 </Root>

--- a/assets/xml/overlays/ovl_Oceff_Wipe7.xml
+++ b/assets/xml/overlays/ovl_Oceff_Wipe7.xml
@@ -5,6 +5,6 @@
         <Array Name="sSongofHealingEffectFrustrumVtx" Count="22" Offset="0xB40">
             <Vtx/>
         </Array>
-        <DList Name="sSongOfHealingEffectFrustumDL" Offset="0xCA0"/>
+        <DList Name="sSongOfHealingEffectFrustumDL" Offset="0xCA0"/> <!-- Original name might be "g1T_model2" -->
     </File>
 </Root>


### PR DESCRIPTION
A lot of these are "fuzzier" than the assets that were originally in object files; Grezzo tended to just shove a lot of this into `zelda2_keep.gar.lzs`, which is MM3D's equivalent of `gameplay_keep`, and it's a little less obvious if they kept the name while they were doing so or if they changed it. The Ocarina effects are a great example; in OoT3D, we can see that *every* Ocarina effect starts with `efc_ocarina_*`. In MM3D, they actually remade some of these assets, and in `zelda2_keep.gar.lzs`, they included both the OoT3D asset (as `efc_ocarina_*`) and the MM3D asset (as `ocarina_*_model`). So which one was originally used in MM? It's hard to say; I *suspect* it was `efc_ocarina_*`, since what reason would they have to change it for the reused effects? But that doesn't explain the Song of Soaring effect, which obviously wasn't present in OoT.

Also, while I was looking at `ovl_Arrow_Light`, I noticed that the indentation was different from basically every other XML file, so I made it consistent with the rest of the codebase.