### PR TITLE
Move gAudioTatumInit and gAudioHeapInitSizes to their own file, using data-with-rodata instead of const qualifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,15 @@ $(BUILD_DIR)/src/code/z_game_over.o: src/code/z_game_over.c
 	$(OBJDUMP_CMD)
 	$(RM_MDEBUG)
 
+# Incremental link audio/session_init data into rodata
+$(BUILD_DIR)/src/audio/session_init.o: src/audio/session_init.c $(BUILD_DIR)/assets/audio/soundfont_sizes.h $(BUILD_DIR)/assets/audio/sequence_sizes.h
+	$(CC_CHECK_COMP) $(CC_CHECK_FLAGS) $(IINC) $(CC_CHECK_WARNINGS) $(C_DEFINES) $(MIPS_BUILTIN_DEFS) -o $(@:.o=.tmp) $<
+	$(CC) -c $(CFLAGS) $(IINC) $(WARNINGS) $(C_DEFINES) $(MIPS_VERSION) $(ENDIAN) $(OPTFLAGS) -o $(@:.o=.tmp) $<
+	$(LD) -r -T linker_scripts/data_with_rodata.ld $(@:.o=.tmp) -o $@
+	@$(RM) $(@:.o=.tmp)
+	$(OBJDUMP_CMD)
+	$(RM_MDEBUG)
+
 $(SHIFTJIS_O_FILES): $(BUILD_DIR)/src/%.o: src/%.c
 	$(SHIFTJIS_CONV) -o $(@:.o=.enc.c) $<
 	$(CC_CHECK_COMP) $(CC_CHECK_FLAGS) $(IINC) $(CC_CHECK_WARNINGS) $(C_DEFINES) $(MIPS_BUILTIN_DEFS) -o $@ $(@:.o=.enc.c)
@@ -782,8 +791,6 @@ $(BUILD_DIR)/assets/audio/sequence_font_table.o: $(BUILD_DIR)/assets/audio/seque
 	$(AS) $(ASFLAGS) $< -o $@
 
 # make headers with file sizes and amounts
-
-$(BUILD_DIR)/src/audio/session_config.o: $(BUILD_DIR)/assets/audio/soundfont_sizes.h $(BUILD_DIR)/assets/audio/sequence_sizes.h
 
 $(BUILD_DIR)/assets/audio/soundfont_sizes.h: $(SOUNDFONT_O_FILES)
 	$(AFILE_SIZES) $@ NUM_SOUNDFONTS SOUNDFONT_SIZES .rodata $^

--- a/include/variables.h
+++ b/include/variables.h
@@ -37,7 +37,11 @@ extern AudioSpec gAudioSpecs[21];
 // rodata
 extern const u16 gAudioEnvironmentalSfx[];
 extern const s16 gAudioTatumInit[];
+#ifndef AVOID_UB
 extern const AudioHeapInitSizes gAudioHeapInitSizes;
+#else
+extern AudioHeapInitSizes gAudioHeapInitSizes;
+#endif
 extern AudioTable gSoundFontTable;
 extern u8 gSequenceFontTable[];
 extern u8 gSequenceTable[];

--- a/include/variables.h
+++ b/include/variables.h
@@ -36,12 +36,8 @@ extern AudioSpec gAudioSpecs[21];
 
 // rodata
 extern const u16 gAudioEnvironmentalSfx[];
-extern const s16 gAudioTatumInit[];
-#ifndef AVOID_UB
-extern const AudioHeapInitSizes gAudioHeapInitSizes;
-#else
+extern s16 gAudioTatumInit[];
 extern AudioHeapInitSizes gAudioHeapInitSizes;
-#endif
 extern AudioTable gSoundFontTable;
 extern u8 gSequenceFontTable[];
 extern u8 gSequenceTable[];
@@ -51,8 +47,6 @@ extern AudioTable gSampleBankTable;
 
 extern u64* gAudioSPDataPtr;
 extern u32 gAudioSPDataSize;
-
-extern AudioContext gAudioCtx; // at 0x80200C70
 
 // other segments
 extern Mtx D_01000000;

--- a/include/z64audio.h
+++ b/include/z64audio.h
@@ -261,4 +261,6 @@ typedef struct AudioContext {
     /* 0x81F4 */ UNK_TYPE1 unk_81F4[4];
 } AudioContext; // size = 0x81F8
 
+extern AudioContext gAudioCtx; // at 0x80200C70
+
 #endif

