### PR TITLE
Match SysCfb_Init without extra symbols

### DIFF
--- a/include/buffers.h
+++ b/include/buffers.h
@@ -15,9 +15,6 @@ typedef union {
     };
 } BufferLow;
 
-// Equivalent to gLoBuffer.framebufferHiRes, but a different symbol is required to match
-extern u16 gFramebufferHiRes1[HIRES_BUFFER_WIDTH][HIRES_BUFFER_HEIGHT];
-
 extern BufferLow gLoBuffer;
 
 
@@ -35,9 +32,6 @@ typedef union {
         u16 framebuffer[SCREEN_HEIGHT][SCREEN_WIDTH] ALIGNED(64);
     };
 } BufferHigh;
-
-// Equivalent to gHiBuffer.framebufferHiRes, but a different symbol is required to match
-extern u16 gFramebufferHiRes0[HIRES_BUFFER_HEIGHT][HIRES_BUFFER_WIDTH];
 
 extern BufferHigh gHiBuffer;
 

--- a/linker_scripts/final/undefined_syms.ld
+++ b/linker_scripts/final/undefined_syms.ld
@@ -1,8 +1,3 @@
-// sys_cfb buffers
-
-gFramebufferHiRes1 = gLoBuffer;
-gFramebufferHiRes0 = gHiBuffer;
-
 // Ucode symbols
 
 rspbootTextEnd = rspbootTextStart + 0x160;

--- a/src/code/sys_cfb.c
+++ b/src/code/sys_cfb.c
@@ -88,10 +88,16 @@ void SysCfb_SetHiResMode(void) {
 }
 
 void SysCfb_Init(void) {
-    sCfbLoRes1 = gLoBuffer.framebuffer;
-    sCfbLoRes0 = gHiBuffer.framebuffer;
-    sCfbHiRes1 = gFramebufferHiRes1;
-    sCfbHiRes0 = gFramebufferHiRes0;
+    do {
+        sCfbLoRes1 = gLoBuffer.framebuffer;
+        sCfbLoRes0 = gHiBuffer.framebuffer;
+    } while ((u64)0);
+
+    do {
+        sCfbHiRes1 = gLoBuffer.framebufferHiRes;
+        sCfbHiRes0 = gHiBuffer.framebufferHiRes;
+    } while ((u64)0);
+
     SysCfb_SetLoResMode();
 }
 


### PR DESCRIPTION
Allows for the removal of both `gFramebufferHiRes0` and `gFramebufferHiRes1`