### PR TITLE
Add makefile rule to build sample blobs out of assets/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -683,6 +683,9 @@ endif
 
 # then assemble the samplebanks...
 
+$(BUILD_DIR)/assets/audio/samples/%.bin: assets/audio/samples/%.bin
+	cp $< $@
+
 $(BUILD_DIR)/assets/audio/samples/%.bin: $(EXTRACTED_DIR)/assets/audio/samples/%.bin
 	cp $< $@
 


### PR DESCRIPTION
There are already makefile rules to build the other audio file types out of `assets/audio` instead of `extracted/$(VERSION)/assets/audio`, so these files should have the same treatment
