### PR TITLE
Apply the NORETURN attribute to functions that do not return

### DIFF
--- a/include/attributes.h
+++ b/include/attributes.h
@@ -14,4 +14,10 @@
 #define NO_REORDER   __attribute__((no_reorder))
 #define SECTION_DATA __attribute__((section(".data")))
 
+#ifdef __GNUC__
+#define UNREACHABLE() __builtin_unreachable()
+#else
+#define UNREACHABLE()
+#endif
+
 #endif

--- a/include/fault.h
+++ b/include/fault.h
@@ -2,6 +2,7 @@
 #define FAULT_H
 
 #include "ultra64.h"
+#include "attributes.h"
 
 #include "stdarg.h"
 #include "stdint.h"
@@ -60,8 +61,8 @@ void Fault_Init(void);
 
 // Fatal Errors
 
-void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2);
-void Fault_AddHungupAndCrash(const char* file, s32 line);
+NORETURN void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2);
+NORETURN void Fault_AddHungupAndCrash(const char* file, s32 line);
 
 // Client Registration
 

--- a/include/functions.h
+++ b/include/functions.h
@@ -25,7 +25,7 @@ void Room_Draw(PlayState* play, Room* room, u32 flags);
 
 void Room_FinishRoomChange(PlayState* play, RoomContext* roomCtx);
 
-void func_80183070(void);
+NORETURN void func_80183070(void);
 
 AudioTask* AudioThread_Update(void);
 void AudioThread_QueueCmdF32(u32 opArgs, f32 data);

--- a/include/libu64/debug.h
+++ b/include/libu64/debug.h
@@ -1,7 +1,9 @@
 #ifndef LIBU64_DEBUG_H
 #define LIBU64_DEBUG_H
 
-void _dbg_hungup(const char* file, int lineNum);
-void Reset(void);
+#include "../attributes.h"
+
+NORETURN void _dbg_hungup(const char* file, int lineNum);
+NORETURN void Reset(void);
 
 #endif

--- a/src/boot/fault.c
+++ b/src/boot/fault.c
@@ -1114,19 +1114,23 @@ void Fault_HangupFaultClient(const char* exp1, const char* exp2) {
  * error occurs. The parameters specify two messages detailing the error, one
  * or both may be NULL.
  */
-void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2) {
+NORETURN void Fault_AddHungupAndCrashImpl(const char* exp1, const char* exp2) {
     FaultClient client;
     s32 pad;
 
     Fault_AddClient(&client, (void*)Fault_HangupFaultClient, (void*)exp1, (void*)exp2);
     *(u32*)0x11111111 = 0; // trigger an exception via unaligned memory access
+
+    // Since the above line triggers an exception and transfers execution to the fault handler
+    // this function does not return and the rest of the function is unreachable.
+    UNREACHABLE();
 }
 
 /**
  * Like `Fault_AddHungupAndCrashImpl`, however provides a fixed message containing
  * file and line number
  */
-void Fault_AddHungupAndCrash(const char* file, s32 line) {
+NORETURN void Fault_AddHungupAndCrash(const char* file, s32 line) {
     char msg[0x100];
 
     sprintf(msg, "HungUp %s:%d", file, line);

--- a/src/boot/libu64/debug.c
+++ b/src/boot/libu64/debug.c
@@ -1,11 +1,11 @@
 #include "global.h"
 #include "fault.h"
 
-void _dbg_hungup(const char* file, int lineNum) {
+NORETURN void _dbg_hungup(const char* file, int lineNum) {
     osGetThreadId(NULL);
     Fault_AddHungupAndCrash(file, lineNum);
 }
 
-void Reset(void) {
+NORETURN void Reset(void) {
     Fault_AddHungupAndCrash("Reset", 0);
 }

--- a/src/code/code_80183070.c
+++ b/src/code/code_80183070.c
@@ -1,6 +1,7 @@
 #include "libc64/sleep.h"
+#include "attributes.h"
 
-void func_80183070(void) {
+NORETURN void func_80183070(void) {
     for (;;) {
         msleep(1000);
     }


### PR DESCRIPTION
Some rationale in the corresponding OoT PR
https://github.com/zeldaret/oot/pull/1532
