### PR TITLE
Fix /bin/bash -> /usr/bin/env bash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
 WORKDIR /mm
 RUN git config --global --add safe.directory /mm
 
-ENTRYPOINT ["/bin/bash", "-c"]
+ENTRYPOINT ["/usr/bin/env", "bash", "-c"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 MAKEFLAGS += --no-builtin-rules
 
 # Ensure the build fails if a piped command fails
-SHELL = /bin/bash
+SHELL = /usr/bin/env bash
 .SHELLFLAGS = -o pipefail -c
 
 # OS Detection

--- a/docs/BUILDING_DOCKER.md
+++ b/docs/BUILDING_DOCKER.md
@@ -29,7 +29,7 @@ and look for `mm` under the "REPOSITORY" column.
 To start the container, you can mount your local filesystem into the Docker container and run an interactive bash session.
 
 ```bash
-docker run -it --rm --mount type=bind,source="$(pwd)",destination=/mm mm /bin/bash
+docker run -it --rm --mount type=bind,source="$(pwd)",destination=/mm mm "/usr/bin/env bash"
 ```
 
 - The `-it` flags Keep STDIN open even if not attached to the container and allocates a pseudo-tty terminal.

--- a/tools/asm-processor/compile-test.sh
+++ b/tools/asm-processor/compile-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o pipefail
 INPUT="$1"
 OUTPUT="${INPUT%.*}.o"

--- a/tools/calc_bss.sh
+++ b/tools/calc_bss.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Given a list of header files, compute the bss index that results from
 # including them. (See prevent_bss_reordering.h for more information.)
 

--- a/tools/check_format.sh
+++ b/tools/check_format.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 STATUSOLD=`git status --porcelain`
 ./tools/format.py -j

--- a/tools/reloc_spec_check.sh
+++ b/tools/reloc_spec_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script checks for overlay's relocs to be correctly used on the spec file depending on the overlay's NON_MATCHING/NON_EQUIVALENT
 # and minimize possible broken NON_MATCHING builds.

--- a/tools/rename_sym.sh
+++ b/tools/rename_sym.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 shopt -s globstar
 

--- a/tools/warnings_count/check_new_warnings.sh
+++ b/tools/warnings_count/check_new_warnings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This script can be used when you want to test locally the amount of warnings produced by your changes before doing a PR.

--- a/tools/warnings_count/compare_warnings.sh
+++ b/tools/warnings_count/compare_warnings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Terminal colour codes
 # when $TERM is empty (non-interactive shell), then expand tput with '-T xterm-256color'

--- a/tools/warnings_count/update_current_warnings.sh
+++ b/tools/warnings_count/update_current_warnings.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # This script should only be used when we need to modify the accepted amount of warnings.


### PR DESCRIPTION
Bash is not guaranteed to be at `/bin/bash` so the build process fails on Linux distributions where this is not the case. This PR fixes that by replacing `/bin/bash` with `/usr/bin/env bash` which correctly resolves the path to bash.