--- a/spec
+++ b/spec
@@ -771,6 +771,7 @@ beginseg
     include "$(BUILD_DIR)/src/audio/sfx.o"
     include "$(BUILD_DIR)/src/audio/sequence.o"
     include "$(BUILD_DIR)/src/audio/session_config.o"
+    include "$(BUILD_DIR)/src/audio/session_init.o"
     include "$(BUILD_DIR)/src/code/jpegutils.o"
     include "$(BUILD_DIR)/src/code/jpegdecoder.o"
     include "$(BUILD_DIR)/src/code/z_game_over.o"

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1339,14 +1339,7 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     }
 
     if (addr = AudioHeap_Alloc(&gAudioCtx.initPool, gAudioHeapInitSizes.permanentPoolSize), addr == NULL) {
-#ifndef AVOID_UB
-        // Cast away const from gAudioHeapInitSizes
-        *((size_t*)&gAudioHeapInitSizes.permanentPoolSize) = 0;
-#else
-        // Avoid UB: gAudioHeapInitSizes isn't really const since it is written to, so do not
-        // declare it as const.
         gAudioHeapInitSizes.permanentPoolSize = 0;
-#endif
     }
 
     AudioHeap_InitPool(&gAudioCtx.permanentPool, addr, gAudioHeapInitSizes.permanentPoolSize);

--- a/src/audio/lib/load.c
+++ b/src/audio/lib/load.c
@@ -1339,8 +1339,14 @@ void AudioLoad_Init(void* heap, size_t heapSize) {
     }
 
     if (addr = AudioHeap_Alloc(&gAudioCtx.initPool, gAudioHeapInitSizes.permanentPoolSize), addr == NULL) {
-        // cast away const from gAudioHeapInitSizes
-        *((u32*)&gAudioHeapInitSizes.permanentPoolSize) = 0;
+#ifndef AVOID_UB
+        // Cast away const from gAudioHeapInitSizes
+        *((size_t*)&gAudioHeapInitSizes.permanentPoolSize) = 0;
+#else
+        // Avoid UB: gAudioHeapInitSizes isn't really const since it is written to, so do not
+        // declare it as const.
+        gAudioHeapInitSizes.permanentPoolSize = 0;
+#endif
     }
 
     AudioHeap_InitPool(&gAudioCtx.permanentPool, addr, gAudioHeapInitSizes.permanentPoolSize);

--- a/src/audio/session_config.c
+++ b/src/audio/session_config.c
@@ -1,10 +1,4 @@
 #include "global.h"
-#include "buffers.h"
-#include "assets/audio/sequence_sizes.h"
-#include "assets/audio/soundfont_sizes.h"
-#define SFX_SEQ_SIZE Sequence_0_SIZE
-#define AMBIENCE_SEQ_SIZE Sequence_1_SIZE
-#define SFX_SOUNDFONTS_SIZE (Soundfont_0_SIZE + Soundfont_1_SIZE + Soundfont_2_SIZE)
 
 static s32 sBssPad[36];
 AudioContext gAudioCtx;
@@ -13,33 +7,6 @@ AudioCustomSeqFunction gAudioCustomSeqFunction;
 AudioCustomReverbFunction gAudioCustomReverbFunction;
 AudioCustomSynthFunction gAudioCustomSynthFunction;
 static s32 sBssPad2[3];
-
-const s16 gAudioTatumInit[] = {
-    0x1C00,          // unused
-    TATUMS_PER_BEAT, // gTatumsPerBeat
-};
-
-// Sizes of everything on the init pool
-#define AI_BUFFERS_SIZE (AIBUF_SIZE * ARRAY_COUNT(gAudioCtx.aiBuffers))
-#define SOUNDFONT_LIST_SIZE (NUM_SOUNDFONTS * sizeof(SoundFont))
-
-// 0x19BD0
-#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + AMBIENCE_SEQ_SIZE + SFX_SOUNDFONTS_SIZE + 0x430)
-
-#ifndef AVOID_UB
-// Qualifying gAudioHeapInitSizes with const appears to be required for matching, however
-// gAudioHeapInitSizes.permanentPoolSize is written to (see load.c)
-#define CONST const
-#else
-// Avoid UB: gAudioHeapInitSizes isn't really const since it is written to, so do not
-// declare it as const.
-#define CONST
-#endif
-CONST AudioHeapInitSizes gAudioHeapInitSizes = {
-    ALIGN16(sizeof(gAudioHeap) - 0x100),                                         // audio heap size
-    ALIGN16(PERMANENT_POOL_SIZE + AI_BUFFERS_SIZE + SOUNDFONT_LIST_SIZE + 0x40), // init pool size
-    ALIGN16(PERMANENT_POOL_SIZE),                                                // permanent pool size
-};
 
 #define REVERB_INDEX_0_SETTINGS \
     { 1, 0x30, 0x3000, 0, 0, 0x7FFF, 0x0000, 0x0000, REVERB_INDEX_NONE, 0x3000, 0, 0 }

