### PR TITLE
Add missing ExternalFile tags to object_dmask and object_osn

### DIFF
--- a/assets/xml/objects/object_dmask.xml
+++ b/assets/xml/objects/object_dmask.xml
@@ -1,4 +1,7 @@
 ﻿<Root>
+    <!-- Dependencies -->
+    <ExternalFile XmlPath="objects/gameplay_keep.xml" OutPath="assets/objects/gameplay_keep/"/>
+
     <File Name="object_dmask" Segment="6">
         <Animation Name="object_dmask_Anim_00017C" Offset="0x17C" /> <!-- Original name is "gbm_fall" -->
         <Animation Name="object_dmask_Anim_0001A8" Offset="0x1A8" /> <!-- Original name is "gbm_normal" -->

--- a/assets/xml/objects/object_osn.xml
+++ b/assets/xml/objects/object_osn.xml
@@ -1,4 +1,7 @@
 ﻿<Root>
+    <!-- Dependencies -->
+    <ExternalFile XmlPath="objects/gameplay_keep.xml" OutPath="assets/objects/gameplay_keep/"/>
+
     <!-- Assets for the Happy Mask Salesman and the cutscene Deku Mask -->
     <File Name="object_osn" Segment="6">
         <!-- Happy Mask Salesman Animations -->


### PR DESCRIPTION
Skeletons in these objects have references to display lists in gameplay_keep, so they should rely on gameplay_keep as an ExternalFile.

Unfortunately though, adding these to the xmls do not appear to actually replace the hardcoded gameplay_keep pointers with symbols.. a ZAPD bug?