--- a/src/audio/session_config.c
+++ b/src/audio/session_config.c
@@ -26,7 +26,16 @@ const s16 gAudioTatumInit[] = {
 // 0x19BD0
 #define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + AMBIENCE_SEQ_SIZE + SFX_SOUNDFONTS_SIZE + 0x430)
 
-const AudioHeapInitSizes gAudioHeapInitSizes = {
+#ifndef AVOID_UB
+// Qualifying gAudioHeapInitSizes with const appears to be required for matching, however
+// gAudioHeapInitSizes.permanentPoolSize is written to (see load.c)
+#define CONST const
+#else
+// Avoid UB: gAudioHeapInitSizes isn't really const since it is written to, so do not
+// declare it as const.
+#define CONST
+#endif
+CONST AudioHeapInitSizes gAudioHeapInitSizes = {
     ALIGN16(sizeof(gAudioHeap) - 0x100),                                         // audio heap size
     ALIGN16(PERMANENT_POOL_SIZE + AI_BUFFERS_SIZE + SOUNDFONT_LIST_SIZE + 0x40), // init pool size
     ALIGN16(PERMANENT_POOL_SIZE),                                                // permanent pool size

--- a/src/audio/session_init.c
+++ b/src/audio/session_init.c
@@ -2,6 +2,7 @@
 #include "buffers.h"
 #include "assets/audio/sequence_sizes.h"
 #include "assets/audio/soundfont_sizes.h"
+
 #define SFX_SEQ_SIZE Sequence_0_SIZE
 #define AMBIENCE_SEQ_SIZE Sequence_1_SIZE
 #define SFX_SOUNDFONTS_SIZE (Soundfont_0_SIZE + Soundfont_1_SIZE + Soundfont_2_SIZE)

--- a/src/audio/session_init.c
+++ b/src/audio/session_init.c
@@ -1,0 +1,25 @@
+#include "z64audio.h"
+#include "buffers.h"
+#include "assets/audio/sequence_sizes.h"
+#include "assets/audio/soundfont_sizes.h"
+#define SFX_SEQ_SIZE Sequence_0_SIZE
+#define AMBIENCE_SEQ_SIZE Sequence_1_SIZE
+#define SFX_SOUNDFONTS_SIZE (Soundfont_0_SIZE + Soundfont_1_SIZE + Soundfont_2_SIZE)
+
+s16 gAudioTatumInit[] = {
+    0x1C00,          // unused
+    TATUMS_PER_BEAT, // gTatumsPerBeat
+};
+
+// Sizes of everything on the init pool
+#define AI_BUFFERS_SIZE (AIBUF_SIZE * ARRAY_COUNT(gAudioCtx.aiBuffers))
+#define SOUNDFONT_LIST_SIZE (NUM_SOUNDFONTS * sizeof(SoundFont))
+
+// 0x19BD0
+#define PERMANENT_POOL_SIZE (SFX_SEQ_SIZE + AMBIENCE_SEQ_SIZE + SFX_SOUNDFONTS_SIZE + 0x430)
+
+AudioHeapInitSizes gAudioHeapInitSizes = {
+    ALIGN16(sizeof(gAudioHeap) - 0x100),                                         // audio heap size
+    ALIGN16(PERMANENT_POOL_SIZE + AI_BUFFERS_SIZE + SOUNDFONT_LIST_SIZE + 0x40), // init pool size
+    ALIGN16(PERMANENT_POOL_SIZE),                                                // permanent pool size
+};


### PR DESCRIPTION
~~`gAudioHeapInitSizes` isn't really const since it is written to, but it seems necessary for matching. When `AVOID_UB` is defined, do not qualify `gAudioHeapInitSizes` with const so we can use a regular assignment where it is written to.~~

New strategy:
Split `gAudioTatumInit` and `gAudioHeapInitSizes` into `session_init.c`, which incrementally links .data into .rodata instead of using any const qualifiers.