### PR TITLE
Macroify MML opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,8 @@ $(shell mkdir -p $(foreach dir, \
                     $(dir:$(EXTRACTED_DIR)/%=$(BUILD_DIR)/%)))
 endif
 
+$(BUILD_DIR)/src/audio/lib/seqplayer.o: C_DEFINES += -DMML_VERSION=MML_VERSION_MM
+
 ifeq ($(COMPILER),ido)
 # directory flags
 $(BUILD_DIR)/src/libultra/os/%.o: OPTFLAGS := -O1

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -1348,7 +1348,7 @@ CHAN_0B13:
 /* 0x0B15 [0xC7 0x07 0x0B 0x2B     ] */ stseq       7, LAYER_0B2A + STSEQ_NOTEDV_DELAY
 /* 0x0B19 [0xC7 0x02 0x0B 0x24     ] */ stseq       2, CHAN_0B23 + STSEQ_LDI_IMM
 /* 0x0B1D [0xB8 0x0C               ] */ rand        12
-/* 0x0B1F [0xC7 0x5C 0x0B 0x2A     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF3), LAYER_0B2A + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0B1F [0xC7 0x5C 0x0B 0x2A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF3), LAYER_0B2A + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_0B23:
 /* 0x0B23 [0xCC 0x01               ] */ ldi         1
 /* 0x0B25 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -2913,7 +2913,7 @@ LAYER_14B6:
 .channel CHAN_PL_DEKUNUTS_STRUGGLE
 /* 0x14E8 [0x88 0x14 0xF2          ] */ ldlayer     0, LAYER_14F2
 /* 0x14EB [0xB8 0x0C               ] */ rand        12
-/* 0x14ED [0xC7 0x4F 0x14 0xFB     ] */ stseq       (NOTEDV_OPCODE | PITCH_C2), LAYER_14FB + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x14ED [0xC7 0x4F 0x14 0xFB     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C2), LAYER_14FB + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x14F1 [0xFF                    ] */ end
 
 .layer LAYER_14F2
@@ -3079,7 +3079,7 @@ LAYER_15EE:
 /* 0x1601 [0xC8 0xB0               ] */ sub         NA_SE_PL_DEKUNUTS_JUMP & 0xFF
 /* 0x1603 [0xCB 0x16 0x27          ] */ ldseq       ARRAY_1627
 /* 0x1606 [0xC7 0x0F 0x16 0x21     ] */ stseq       PITCH_C2, LAYER_161F + STSEQ_PORTAMENTO_PITCH
-/* 0x160A [0xC7 0x67 0x16 0x23     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_1623 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x160A [0xC7 0x67 0x16 0x23     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_1623 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x160E [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x160F [0xC8 0xB0               ] */ sub         NA_SE_PL_DEKUNUTS_JUMP & 0xFF
 /* 0x1611 [0xCB 0x16 0x2F          ] */ ldseq       ARRAY_162F
@@ -6510,7 +6510,7 @@ LAYER_307C:
 /* 0x30AE [0xFF                    ] */ end
 
 .channel CHAN_EV_FLUTTER_FLAG
-/* 0x30AF [0xCC 0x60               ] */ ldi         NOTEDV_OPCODE | PITCH_F3
+/* 0x30AF [0xCC 0x60               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_F3
 /* 0x30B1 [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x30B5 [0xCC 0x1F               ] */ ldi         31
 /* 0x30B7 [0xC7 0x00 0x30 0xC9     ] */ stseq       0, CHAN_30C8 + STSEQ_RAND
@@ -6530,7 +6530,7 @@ CHAN_30C8:
 /* 0x30D8 [0x56                    ] */ subio       IO_PORT_6
 /* 0x30D9 [0xC9 0x07               ] */ and         7
 CHAN_30DB:
-/* 0x30DB [0xC7 0x60 0x30 0xEC     ] */ stseq       (NOTEDV_OPCODE | PITCH_F3), LAYER_30EC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x30DB [0xC7 0x60 0x30 0xEC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_30EC + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x30DF [0x66                    ] */ ldio        IO_PORT_6
 /* 0x30E0 [0xC8 0xFC               ] */ sub         252
 /* 0x30E2 [0xC9 0x04               ] */ and         4
@@ -7556,7 +7556,7 @@ CHAN_3728:
 /* 0x3728 [0xB8 0x21               ] */ rand        33
 /* 0x372A [0xC7 0x20 0x37 0x3E     ] */ stseq       32, LAYER_373D + STSEQ_NOTEDV_DELAY
 /* 0x372E [0xB8 0x04               ] */ rand        4
-/* 0x3730 [0xC7 0x6B 0x37 0x3D     ] */ stseq       (NOTEDV_OPCODE | PITCH_E4), LAYER_373D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3730 [0xC7 0x6B 0x37 0x3D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E4), LAYER_373D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3734 [0xCC 0x20               ] */ ldi         32
 /* 0x3736 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x3739 [0xF4 0xED               ] */ rjump       CHAN_3728
@@ -8012,7 +8012,7 @@ LAYER_3A26:
 
 .channel CHAN_EV_BURNING
 /* 0x3A2C [0x89 0x3A 0x3A          ] */ ldlayer     1, LAYER_3A3A
-/* 0x3A2F [0xCC 0x58               ] */ ldi         NOTEDV_OPCODE | PITCH_A2
+/* 0x3A2F [0xCC 0x58               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_A2
 /* 0x3A31 [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x3A35 [0xFB 0x30 0xBB          ] */ jump        CHAN_30BB
 
@@ -8161,7 +8161,7 @@ LAYER_3AE5:
 .channel CHAN_EV_FLYING_AIR
 /* 0x3B15 [0x89 0x3B 0x2C          ] */ ldlayer     1, LAYER_3B2C
 /* 0x3B18 [0x8A 0x3B 0x2A          ] */ ldlayer     2, LAYER_3B2A
-/* 0x3B1B [0xCC 0x60               ] */ ldi         NOTEDV_OPCODE | PITCH_F3
+/* 0x3B1B [0xCC 0x60               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_F3
 /* 0x3B1D [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x3B21 [0xCC 0x0B               ] */ ldi         11
 /* 0x3B23 [0xC7 0x00 0x30 0xC9     ] */ stseq       0, CHAN_30C8 + STSEQ_RAND
@@ -8231,7 +8231,7 @@ CHAN_3B8F:
 /* 0x3B8F [0xCC 0x64               ] */ ldi         100
 /* 0x3B91 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x3B94 [0xB8 0x04               ] */ rand        4
-/* 0x3B96 [0xC7 0x5F 0x3B 0xA7     ] */ stseq       (NOTEDV_OPCODE | PITCH_E3), LAYER_3BA7 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3B96 [0xC7 0x5F 0x3B 0xA7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E3), LAYER_3BA7 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3B9A [0xF4 0xF3               ] */ rjump       CHAN_3B8F
 
 .layer LAYER_3B9C
@@ -8818,9 +8818,9 @@ CHAN_3F29:
 /* 0x3F2E [0xDC 0x40               ] */ panweight   64
 CHAN_3F30:
 /* 0x3F30 [0xB8 0x06               ] */ rand        6
-/* 0x3F32 [0xC7 0x62 0x3F 0x62     ] */ stseq       (NOTEDV_OPCODE | PITCH_G3), LAYER_3F62 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3F32 [0xC7 0x62 0x3F 0x62     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_3F62 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3F36 [0xC7 0x23 0x3F 0x5A     ] */ stseq       35, LAYER_3F58 + STSEQ_PORTAMENTO_PITCH
-/* 0x3F3A [0xC7 0x61 0x3F 0x5C     ] */ stseq       (NOTEDV_OPCODE | PITCH_GF3), LAYER_3F5C + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3F3A [0xC7 0x61 0x3F 0x5C     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_GF3), LAYER_3F5C + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3F3E [0xB8 0x03               ] */ rand        3
 /* 0x3F40 [0xC7 0x00 0x3F 0x69     ] */ stseq       0, LAYER_3F68 + STSEQ_TRANSPOSITION
 /* 0x3F44 [0x88 0x3F 0x60          ] */ ldlayer     0, LAYER_3F60
@@ -9292,7 +9292,7 @@ CHAN_41F5:
 /* 0x41FD [0x56                    ] */ subio       IO_PORT_6
 /* 0x41FE [0xC7 0x00 0x42 0x5B     ] */ stseq       0, LAYER_425A + STSEQ_SURROUNDEFFECT
 /* 0x4202 [0xCC 0x00               ] */ ldi         0
-/* 0x4204 [0xC7 0xF1 0x42 0x5A     ] */ stseq       SURROUNDEFFECT_OPCODE, LAYER_425A + STSEQ_GENERAL_OPCODE
+/* 0x4204 [0xC7 0xF1 0x42 0x5A     ] */ stseq       ASEQ_OPC_LAYER_F1, LAYER_425A + STSEQ_GENERAL_OPCODE
 /* 0x4208 [0xCC 0x01               ] */ ldi         1
 /* 0x420A [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x420D [0xF4 0xE6               ] */ rjump       CHAN_41F5
@@ -9301,7 +9301,7 @@ CHAN_420F:
 /* 0x420F [0xCC 0x14               ] */ ldi         20
 /* 0x4211 [0xC7 0x00 0x42 0x5B     ] */ stseq       0, LAYER_425A + STSEQ_STEREO
 /* 0x4215 [0xCC 0x00               ] */ ldi         0
-/* 0x4217 [0xC7 0xCD 0x42 0x5A     ] */ stseq       STEREO_OPCODE, LAYER_425A + STSEQ_GENERAL_OPCODE
+/* 0x4217 [0xC7 0xCD 0x42 0x5A     ] */ stseq       ASEQ_OPC_LAYER_STEREO, LAYER_425A + STSEQ_GENERAL_OPCODE
 /* 0x421B [0xFF                    ] */ end
 
 .layer LAYER_421C
@@ -9543,8 +9543,8 @@ LAYER_4385:
 /* 0x43A9 [0xB8 0x32               ] */ rand        50
 /* 0x43AB [0xC7 0x00 0x43 0xC5     ] */ stseq       0, LAYER_43C4 + STSEQ_BENDFINE
 /* 0x43AF [0xB8 0x03               ] */ rand        3
-/* 0x43B1 [0xC7 0x72 0x43 0xCA     ] */ stseq       (NOTEDV_OPCODE | PITCH_B4), LAYER_43CA + STSEQ_NOTEDV_OPCODE_PITCH
-/* 0x43B5 [0xC7 0x72 0x43 0xD4     ] */ stseq       (NOTEDV_OPCODE | PITCH_B4), LAYER_43D4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x43B1 [0xC7 0x72 0x43 0xCA     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_B4), LAYER_43CA + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x43B5 [0xC7 0x72 0x43 0xD4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_B4), LAYER_43D4 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x43B9 [0xB8 0x0C               ] */ rand        12
 /* 0x43BB [0xC7 0x06 0x43 0xCB     ] */ stseq       6, LAYER_43CA + STSEQ_NOTEDV_DELAY
 /* 0x43BF [0xC7 0x06 0x43 0xD5     ] */ stseq       6, LAYER_43D4 + STSEQ_NOTEDV_DELAY
@@ -9734,7 +9734,7 @@ LAYER_4481:
 .channel CHAN_EV_ROCK_CUBE_RISING
 /* 0x44D7 [0xCC 0x00               ] */ ldi         0
 /* 0x44D9 [0xC7 0x22 0x44 0xF2     ] */ stseq       34, LAYER_44F0 + STSEQ_PORTAMENTO_PITCH
-/* 0x44DD [0xC7 0x69 0x44 0xF4     ] */ stseq       (NOTEDV_OPCODE | PITCH_D4), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x44DD [0xC7 0x69 0x44 0xF4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_D4), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_44E1:
 /* 0x44E1 [0x88 0x44 0xE8          ] */ ldlayer     0, LAYER_44E8
 /* 0x44E4 [0x89 0x44 0xEE          ] */ ldlayer     1, LAYER_44EE
@@ -9758,7 +9758,7 @@ LAYER_44F8:
 .channel CHAN_EV_ROCK_CUBE_FALL
 /* 0x44FC [0xCC 0x00               ] */ ldi         0
 /* 0x44FE [0xC7 0x29 0x44 0xF2     ] */ stseq       41, LAYER_44F0 + STSEQ_PORTAMENTO_PITCH
-/* 0x4502 [0xC7 0x62 0x44 0xF4     ] */ stseq       (NOTEDV_OPCODE | PITCH_G3), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4502 [0xC7 0x62 0x44 0xF4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4506 [0xF4 0xD9               ] */ rjump       CHAN_44E1
 
 .channel CHAN_EV_BELL_SPIT
@@ -10902,7 +10902,7 @@ CHAN_4C4A:
 /* 0x4C6C [0xB8 0x06               ] */ rand        6
 /* 0x4C6E [0xC7 0x14 0x4C 0xC2     ] */ stseq       20, LAYER_4CC1 + STSEQ_NOTEDV_DELAY
 /* 0x4C72 [0xB8 0x06               ] */ rand        6
-/* 0x4C74 [0xC7 0x54 0x4C 0xC8     ] */ stseq       (NOTEDV_OPCODE | PITCH_F2), LAYER_4CC8 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4C74 [0xC7 0x54 0x4C 0xC8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F2), LAYER_4CC8 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4C78 [0xCC 0x14               ] */ ldi         20
 /* 0x4C7A [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x4C7D [0xB8 0x7F               ] */ rand        127
@@ -11120,7 +11120,7 @@ CHAN_4DDD:
 /* 0x4DDD [0xB8 0x0C               ] */ rand        12
 CHAN_4DDF:
 /* 0x4DDF [0x76                    ] */ stio        IO_PORT_6
-/* 0x4DE0 [0xC7 0x67 0x4D 0xFC     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_4DFC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4DE0 [0xC7 0x67 0x4D 0xFC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_4DFC + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_4DE4:
 /* 0x4DE4 [0xCC 0x20               ] */ ldi         32
 /* 0x4DE6 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -11321,7 +11321,7 @@ LAYER_4F1C:
 /* 0x4F54 [0xED 0x14               ] */ gain        20
 /* 0x4F56 [0x8A 0x4F 0x65          ] */ ldlayer     2, LAYER_4F65
 /* 0x4F59 [0x89 0x3A 0x3A          ] */ ldlayer     1, LAYER_3A3A
-/* 0x4F5C [0xCC 0x58               ] */ ldi         NOTEDV_OPCODE | PITCH_A2
+/* 0x4F5C [0xCC 0x58               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_A2
 /* 0x4F5E [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x4F62 [0xFB 0x30 0xBB          ] */ jump        CHAN_30BB
 
@@ -11516,7 +11516,7 @@ LAYER_5026:
 /* 0x5081 [0x89 0x50 0xCD          ] */ ldlayer     1, LAYER_50CD
 CHAN_5084:
 /* 0x5084 [0xB8 0x03               ] */ rand        3
-/* 0x5086 [0xC7 0x4A 0x50 0xC8     ] */ stseq       (NOTEDV_OPCODE | PITCH_G1), LAYER_50C8 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x5086 [0xC7 0x4A 0x50 0xC8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G1), LAYER_50C8 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x508A [0xCC 0x03               ] */ ldi         3
 /* 0x508C [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x508F [0xB8 0x02               ] */ rand        2
@@ -11528,7 +11528,7 @@ CHAN_5084:
 /* 0x50A0 [0xCC 0x03               ] */ ldi         3
 /* 0x50A2 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x50A5 [0xB8 0x03               ] */ rand        3
-/* 0x50A7 [0xC7 0x4D 0x50 0xCF     ] */ stseq       (NOTEDV_OPCODE | PITCH_BF1), LAYER_50CF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x50A7 [0xC7 0x4D 0x50 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_BF1), LAYER_50CF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x50AB [0xCC 0x03               ] */ ldi         3
 /* 0x50AD [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x50B0 [0xB8 0x02               ] */ rand        2
@@ -12410,7 +12410,7 @@ CHAN_5668:
 /* 0x5C53 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x5C55 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS               # Load sfx index
 /* 0x5C56 [0xC8 0xB0               ] */ sub         NA_SE_EN_TWINROBA_LAUGH & 0xFF  # Subtract base id for this group
-/* 0x5C58 [0xC7 0x00 0x5C 0x67     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_0), LAYER_5C67 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x5C58 [0xC7 0x00 0x5C 0x67     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_5C67 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x5C5C [0xCB 0x5C 0x6C          ] */ ldseq       ARRAY_5C6C
 /* 0x5C5F [0xC7 0x00 0x5C 0x69     ] */ stseq       0, LAYER_5C67 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x5C63 [0x88 0x5C 0x67          ] */ ldlayer     0, LAYER_5C67
@@ -13435,7 +13435,7 @@ CHAN_62E8:
 /* 0x62EA [0xC7 0x03 0x63 0x00     ] */ stseq       3, LAYER_62FF + STSEQ_NOTEDV_DELAY
 /* 0x62EE [0xC7 0x03 0x62 0xF9     ] */ stseq       3, CHAN_62F8 + 1
 /* 0x62F2 [0xB8 0x08               ] */ rand        8
-/* 0x62F4 [0xC7 0x5B 0x62 0xFF     ] */ stseq       (NOTEDV_OPCODE | PITCH_C3), LAYER_62FF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x62F4 [0xC7 0x5B 0x62 0xFF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C3), LAYER_62FF + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_62F8:
 /* 0x62F8 [0xCC 0x01               ] */ ldi         1
 /* 0x62FA [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -17110,7 +17110,7 @@ LAYER_799E:
 /* 0x7A71 [0xB8 0x69               ] */ rand        105
 /* 0x7A73 [0xC7 0x96 0x7A 0x91     ] */ stseq       150, LAYER_7A8E + STSEQ_PORTAMENTO_TIME
 /* 0x7A77 [0xB8 0x04               ] */ rand        4
-/* 0x7A79 [0xC7 0x67 0x7A 0x92     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_7A92 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x7A79 [0xC7 0x67 0x7A 0x92     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_7A92 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x7A7D [0xB8 0x1E               ] */ rand        30
 /* 0x7A7F [0xC7 0x00 0x7A 0x97     ] */ stseq       0, LAYER_7A96 + STSEQ_LDELAY
 /* 0x7A83 [0xB8 0x10               ] */ rand        16
@@ -18640,13 +18640,13 @@ LAYER_8480:
 
 .channel CHAN_EN_ICEB_FOOTSTEP_OLD
 /* 0x8496 [0xB8 0x02               ] */ rand        2
-/* 0x8498 [0xC7 0x50 0x84 0xBC     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF2), LAYER_84BC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x8498 [0xC7 0x50 0x84 0xBC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84BC + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x849C [0xB8 0x02               ] */ rand        2
-/* 0x849E [0xC7 0x50 0x84 0xBF     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF2), LAYER_84BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x849E [0xC7 0x50 0x84 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84A2 [0xB8 0x03               ] */ rand        3
-/* 0x84A4 [0xC7 0x50 0x84 0xC2     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF2), LAYER_84C2 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x84A4 [0xC7 0x50 0x84 0xC2     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84C2 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84A8 [0xB8 0x02               ] */ rand        2
-/* 0x84AA [0xC7 0x50 0x84 0xC5     ] */ stseq       (NOTEDV_OPCODE | PITCH_DF2), LAYER_84C5 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x84AA [0xC7 0x50 0x84 0xC5     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84C5 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84AE [0xED 0x13               ] */ gain        19
 /* 0x84B0 [0x88 0x84 0xC9          ] */ ldlayer     0, LAYER_84C9
 /* 0x84B3 [0x89 0x84 0xBA          ] */ ldlayer     1, LAYER_84BA
@@ -20853,7 +20853,7 @@ LAYER_92D9:
 /* 0x9347 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9349 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x934A [0xC8 0x30               ] */ sub         NA_SE_EN_BOSU_ATTACK & 0xFF
-/* 0x934C [0xC7 0x14 0x93 0x5B     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_20), LAYER_935B + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x934C [0xC7 0x14 0x93 0x5B     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_20), LAYER_935B + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9350 [0xCB 0x93 0x60          ] */ ldseq       ARRAY_9360
 /* 0x9353 [0xC7 0x00 0x93 0x5D     ] */ stseq       0, LAYER_935B + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9357 [0x88 0x93 0x5B          ] */ ldlayer     0, LAYER_935B
@@ -20871,7 +20871,7 @@ LAYER_92D9:
 /* 0x936C [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x936E [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x936F [0xC8 0x3A               ] */ sub         NA_SE_EN_BOSU_DAMAGE & 0xFF
-/* 0x9371 [0xC7 0x1E 0x93 0x83     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_30), LAYER_9383 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9371 [0xC7 0x1E 0x93 0x83     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_30), LAYER_9383 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9375 [0xCB 0x93 0x88          ] */ ldseq       ARRAY_9388
 /* 0x9378 [0xC7 0x00 0x93 0x85     ] */ stseq       0, LAYER_9383 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x937C [0x88 0x93 0x83          ] */ ldlayer     0, LAYER_9383
@@ -20890,7 +20890,7 @@ LAYER_92D9:
 /* 0x9390 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9392 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9393 [0xC8 0x5B               ] */ sub         NA_SE_EN_BOSU_DEAD_VOICE & 0xFF
-/* 0x9395 [0xC7 0x21 0x93 0xA4     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_33), LAYER_93A4 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9395 [0xC7 0x21 0x93 0xA4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_33), LAYER_93A4 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9399 [0xCB 0x93 0xA9          ] */ ldseq       ARRAY_93A9
 /* 0x939C [0xC7 0x00 0x93 0xA6     ] */ stseq       0, LAYER_93A4 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x93A0 [0x88 0x93 0xA4          ] */ ldlayer     0, LAYER_93A4
@@ -21395,7 +21395,7 @@ LAYER_9688:
 /* 0x9690 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9692 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9693 [0xC8 0x53               ] */ sub         NA_SE_EN_LAST3_VOICE_KICK_OLD & 0xFF
-/* 0x9695 [0xC7 0x24 0x96 0xA4     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_36), LAYER_96A4 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9695 [0xC7 0x24 0x96 0xA4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_36), LAYER_96A4 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9699 [0xCB 0x96 0xA9          ] */ ldseq       ARRAY_96A9
 /* 0x969C [0xC7 0x00 0x96 0xA6     ] */ stseq       0, LAYER_96A4 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x96A0 [0x88 0x96 0xA4          ] */ ldlayer     0, LAYER_96A4
@@ -21413,7 +21413,7 @@ LAYER_9688:
 /* 0x96B0 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x96B2 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x96B3 [0xC8 0x58               ] */ sub         NA_SE_EN_LAST3_VOICE_DAMAGE_OLD & 0xFF
-/* 0x96B5 [0xC7 0x29 0x96 0xC7     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_41), LAYER_96C7 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x96B5 [0xC7 0x29 0x96 0xC7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_41), LAYER_96C7 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x96B9 [0xCB 0x96 0xCC          ] */ ldseq       ARRAY_96CC
 /* 0x96BC [0xC7 0x00 0x96 0xC9     ] */ stseq       0, LAYER_96C7 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x96C0 [0x88 0x96 0xC7          ] */ ldlayer     0, LAYER_96C7
@@ -21659,7 +21659,7 @@ LAYER_981D:
 /* 0x9844 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9846 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9847 [0xC8 0x68               ] */ sub         NA_SE_EN_LAST2_VOICE_BALLET & 0xFF
-/* 0x9849 [0xC7 0x2C 0x98 0x58     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_44), LAYER_9858 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9849 [0xC7 0x2C 0x98 0x58     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_44), LAYER_9858 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x984D [0xCB 0x98 0x5D          ] */ ldseq       ARRAY_985D
 /* 0x9850 [0xC7 0x00 0x98 0x5A     ] */ stseq       0, LAYER_9858 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9854 [0x88 0x98 0x58          ] */ ldlayer     0, LAYER_9858
@@ -21677,7 +21677,7 @@ LAYER_981D:
 /* 0x9863 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9865 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9866 [0xC8 0x6C               ] */ sub         NA_SE_EN_LAST2_DAMAGE_OLD & 0xFF
-/* 0x9868 [0xC7 0x30 0x98 0x7A     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_48), LAYER_987A + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9868 [0xC7 0x30 0x98 0x7A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_48), LAYER_987A + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x986C [0xCB 0x98 0x7F          ] */ ldseq       ARRAY_987F
 /* 0x986F [0xC7 0x00 0x98 0x7C     ] */ stseq       0, LAYER_987A + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9873 [0x88 0x98 0x7A          ] */ ldlayer     0, LAYER_987A
@@ -21786,7 +21786,7 @@ LAYER_98AA:
 /* 0x9903 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9905 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9906 [0xC8 0x71               ] */ sub         NA_SE_EN_PIRATE_COOL_LAUGH & 0xFF
-/* 0x9908 [0xC7 0x34 0x99 0x17     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_52), LAYER_9917 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9908 [0xC7 0x34 0x99 0x17     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_52), LAYER_9917 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x990C [0xCB 0x99 0x1C          ] */ ldseq       ARRAY_991C
 /* 0x990F [0xC7 0x00 0x99 0x19     ] */ stseq       0, LAYER_9917 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9913 [0x88 0x99 0x17          ] */ ldlayer     0, LAYER_9917
@@ -22115,7 +22115,7 @@ LAYER_9B3B:
 /* 0x9B3E [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9B40 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9B41 [0xC8 0x75               ] */ sub         NA_SE_EN_STAL01_LAUGH & 0xFF
-/* 0x9B43 [0xC7 0x38 0x9B 0x60     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_56), LAYER_9B60 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9B43 [0xC7 0x38 0x9B 0x60     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_56), LAYER_9B60 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9B47 [0xCB 0x9B 0x65          ] */ ldseq       ARRAY_9B65
 /* 0x9B4A [0xC7 0x00 0x9B 0x62     ] */ stseq       0, LAYER_9B60 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9B4E [0x88 0x9B 0x5C          ] */ ldlayer     0, LAYER_9B5C
@@ -22140,7 +22140,7 @@ LAYER_9B3B:
 /* 0x9B68 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9B6A [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9B6B [0xC8 0x78               ] */ sub         NA_SE_EN_STAL04_ANGER & 0xFF
-/* 0x9B6D [0xC7 0x3B 0x9B 0x8A     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_59), LAYER_9B8A + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9B6D [0xC7 0x3B 0x9B 0x8A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_59), LAYER_9B8A + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9B71 [0xCB 0x9B 0x8F          ] */ ldseq       ARRAY_9B8F
 /* 0x9B74 [0xC7 0x00 0x9B 0x8C     ] */ stseq       0, LAYER_9B8A + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9B78 [0x88 0x9B 0x86          ] */ ldlayer     0, LAYER_9B86
@@ -22183,7 +22183,7 @@ LAYER_9B3B:
 /* 0x9BAF [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9BB1 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9BB2 [0xC8 0x7E               ] */ sub         NA_SE_EN_STAL10_LAUGH_SHY & 0xFF
-/* 0x9BB4 [0xC7 0x01 0x9B 0xC9     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_1), LAYER_9BC9 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9BB4 [0xC7 0x01 0x9B 0xC9     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_1), LAYER_9BC9 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9BB8 [0xCB 0x9B 0xCE          ] */ ldseq       ARRAY_9BCE
 /* 0x9BBB [0xC7 0x00 0x9B 0xCB     ] */ stseq       0, LAYER_9BC9 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9BBF [0x88 0x9B 0xC7          ] */ ldlayer     0, LAYER_9BC7
@@ -23240,7 +23240,7 @@ CHAN_A0C0:
 /* 0xA289 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0xA28B [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xA28C [0xC8 0xC7               ] */ sub         NA_SE_EN__copy514 & 0xFF
-/* 0xA28E [0xC7 0x12 0xA2 0x9F     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_18), LAYER_A29F + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xA28E [0xC7 0x12 0xA2 0x9F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_18), LAYER_A29F + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xA292 [0xCB 0xA2 0xA4          ] */ ldseq       ARRAY_A2A4
 /* 0xA295 [0xC7 0x00 0xA2 0xA1     ] */ stseq       0, LAYER_A29F + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0xA299 [0x88 0xA2 0x9D          ] */ ldlayer     0, LAYER_A29D
@@ -23404,7 +23404,7 @@ LAYER_A29F:
 /* 0xA38B [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0xA38D [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xA38E [0xC8 0xD7               ] */ sub         NA_SE_EN_IRONNACK_DAMAGE & 0xFF
-/* 0xA390 [0xC7 0x00 0xA3 0xA2     ] */ stseq       (NOTEDVG_OPCODE | SF1_EFFECT_0), LAYER_A3A2 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xA390 [0xC7 0x00 0xA3 0xA2     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_A3A2 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xA394 [0xCB 0xA3 0xA7          ] */ ldseq       ARRAY_A3A7
 /* 0xA397 [0xC7 0x00 0xA3 0xA4     ] */ stseq       0, LAYER_A3A2 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0xA39B [0x88 0xA3 0xA2          ] */ ldlayer     0, LAYER_A3A2
@@ -25620,7 +25620,7 @@ CHAN_B644:
 /* 0xB646 [0x3F 0x06               ] */ stcio       15, IO_PORT_6
 CHAN_B648:
 /* 0xB648 [0xCB 0xB6 0xA0          ] */ ldseq       ARRAY_B6A0
-/* 0xB64B [0xC7 0x40 0xB6 0x5D     ] */ stseq       (NOTEDV_OPCODE | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB64B [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB64F [0x66                    ] */ ldio        IO_PORT_6
 CHAN_B650:
 /* 0xB650 [0xCB 0xB6 0xA4          ] */ ldseq       ARRAY_B6A4
@@ -25652,7 +25652,7 @@ CHAN_B66E:
 /* 0xB674 [0xB4                    ] */ ptrtodyntbl
 /* 0xB675 [0xCC 0x00               ] */ ldi         0
 /* 0xB677 [0xB6                    ] */ dyntblv
-/* 0xB678 [0xC7 0x40 0xB6 0x5D     ] */ stseq       (NOTEDV_OPCODE | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB678 [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB67C [0xCC 0x01               ] */ ldi         1
 /* 0xB67E [0xB6                    ] */ dyntblv
 /* 0xB67F [0xF4 0xD2               ] */ rjump       CHAN_B653
@@ -25937,7 +25937,7 @@ CHAN_B803:
 /* 0xB806 [0x76                    ] */ stio        IO_PORT_6
 /* 0xB807 [0xC9 0x01               ] */ and         1
 /* 0xB809 [0xCB 0xB8 0x1D          ] */ ldseq       ARRAY_B81D
-/* 0xB80C [0xC7 0x40 0xBA 0x57     ] */ stseq       (NOTEDV_OPCODE | PITCH_A0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB80C [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB810 [0xB8 0x02               ] */ rand        2
 /* 0xB812 [0xCB 0xB8 0x1F          ] */ ldseq       ARRAY_B81F
 /* 0xB815 [0xC7 0x00 0xBA 0x59     ] */ stseq       0, LAYER_BA57 + STSEQ_NOTEDV_VELOCITY_2
@@ -26099,7 +26099,7 @@ CHAN_B8E5:
 /* 0xB8EC [0x76                    ] */ stio        IO_PORT_6
 /* 0xB8ED [0xC9 0x01               ] */ and         1
 /* 0xB8EF [0xCB 0xB9 0x0B          ] */ ldseq       ARRAY_B90B
-/* 0xB8F2 [0xC7 0x40 0xB9 0x05     ] */ stseq       (NOTEDV_OPCODE | SF0_EFFECT_0), LAYER_B905 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB8F2 [0xC7 0x40 0xB9 0x05     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B905 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB8F6 [0xB8 0x02               ] */ rand        2
 /* 0xB8F8 [0xCB 0xB9 0x0D          ] */ ldseq       ARRAY_B90D
 /* 0xB8FB [0xC7 0x00 0xB9 0x07     ] */ stseq       0, LAYER_B905 + STSEQ_NOTEDV_VELOCITY_2
@@ -26331,7 +26331,7 @@ CHAN_BA3B:
 /* 0xBA3E [0x76                    ] */ stio        IO_PORT_6
 /* 0xBA3F [0xC9 0x01               ] */ and         1
 /* 0xBA41 [0xCB 0xBA 0x5D          ] */ ldseq       ARRAY_BA5D
-/* 0xBA44 [0xC7 0x40 0xBA 0x57     ] */ stseq       (NOTEDV_OPCODE | SF0_EFFECT_0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xBA44 [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xBA48 [0xB8 0x02               ] */ rand        2
 /* 0xBA4A [0xCB 0xBA 0x5F          ] */ ldseq       ARRAY_BA5F
 /* 0xBA4D [0xC7 0x00 0xBA 0x59     ] */ stseq       0, LAYER_BA57 + STSEQ_NOTEDV_VELOCITY_2
@@ -26431,7 +26431,7 @@ CHAN_BA9A:
 /* 0xBAC5 [0x71                    ] */ stio        IO_PORT_1
 /* 0xBAC6 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBAC7 [0xC8 0x50               ] */ sub         NA_SE_VO_NARRATION_0 & 0xFF
-/* 0xBAC9 [0xC7 0x19 0xBA 0xDC     ] */ stseq       (NOTEDVG_OPCODE | SF0_EFFECT_25), LAYER_BADC + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBAC9 [0xC7 0x19 0xBA 0xDC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_25), LAYER_BADC + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBACD [0xCB 0xBA 0xE1          ] */ ldseq       ARRAY_BAE1
 /* 0xBAD0 [0xC7 0x00 0xBA 0xDE     ] */ stseq       0, LAYER_BADC + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBAD4 [0x88 0xBA 0xDA          ] */ ldlayer     0, LAYER_BADA
@@ -26454,7 +26454,7 @@ LAYER_BADC:
 /* 0xBB0A [0x71                    ] */ stio        IO_PORT_1
 /* 0xBB0B [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBB0C [0xC8 0x77               ] */ sub         NA_SE_VO_Z1_OPENDOOR & 0xFF
-/* 0xBB0E [0xC7 0x00 0xBB 0x1F     ] */ stseq       (NOTEDVG_OPCODE | SF0_EFFECT_0), LAYER_BB1F + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBB0E [0xC7 0x00 0xBB 0x1F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BB1F + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBB12 [0xCB 0xBB 0x24          ] */ ldseq       ARRAY_BB24
 /* 0xBB15 [0xC7 0x00 0xBB 0x21     ] */ stseq       0, LAYER_BB1F + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBB19 [0x88 0xBB 0x1D          ] */ ldlayer     0, LAYER_BB1D
@@ -27039,7 +27039,7 @@ LAYER_BDE7:
 /* 0xBE59 [0xCC 0x08               ] */ ldi         8
 /* 0xBE5B [0x71                    ] */ stio        IO_PORT_1
 /* 0xBE5C [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
-/* 0xBE5D [0xC7 0x00 0xBE 0x67     ] */ stseq       (NOTEDVG_OPCODE | SF0_EFFECT_0), LAYER_BE67 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBE5D [0xC7 0x00 0xBE 0x67     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE67 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBE61 [0x88 0xBE 0x65          ] */ ldlayer     0, LAYER_BE65
 /* 0xBE64 [0xFF                    ] */ end
 
@@ -27054,7 +27054,7 @@ LAYER_BE67:
 /* 0xBE6E [0x71                    ] */ stio        IO_PORT_1
 /* 0xBE6F [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBE70 [0xC8 0x40               ] */ sub         NA_SE_VO_CHVO07 & 0xFF
-/* 0xBE72 [0xC7 0x00 0xBE 0x83     ] */ stseq       (NOTEDVG_OPCODE | SF0_EFFECT_0), LAYER_BE83 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBE72 [0xC7 0x00 0xBE 0x83     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE83 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBE76 [0xCB 0xBE 0x88          ] */ ldseq       ARRAY_BE88
 /* 0xBE79 [0xC7 0x00 0xBE 0x85     ] */ stseq       0, LAYER_BE83 + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBE7D [0x88 0xBE 0x81          ] */ ldlayer     0, LAYER_BE81
@@ -27077,7 +27077,7 @@ LAYER_BE83:
 /* 0xBECA [0x71                    ] */ stio        IO_PORT_1
 /* 0xBECB [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBECC [0xC8 0x80               ] */ sub         NA_SE_VO_OMVO03 & 0xFF
-/* 0xBECE [0xC7 0x00 0xBE 0xD8     ] */ stseq       (NOTEDVG_OPCODE | SF0_EFFECT_0), LAYER_BED8 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBECE [0xC7 0x00 0xBE 0xD8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BED8 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBED2 [0x88 0xBE 0xD6          ] */ ldlayer     0, LAYER_BED6
 /* 0xBED5 [0xFF                    ] */ end
 

--- a/assets/audio/sequences/seq_0.prg.seq
+++ b/assets/audio/sequences/seq_0.prg.seq
@@ -1348,7 +1348,7 @@ CHAN_0B13:
 /* 0x0B15 [0xC7 0x07 0x0B 0x2B     ] */ stseq       7, LAYER_0B2A + STSEQ_NOTEDV_DELAY
 /* 0x0B19 [0xC7 0x02 0x0B 0x24     ] */ stseq       2, CHAN_0B23 + STSEQ_LDI_IMM
 /* 0x0B1D [0xB8 0x0C               ] */ rand        12
-/* 0x0B1F [0xC7 0x5C 0x0B 0x2A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF3), LAYER_0B2A + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0B1F [0xC7 0x5C 0x0B 0x2A     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF3), LAYER_0B2A + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_0B23:
 /* 0x0B23 [0xCC 0x01               ] */ ldi         1
 /* 0x0B25 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -2913,7 +2913,7 @@ LAYER_14B6:
 .channel CHAN_PL_DEKUNUTS_STRUGGLE
 /* 0x14E8 [0x88 0x14 0xF2          ] */ ldlayer     0, LAYER_14F2
 /* 0x14EB [0xB8 0x0C               ] */ rand        12
-/* 0x14ED [0xC7 0x4F 0x14 0xFB     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C2), LAYER_14FB + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x14ED [0xC7 0x4F 0x14 0xFB     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C2), LAYER_14FB + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x14F1 [0xFF                    ] */ end
 
 .layer LAYER_14F2
@@ -3079,7 +3079,7 @@ LAYER_15EE:
 /* 0x1601 [0xC8 0xB0               ] */ sub         NA_SE_PL_DEKUNUTS_JUMP & 0xFF
 /* 0x1603 [0xCB 0x16 0x27          ] */ ldseq       ARRAY_1627
 /* 0x1606 [0xC7 0x0F 0x16 0x21     ] */ stseq       PITCH_C2, LAYER_161F + STSEQ_PORTAMENTO_PITCH
-/* 0x160A [0xC7 0x67 0x16 0x23     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_1623 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x160A [0xC7 0x67 0x16 0x23     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_1623 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x160E [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x160F [0xC8 0xB0               ] */ sub         NA_SE_PL_DEKUNUTS_JUMP & 0xFF
 /* 0x1611 [0xCB 0x16 0x2F          ] */ ldseq       ARRAY_162F
@@ -6510,7 +6510,7 @@ LAYER_307C:
 /* 0x30AE [0xFF                    ] */ end
 
 .channel CHAN_EV_FLUTTER_FLAG
-/* 0x30AF [0xCC 0x60               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_F3
+/* 0x30AF [0xCC 0x60               ] */ ldi         ASEQ_OP_LAYER_NOTEDV | PITCH_F3
 /* 0x30B1 [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x30B5 [0xCC 0x1F               ] */ ldi         31
 /* 0x30B7 [0xC7 0x00 0x30 0xC9     ] */ stseq       0, CHAN_30C8 + STSEQ_RAND
@@ -6530,7 +6530,7 @@ CHAN_30C8:
 /* 0x30D8 [0x56                    ] */ subio       IO_PORT_6
 /* 0x30D9 [0xC9 0x07               ] */ and         7
 CHAN_30DB:
-/* 0x30DB [0xC7 0x60 0x30 0xEC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F3), LAYER_30EC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x30DB [0xC7 0x60 0x30 0xEC     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_F3), LAYER_30EC + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x30DF [0x66                    ] */ ldio        IO_PORT_6
 /* 0x30E0 [0xC8 0xFC               ] */ sub         252
 /* 0x30E2 [0xC9 0x04               ] */ and         4
@@ -7556,7 +7556,7 @@ CHAN_3728:
 /* 0x3728 [0xB8 0x21               ] */ rand        33
 /* 0x372A [0xC7 0x20 0x37 0x3E     ] */ stseq       32, LAYER_373D + STSEQ_NOTEDV_DELAY
 /* 0x372E [0xB8 0x04               ] */ rand        4
-/* 0x3730 [0xC7 0x6B 0x37 0x3D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E4), LAYER_373D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3730 [0xC7 0x6B 0x37 0x3D     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_E4), LAYER_373D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3734 [0xCC 0x20               ] */ ldi         32
 /* 0x3736 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x3739 [0xF4 0xED               ] */ rjump       CHAN_3728
@@ -8012,7 +8012,7 @@ LAYER_3A26:
 
 .channel CHAN_EV_BURNING
 /* 0x3A2C [0x89 0x3A 0x3A          ] */ ldlayer     1, LAYER_3A3A
-/* 0x3A2F [0xCC 0x58               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_A2
+/* 0x3A2F [0xCC 0x58               ] */ ldi         ASEQ_OP_LAYER_NOTEDV | PITCH_A2
 /* 0x3A31 [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x3A35 [0xFB 0x30 0xBB          ] */ jump        CHAN_30BB
 
@@ -8161,7 +8161,7 @@ LAYER_3AE5:
 .channel CHAN_EV_FLYING_AIR
 /* 0x3B15 [0x89 0x3B 0x2C          ] */ ldlayer     1, LAYER_3B2C
 /* 0x3B18 [0x8A 0x3B 0x2A          ] */ ldlayer     2, LAYER_3B2A
-/* 0x3B1B [0xCC 0x60               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_F3
+/* 0x3B1B [0xCC 0x60               ] */ ldi         ASEQ_OP_LAYER_NOTEDV | PITCH_F3
 /* 0x3B1D [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x3B21 [0xCC 0x0B               ] */ ldi         11
 /* 0x3B23 [0xC7 0x00 0x30 0xC9     ] */ stseq       0, CHAN_30C8 + STSEQ_RAND
@@ -8231,7 +8231,7 @@ CHAN_3B8F:
 /* 0x3B8F [0xCC 0x64               ] */ ldi         100
 /* 0x3B91 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x3B94 [0xB8 0x04               ] */ rand        4
-/* 0x3B96 [0xC7 0x5F 0x3B 0xA7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_E3), LAYER_3BA7 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3B96 [0xC7 0x5F 0x3B 0xA7     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_E3), LAYER_3BA7 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3B9A [0xF4 0xF3               ] */ rjump       CHAN_3B8F
 
 .layer LAYER_3B9C
@@ -8818,9 +8818,9 @@ CHAN_3F29:
 /* 0x3F2E [0xDC 0x40               ] */ panweight   64
 CHAN_3F30:
 /* 0x3F30 [0xB8 0x06               ] */ rand        6
-/* 0x3F32 [0xC7 0x62 0x3F 0x62     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_3F62 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3F32 [0xC7 0x62 0x3F 0x62     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_G3), LAYER_3F62 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3F36 [0xC7 0x23 0x3F 0x5A     ] */ stseq       35, LAYER_3F58 + STSEQ_PORTAMENTO_PITCH
-/* 0x3F3A [0xC7 0x61 0x3F 0x5C     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_GF3), LAYER_3F5C + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x3F3A [0xC7 0x61 0x3F 0x5C     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_GF3), LAYER_3F5C + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x3F3E [0xB8 0x03               ] */ rand        3
 /* 0x3F40 [0xC7 0x00 0x3F 0x69     ] */ stseq       0, LAYER_3F68 + STSEQ_TRANSPOSITION
 /* 0x3F44 [0x88 0x3F 0x60          ] */ ldlayer     0, LAYER_3F60
@@ -9292,7 +9292,7 @@ CHAN_41F5:
 /* 0x41FD [0x56                    ] */ subio       IO_PORT_6
 /* 0x41FE [0xC7 0x00 0x42 0x5B     ] */ stseq       0, LAYER_425A + STSEQ_SURROUNDEFFECT
 /* 0x4202 [0xCC 0x00               ] */ ldi         0
-/* 0x4204 [0xC7 0xF1 0x42 0x5A     ] */ stseq       ASEQ_OPC_LAYER_F1, LAYER_425A + STSEQ_GENERAL_OPCODE
+/* 0x4204 [0xC7 0xF1 0x42 0x5A     ] */ stseq       ASEQ_OP_LAYER_F1, LAYER_425A + STSEQ_GENERAL_OPCODE
 /* 0x4208 [0xCC 0x01               ] */ ldi         1
 /* 0x420A [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x420D [0xF4 0xE6               ] */ rjump       CHAN_41F5
@@ -9301,7 +9301,7 @@ CHAN_420F:
 /* 0x420F [0xCC 0x14               ] */ ldi         20
 /* 0x4211 [0xC7 0x00 0x42 0x5B     ] */ stseq       0, LAYER_425A + STSEQ_STEREO
 /* 0x4215 [0xCC 0x00               ] */ ldi         0
-/* 0x4217 [0xC7 0xCD 0x42 0x5A     ] */ stseq       ASEQ_OPC_LAYER_STEREO, LAYER_425A + STSEQ_GENERAL_OPCODE
+/* 0x4217 [0xC7 0xCD 0x42 0x5A     ] */ stseq       ASEQ_OP_LAYER_STEREO, LAYER_425A + STSEQ_GENERAL_OPCODE
 /* 0x421B [0xFF                    ] */ end
 
 .layer LAYER_421C
@@ -9543,8 +9543,8 @@ LAYER_4385:
 /* 0x43A9 [0xB8 0x32               ] */ rand        50
 /* 0x43AB [0xC7 0x00 0x43 0xC5     ] */ stseq       0, LAYER_43C4 + STSEQ_BENDFINE
 /* 0x43AF [0xB8 0x03               ] */ rand        3
-/* 0x43B1 [0xC7 0x72 0x43 0xCA     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_B4), LAYER_43CA + STSEQ_NOTEDV_OPCODE_PITCH
-/* 0x43B5 [0xC7 0x72 0x43 0xD4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_B4), LAYER_43D4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x43B1 [0xC7 0x72 0x43 0xCA     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_B4), LAYER_43CA + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x43B5 [0xC7 0x72 0x43 0xD4     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_B4), LAYER_43D4 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x43B9 [0xB8 0x0C               ] */ rand        12
 /* 0x43BB [0xC7 0x06 0x43 0xCB     ] */ stseq       6, LAYER_43CA + STSEQ_NOTEDV_DELAY
 /* 0x43BF [0xC7 0x06 0x43 0xD5     ] */ stseq       6, LAYER_43D4 + STSEQ_NOTEDV_DELAY
@@ -9734,7 +9734,7 @@ LAYER_4481:
 .channel CHAN_EV_ROCK_CUBE_RISING
 /* 0x44D7 [0xCC 0x00               ] */ ldi         0
 /* 0x44D9 [0xC7 0x22 0x44 0xF2     ] */ stseq       34, LAYER_44F0 + STSEQ_PORTAMENTO_PITCH
-/* 0x44DD [0xC7 0x69 0x44 0xF4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_D4), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x44DD [0xC7 0x69 0x44 0xF4     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_D4), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_44E1:
 /* 0x44E1 [0x88 0x44 0xE8          ] */ ldlayer     0, LAYER_44E8
 /* 0x44E4 [0x89 0x44 0xEE          ] */ ldlayer     1, LAYER_44EE
@@ -9758,7 +9758,7 @@ LAYER_44F8:
 .channel CHAN_EV_ROCK_CUBE_FALL
 /* 0x44FC [0xCC 0x00               ] */ ldi         0
 /* 0x44FE [0xC7 0x29 0x44 0xF2     ] */ stseq       41, LAYER_44F0 + STSEQ_PORTAMENTO_PITCH
-/* 0x4502 [0xC7 0x62 0x44 0xF4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4502 [0xC7 0x62 0x44 0xF4     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_G3), LAYER_44F4 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4506 [0xF4 0xD9               ] */ rjump       CHAN_44E1
 
 .channel CHAN_EV_BELL_SPIT
@@ -10902,7 +10902,7 @@ CHAN_4C4A:
 /* 0x4C6C [0xB8 0x06               ] */ rand        6
 /* 0x4C6E [0xC7 0x14 0x4C 0xC2     ] */ stseq       20, LAYER_4CC1 + STSEQ_NOTEDV_DELAY
 /* 0x4C72 [0xB8 0x06               ] */ rand        6
-/* 0x4C74 [0xC7 0x54 0x4C 0xC8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_F2), LAYER_4CC8 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4C74 [0xC7 0x54 0x4C 0xC8     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_F2), LAYER_4CC8 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x4C78 [0xCC 0x14               ] */ ldi         20
 /* 0x4C7A [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x4C7D [0xB8 0x7F               ] */ rand        127
@@ -11120,7 +11120,7 @@ CHAN_4DDD:
 /* 0x4DDD [0xB8 0x0C               ] */ rand        12
 CHAN_4DDF:
 /* 0x4DDF [0x76                    ] */ stio        IO_PORT_6
-/* 0x4DE0 [0xC7 0x67 0x4D 0xFC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_4DFC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x4DE0 [0xC7 0x67 0x4D 0xFC     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_4DFC + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_4DE4:
 /* 0x4DE4 [0xCC 0x20               ] */ ldi         32
 /* 0x4DE6 [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -11321,7 +11321,7 @@ LAYER_4F1C:
 /* 0x4F54 [0xED 0x14               ] */ gain        20
 /* 0x4F56 [0x8A 0x4F 0x65          ] */ ldlayer     2, LAYER_4F65
 /* 0x4F59 [0x89 0x3A 0x3A          ] */ ldlayer     1, LAYER_3A3A
-/* 0x4F5C [0xCC 0x58               ] */ ldi         ASEQ_OPC_LAYER_NOTEDV | PITCH_A2
+/* 0x4F5C [0xCC 0x58               ] */ ldi         ASEQ_OP_LAYER_NOTEDV | PITCH_A2
 /* 0x4F5E [0xC7 0x00 0x30 0xDC     ] */ stseq       0, CHAN_30DB + STSEQ_STSEQ_IMM
 /* 0x4F62 [0xFB 0x30 0xBB          ] */ jump        CHAN_30BB
 
@@ -11516,7 +11516,7 @@ LAYER_5026:
 /* 0x5081 [0x89 0x50 0xCD          ] */ ldlayer     1, LAYER_50CD
 CHAN_5084:
 /* 0x5084 [0xB8 0x03               ] */ rand        3
-/* 0x5086 [0xC7 0x4A 0x50 0xC8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G1), LAYER_50C8 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x5086 [0xC7 0x4A 0x50 0xC8     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_G1), LAYER_50C8 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x508A [0xCC 0x03               ] */ ldi         3
 /* 0x508C [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x508F [0xB8 0x02               ] */ rand        2
@@ -11528,7 +11528,7 @@ CHAN_5084:
 /* 0x50A0 [0xCC 0x03               ] */ ldi         3
 /* 0x50A2 [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x50A5 [0xB8 0x03               ] */ rand        3
-/* 0x50A7 [0xC7 0x4D 0x50 0xCF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_BF1), LAYER_50CF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x50A7 [0xC7 0x4D 0x50 0xCF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_BF1), LAYER_50CF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x50AB [0xCC 0x03               ] */ ldi         3
 /* 0x50AD [0xFC 0x00 0x48          ] */ call        CHAN_0048
 /* 0x50B0 [0xB8 0x02               ] */ rand        2
@@ -12410,7 +12410,7 @@ CHAN_5668:
 /* 0x5C53 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x5C55 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS               # Load sfx index
 /* 0x5C56 [0xC8 0xB0               ] */ sub         NA_SE_EN_TWINROBA_LAUGH & 0xFF  # Subtract base id for this group
-/* 0x5C58 [0xC7 0x00 0x5C 0x67     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_5C67 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x5C58 [0xC7 0x00 0x5C 0x67     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_5C67 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x5C5C [0xCB 0x5C 0x6C          ] */ ldseq       ARRAY_5C6C
 /* 0x5C5F [0xC7 0x00 0x5C 0x69     ] */ stseq       0, LAYER_5C67 + STSEQ_NOTEDVG_DELAY_LO
 /* 0x5C63 [0x88 0x5C 0x67          ] */ ldlayer     0, LAYER_5C67
@@ -13435,7 +13435,7 @@ CHAN_62E8:
 /* 0x62EA [0xC7 0x03 0x63 0x00     ] */ stseq       3, LAYER_62FF + STSEQ_NOTEDV_DELAY
 /* 0x62EE [0xC7 0x03 0x62 0xF9     ] */ stseq       3, CHAN_62F8 + 1
 /* 0x62F2 [0xB8 0x08               ] */ rand        8
-/* 0x62F4 [0xC7 0x5B 0x62 0xFF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C3), LAYER_62FF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x62F4 [0xC7 0x5B 0x62 0xFF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C3), LAYER_62FF + STSEQ_NOTEDV_OPCODE_PITCH
 CHAN_62F8:
 /* 0x62F8 [0xCC 0x01               ] */ ldi         1
 /* 0x62FA [0xFC 0x00 0x48          ] */ call        CHAN_0048
@@ -17110,7 +17110,7 @@ LAYER_799E:
 /* 0x7A71 [0xB8 0x69               ] */ rand        105
 /* 0x7A73 [0xC7 0x96 0x7A 0x91     ] */ stseq       150, LAYER_7A8E + STSEQ_PORTAMENTO_TIME
 /* 0x7A77 [0xB8 0x04               ] */ rand        4
-/* 0x7A79 [0xC7 0x67 0x7A 0x92     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_7A92 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x7A79 [0xC7 0x67 0x7A 0x92     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_7A92 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x7A7D [0xB8 0x1E               ] */ rand        30
 /* 0x7A7F [0xC7 0x00 0x7A 0x97     ] */ stseq       0, LAYER_7A96 + STSEQ_LDELAY
 /* 0x7A83 [0xB8 0x10               ] */ rand        16
@@ -18640,13 +18640,13 @@ LAYER_8480:
 
 .channel CHAN_EN_ICEB_FOOTSTEP_OLD
 /* 0x8496 [0xB8 0x02               ] */ rand        2
-/* 0x8498 [0xC7 0x50 0x84 0xBC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84BC + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x8498 [0xC7 0x50 0x84 0xBC     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF2), LAYER_84BC + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x849C [0xB8 0x02               ] */ rand        2
-/* 0x849E [0xC7 0x50 0x84 0xBF     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84BF + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x849E [0xC7 0x50 0x84 0xBF     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF2), LAYER_84BF + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84A2 [0xB8 0x03               ] */ rand        3
-/* 0x84A4 [0xC7 0x50 0x84 0xC2     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84C2 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x84A4 [0xC7 0x50 0x84 0xC2     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF2), LAYER_84C2 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84A8 [0xB8 0x02               ] */ rand        2
-/* 0x84AA [0xC7 0x50 0x84 0xC5     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_DF2), LAYER_84C5 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x84AA [0xC7 0x50 0x84 0xC5     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_DF2), LAYER_84C5 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x84AE [0xED 0x13               ] */ gain        19
 /* 0x84B0 [0x88 0x84 0xC9          ] */ ldlayer     0, LAYER_84C9
 /* 0x84B3 [0x89 0x84 0xBA          ] */ ldlayer     1, LAYER_84BA
@@ -20853,7 +20853,7 @@ LAYER_92D9:
 /* 0x9347 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9349 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x934A [0xC8 0x30               ] */ sub         NA_SE_EN_BOSU_ATTACK & 0xFF
-/* 0x934C [0xC7 0x14 0x93 0x5B     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_20), LAYER_935B + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x934C [0xC7 0x14 0x93 0x5B     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_20), LAYER_935B + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9350 [0xCB 0x93 0x60          ] */ ldseq       ARRAY_9360
 /* 0x9353 [0xC7 0x00 0x93 0x5D     ] */ stseq       0, LAYER_935B + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9357 [0x88 0x93 0x5B          ] */ ldlayer     0, LAYER_935B
@@ -20871,7 +20871,7 @@ LAYER_92D9:
 /* 0x936C [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x936E [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x936F [0xC8 0x3A               ] */ sub         NA_SE_EN_BOSU_DAMAGE & 0xFF
-/* 0x9371 [0xC7 0x1E 0x93 0x83     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_30), LAYER_9383 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9371 [0xC7 0x1E 0x93 0x83     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_30), LAYER_9383 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9375 [0xCB 0x93 0x88          ] */ ldseq       ARRAY_9388
 /* 0x9378 [0xC7 0x00 0x93 0x85     ] */ stseq       0, LAYER_9383 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x937C [0x88 0x93 0x83          ] */ ldlayer     0, LAYER_9383
@@ -20890,7 +20890,7 @@ LAYER_92D9:
 /* 0x9390 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9392 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9393 [0xC8 0x5B               ] */ sub         NA_SE_EN_BOSU_DEAD_VOICE & 0xFF
-/* 0x9395 [0xC7 0x21 0x93 0xA4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_33), LAYER_93A4 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9395 [0xC7 0x21 0x93 0xA4     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_33), LAYER_93A4 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9399 [0xCB 0x93 0xA9          ] */ ldseq       ARRAY_93A9
 /* 0x939C [0xC7 0x00 0x93 0xA6     ] */ stseq       0, LAYER_93A4 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x93A0 [0x88 0x93 0xA4          ] */ ldlayer     0, LAYER_93A4
@@ -21395,7 +21395,7 @@ LAYER_9688:
 /* 0x9690 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9692 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9693 [0xC8 0x53               ] */ sub         NA_SE_EN_LAST3_VOICE_KICK_OLD & 0xFF
-/* 0x9695 [0xC7 0x24 0x96 0xA4     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_36), LAYER_96A4 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9695 [0xC7 0x24 0x96 0xA4     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_36), LAYER_96A4 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9699 [0xCB 0x96 0xA9          ] */ ldseq       ARRAY_96A9
 /* 0x969C [0xC7 0x00 0x96 0xA6     ] */ stseq       0, LAYER_96A4 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x96A0 [0x88 0x96 0xA4          ] */ ldlayer     0, LAYER_96A4
@@ -21413,7 +21413,7 @@ LAYER_9688:
 /* 0x96B0 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x96B2 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x96B3 [0xC8 0x58               ] */ sub         NA_SE_EN_LAST3_VOICE_DAMAGE_OLD & 0xFF
-/* 0x96B5 [0xC7 0x29 0x96 0xC7     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_41), LAYER_96C7 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x96B5 [0xC7 0x29 0x96 0xC7     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_41), LAYER_96C7 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x96B9 [0xCB 0x96 0xCC          ] */ ldseq       ARRAY_96CC
 /* 0x96BC [0xC7 0x00 0x96 0xC9     ] */ stseq       0, LAYER_96C7 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x96C0 [0x88 0x96 0xC7          ] */ ldlayer     0, LAYER_96C7
@@ -21659,7 +21659,7 @@ LAYER_981D:
 /* 0x9844 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9846 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9847 [0xC8 0x68               ] */ sub         NA_SE_EN_LAST2_VOICE_BALLET & 0xFF
-/* 0x9849 [0xC7 0x2C 0x98 0x58     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_44), LAYER_9858 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9849 [0xC7 0x2C 0x98 0x58     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_44), LAYER_9858 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x984D [0xCB 0x98 0x5D          ] */ ldseq       ARRAY_985D
 /* 0x9850 [0xC7 0x00 0x98 0x5A     ] */ stseq       0, LAYER_9858 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9854 [0x88 0x98 0x58          ] */ ldlayer     0, LAYER_9858
@@ -21677,7 +21677,7 @@ LAYER_981D:
 /* 0x9863 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9865 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9866 [0xC8 0x6C               ] */ sub         NA_SE_EN_LAST2_DAMAGE_OLD & 0xFF
-/* 0x9868 [0xC7 0x30 0x98 0x7A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_48), LAYER_987A + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9868 [0xC7 0x30 0x98 0x7A     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_48), LAYER_987A + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x986C [0xCB 0x98 0x7F          ] */ ldseq       ARRAY_987F
 /* 0x986F [0xC7 0x00 0x98 0x7C     ] */ stseq       0, LAYER_987A + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9873 [0x88 0x98 0x7A          ] */ ldlayer     0, LAYER_987A
@@ -21786,7 +21786,7 @@ LAYER_98AA:
 /* 0x9903 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9905 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9906 [0xC8 0x71               ] */ sub         NA_SE_EN_PIRATE_COOL_LAUGH & 0xFF
-/* 0x9908 [0xC7 0x34 0x99 0x17     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_52), LAYER_9917 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9908 [0xC7 0x34 0x99 0x17     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_52), LAYER_9917 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x990C [0xCB 0x99 0x1C          ] */ ldseq       ARRAY_991C
 /* 0x990F [0xC7 0x00 0x99 0x19     ] */ stseq       0, LAYER_9917 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9913 [0x88 0x99 0x17          ] */ ldlayer     0, LAYER_9917
@@ -22115,7 +22115,7 @@ LAYER_9B3B:
 /* 0x9B3E [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9B40 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9B41 [0xC8 0x75               ] */ sub         NA_SE_EN_STAL01_LAUGH & 0xFF
-/* 0x9B43 [0xC7 0x38 0x9B 0x60     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_56), LAYER_9B60 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9B43 [0xC7 0x38 0x9B 0x60     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_56), LAYER_9B60 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9B47 [0xCB 0x9B 0x65          ] */ ldseq       ARRAY_9B65
 /* 0x9B4A [0xC7 0x00 0x9B 0x62     ] */ stseq       0, LAYER_9B60 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9B4E [0x88 0x9B 0x5C          ] */ ldlayer     0, LAYER_9B5C
@@ -22140,7 +22140,7 @@ LAYER_9B3B:
 /* 0x9B68 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9B6A [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9B6B [0xC8 0x78               ] */ sub         NA_SE_EN_STAL04_ANGER & 0xFF
-/* 0x9B6D [0xC7 0x3B 0x9B 0x8A     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_59), LAYER_9B8A + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9B6D [0xC7 0x3B 0x9B 0x8A     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_59), LAYER_9B8A + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9B71 [0xCB 0x9B 0x8F          ] */ ldseq       ARRAY_9B8F
 /* 0x9B74 [0xC7 0x00 0x9B 0x8C     ] */ stseq       0, LAYER_9B8A + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9B78 [0x88 0x9B 0x86          ] */ ldlayer     0, LAYER_9B86
@@ -22183,7 +22183,7 @@ LAYER_9B3B:
 /* 0x9BAF [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0x9BB1 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0x9BB2 [0xC8 0x7E               ] */ sub         NA_SE_EN_STAL10_LAUGH_SHY & 0xFF
-/* 0x9BB4 [0xC7 0x01 0x9B 0xC9     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_1), LAYER_9BC9 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0x9BB4 [0xC7 0x01 0x9B 0xC9     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_1), LAYER_9BC9 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0x9BB8 [0xCB 0x9B 0xCE          ] */ ldseq       ARRAY_9BCE
 /* 0x9BBB [0xC7 0x00 0x9B 0xCB     ] */ stseq       0, LAYER_9BC9 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0x9BBF [0x88 0x9B 0xC7          ] */ ldlayer     0, LAYER_9BC7
@@ -23240,7 +23240,7 @@ CHAN_A0C0:
 /* 0xA289 [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0xA28B [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xA28C [0xC8 0xC7               ] */ sub         NA_SE_EN__copy514 & 0xFF
-/* 0xA28E [0xC7 0x12 0xA2 0x9F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_18), LAYER_A29F + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xA28E [0xC7 0x12 0xA2 0x9F     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_18), LAYER_A29F + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xA292 [0xCB 0xA2 0xA4          ] */ ldseq       ARRAY_A2A4
 /* 0xA295 [0xC7 0x00 0xA2 0xA1     ] */ stseq       0, LAYER_A29F + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0xA299 [0x88 0xA2 0x9D          ] */ ldlayer     0, LAYER_A29D
@@ -23404,7 +23404,7 @@ LAYER_A29F:
 /* 0xA38B [0xC1 0x7E               ] */ instr       FONTANY_INSTR_SFX
 /* 0xA38D [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xA38E [0xC8 0xD7               ] */ sub         NA_SE_EN_IRONNACK_DAMAGE & 0xFF
-/* 0xA390 [0xC7 0x00 0xA3 0xA2     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_A3A2 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xA390 [0xC7 0x00 0xA3 0xA2     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF1_EFFECT_0), LAYER_A3A2 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xA394 [0xCB 0xA3 0xA7          ] */ ldseq       ARRAY_A3A7
 /* 0xA397 [0xC7 0x00 0xA3 0xA4     ] */ stseq       0, LAYER_A3A2 + STSEQ_NOTEDVG_VELOCITY_SHORTDELAY
 /* 0xA39B [0x88 0xA3 0xA2          ] */ ldlayer     0, LAYER_A3A2
@@ -25620,7 +25620,7 @@ CHAN_B644:
 /* 0xB646 [0x3F 0x06               ] */ stcio       15, IO_PORT_6
 CHAN_B648:
 /* 0xB648 [0xCB 0xB6 0xA0          ] */ ldseq       ARRAY_B6A0
-/* 0xB64B [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB64B [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB64F [0x66                    ] */ ldio        IO_PORT_6
 CHAN_B650:
 /* 0xB650 [0xCB 0xB6 0xA4          ] */ ldseq       ARRAY_B6A4
@@ -25652,7 +25652,7 @@ CHAN_B66E:
 /* 0xB674 [0xB4                    ] */ ptrtodyntbl
 /* 0xB675 [0xCC 0x00               ] */ ldi         0
 /* 0xB677 [0xB6                    ] */ dyntblv
-/* 0xB678 [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB678 [0xC7 0x40 0xB6 0x5D     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B65D + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB67C [0xCC 0x01               ] */ ldi         1
 /* 0xB67E [0xB6                    ] */ dyntblv
 /* 0xB67F [0xF4 0xD2               ] */ rjump       CHAN_B653
@@ -25937,7 +25937,7 @@ CHAN_B803:
 /* 0xB806 [0x76                    ] */ stio        IO_PORT_6
 /* 0xB807 [0xC9 0x01               ] */ and         1
 /* 0xB809 [0xCB 0xB8 0x1D          ] */ ldseq       ARRAY_B81D
-/* 0xB80C [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_A0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB80C [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_A0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB810 [0xB8 0x02               ] */ rand        2
 /* 0xB812 [0xCB 0xB8 0x1F          ] */ ldseq       ARRAY_B81F
 /* 0xB815 [0xC7 0x00 0xBA 0x59     ] */ stseq       0, LAYER_BA57 + STSEQ_NOTEDV_VELOCITY_2
@@ -26099,7 +26099,7 @@ CHAN_B8E5:
 /* 0xB8EC [0x76                    ] */ stio        IO_PORT_6
 /* 0xB8ED [0xC9 0x01               ] */ and         1
 /* 0xB8EF [0xCB 0xB9 0x0B          ] */ ldseq       ARRAY_B90B
-/* 0xB8F2 [0xC7 0x40 0xB9 0x05     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B905 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xB8F2 [0xC7 0x40 0xB9 0x05     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_B905 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xB8F6 [0xB8 0x02               ] */ rand        2
 /* 0xB8F8 [0xCB 0xB9 0x0D          ] */ ldseq       ARRAY_B90D
 /* 0xB8FB [0xC7 0x00 0xB9 0x07     ] */ stseq       0, LAYER_B905 + STSEQ_NOTEDV_VELOCITY_2
@@ -26331,7 +26331,7 @@ CHAN_BA3B:
 /* 0xBA3E [0x76                    ] */ stio        IO_PORT_6
 /* 0xBA3F [0xC9 0x01               ] */ and         1
 /* 0xBA41 [0xCB 0xBA 0x5D          ] */ ldseq       ARRAY_BA5D
-/* 0xBA44 [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0xBA44 [0xC7 0x40 0xBA 0x57     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | SF0_EFFECT_0), LAYER_BA57 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0xBA48 [0xB8 0x02               ] */ rand        2
 /* 0xBA4A [0xCB 0xBA 0x5F          ] */ ldseq       ARRAY_BA5F
 /* 0xBA4D [0xC7 0x00 0xBA 0x59     ] */ stseq       0, LAYER_BA57 + STSEQ_NOTEDV_VELOCITY_2
@@ -26431,7 +26431,7 @@ CHAN_BA9A:
 /* 0xBAC5 [0x71                    ] */ stio        IO_PORT_1
 /* 0xBAC6 [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBAC7 [0xC8 0x50               ] */ sub         NA_SE_VO_NARRATION_0 & 0xFF
-/* 0xBAC9 [0xC7 0x19 0xBA 0xDC     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_25), LAYER_BADC + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBAC9 [0xC7 0x19 0xBA 0xDC     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF0_EFFECT_25), LAYER_BADC + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBACD [0xCB 0xBA 0xE1          ] */ ldseq       ARRAY_BAE1
 /* 0xBAD0 [0xC7 0x00 0xBA 0xDE     ] */ stseq       0, LAYER_BADC + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBAD4 [0x88 0xBA 0xDA          ] */ ldlayer     0, LAYER_BADA
@@ -26454,7 +26454,7 @@ LAYER_BADC:
 /* 0xBB0A [0x71                    ] */ stio        IO_PORT_1
 /* 0xBB0B [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBB0C [0xC8 0x77               ] */ sub         NA_SE_VO_Z1_OPENDOOR & 0xFF
-/* 0xBB0E [0xC7 0x00 0xBB 0x1F     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BB1F + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBB0E [0xC7 0x00 0xBB 0x1F     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BB1F + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBB12 [0xCB 0xBB 0x24          ] */ ldseq       ARRAY_BB24
 /* 0xBB15 [0xC7 0x00 0xBB 0x21     ] */ stseq       0, LAYER_BB1F + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBB19 [0x88 0xBB 0x1D          ] */ ldlayer     0, LAYER_BB1D
@@ -27039,7 +27039,7 @@ LAYER_BDE7:
 /* 0xBE59 [0xCC 0x08               ] */ ldi         8
 /* 0xBE5B [0x71                    ] */ stio        IO_PORT_1
 /* 0xBE5C [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
-/* 0xBE5D [0xC7 0x00 0xBE 0x67     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE67 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBE5D [0xC7 0x00 0xBE 0x67     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE67 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBE61 [0x88 0xBE 0x65          ] */ ldlayer     0, LAYER_BE65
 /* 0xBE64 [0xFF                    ] */ end
 
@@ -27054,7 +27054,7 @@ LAYER_BE67:
 /* 0xBE6E [0x71                    ] */ stio        IO_PORT_1
 /* 0xBE6F [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBE70 [0xC8 0x40               ] */ sub         NA_SE_VO_CHVO07 & 0xFF
-/* 0xBE72 [0xC7 0x00 0xBE 0x83     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE83 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBE72 [0xC7 0x00 0xBE 0x83     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BE83 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBE76 [0xCB 0xBE 0x88          ] */ ldseq       ARRAY_BE88
 /* 0xBE79 [0xC7 0x00 0xBE 0x85     ] */ stseq       0, LAYER_BE83 + STSEQ_NOTEDVG_DELAY_LO
 /* 0xBE7D [0x88 0xBE 0x81          ] */ ldlayer     0, LAYER_BE81
@@ -27077,7 +27077,7 @@ LAYER_BE83:
 /* 0xBECA [0x71                    ] */ stio        IO_PORT_1
 /* 0xBECB [0x64                    ] */ ldio        IO_PORT_SFX_INDEX_LOBITS
 /* 0xBECC [0xC8 0x80               ] */ sub         NA_SE_VO_OMVO03 & 0xFF
-/* 0xBECE [0xC7 0x00 0xBE 0xD8     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BED8 + STSEQ_NOTEDVG_OPCODE_PITCH
+/* 0xBECE [0xC7 0x00 0xBE 0xD8     ] */ stseq       (ASEQ_OP_LAYER_NOTEDVG | SF0_EFFECT_0), LAYER_BED8 + STSEQ_NOTEDVG_OPCODE_PITCH
 /* 0xBED2 [0x88 0xBE 0xD6          ] */ ldlayer     0, LAYER_BED6
 /* 0xBED5 [0xFF                    ] */ end
 

--- a/assets/audio/sequences/seq_1.prg.seq
+++ b/assets/audio/sequences/seq_1.prg.seq
@@ -476,7 +476,7 @@ CHAN_030A:
 CHAN_031F:
 /* 0x031F [0xB8 0x18               ] */ rand        24
 CHAN_0321:
-/* 0x0321 [0xC7 0x62 0x03 0x75     ] */ stseq       (NOTEDV_OPCODE | PITCH_G3), LAYER_0375 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0321 [0xC7 0x62 0x03 0x75     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_0375 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0325 [0xCC 0x40               ] */ ldi         64
 /* 0x0327 [0x53                    ] */ subio       IO_PORT_3
 /* 0x0328 [0xC7 0x00 0x03 0x2D     ] */ stseq       0, STSEQ_HERE + STSEQ_RAND
@@ -504,7 +504,7 @@ CHAN_0337:
 /* 0x034D [0xC8 0xFF               ] */ sub         255
 /* 0x034F [0xC7 0x64 0x03 0x8D     ] */ stseq       100, LAYER_038B + STSEQ_NOTEDV_VELOCITY_2
 /* 0x0353 [0xC7 0x64 0x03 0x90     ] */ stseq       100, LAYER_038E + STSEQ_NOTEDV_VELOCITY_2
-/* 0x0357 [0xC7 0x67 0x03 0x8B     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_038B + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0357 [0xC7 0x67 0x03 0x8B     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_038B + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x035B [0xFF                    ] */ end
 
 .array ARRAY_035C
@@ -514,10 +514,10 @@ CHAN_0337:
     .byte SF2_INST_15
 
 .array ARRAY_0360
-    .byte NOTEDV_OPCODE | PITCH_G3
-    .byte NOTEDV_OPCODE | PITCH_G3
-    .byte NOTEDV_OPCODE | PITCH_G3
-    .byte NOTEDV_OPCODE | PITCH_G2
+    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G2
 
 .array ARRAY_0364
     .byte 60, 115, 100, 100
@@ -1637,11 +1637,11 @@ CHAN_0DDF:
 /* 0x0DE6 [0xCB 0x0F 0x2D          ] */ ldseq       ARRAY_0F2D
 /* 0x0DE9 [0xCB 0x0E 0xED          ] */ ldseq       ARRAY_0EED
 /* 0x0DEC [0x74                    ] */ stio        IO_PORT_4
-/* 0x0DED [0xC7 0x67 0x0D 0xF5     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), CHAN_0DF4 + STSEQ_STSEQ_IMM
+/* 0x0DED [0xC7 0x67 0x0D 0xF5     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), CHAN_0DF4 + STSEQ_STSEQ_IMM
 /* 0x0DF1 [0xB8 0x02               ] */ rand        2
 /* 0x0DF3 [0x73                    ] */ stio        IO_PORT_3
 CHAN_0DF4:
-/* 0x0DF4 [0xC7 0x67 0x0E 0x3C     ] */ stseq       (NOTEDV_OPCODE | PITCH_C4), LAYER_0E3C + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0DF4 [0xC7 0x67 0x0E 0x3C     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0E3C + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0DF8 [0xB8 0x1E               ] */ rand        30
 /* 0x0DFA [0xC7 0x31 0x0E 0x39     ] */ stseq       49, LAYER_0E38 + STSEQ_NOTEPAN
 /* 0x0DFE [0x76                    ] */ stio        IO_PORT_6

--- a/assets/audio/sequences/seq_1.prg.seq
+++ b/assets/audio/sequences/seq_1.prg.seq
@@ -476,7 +476,7 @@ CHAN_030A:
 CHAN_031F:
 /* 0x031F [0xB8 0x18               ] */ rand        24
 CHAN_0321:
-/* 0x0321 [0xC7 0x62 0x03 0x75     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_G3), LAYER_0375 + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0321 [0xC7 0x62 0x03 0x75     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_G3), LAYER_0375 + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0325 [0xCC 0x40               ] */ ldi         64
 /* 0x0327 [0x53                    ] */ subio       IO_PORT_3
 /* 0x0328 [0xC7 0x00 0x03 0x2D     ] */ stseq       0, STSEQ_HERE + STSEQ_RAND
@@ -504,7 +504,7 @@ CHAN_0337:
 /* 0x034D [0xC8 0xFF               ] */ sub         255
 /* 0x034F [0xC7 0x64 0x03 0x8D     ] */ stseq       100, LAYER_038B + STSEQ_NOTEDV_VELOCITY_2
 /* 0x0353 [0xC7 0x64 0x03 0x90     ] */ stseq       100, LAYER_038E + STSEQ_NOTEDV_VELOCITY_2
-/* 0x0357 [0xC7 0x67 0x03 0x8B     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_038B + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0357 [0xC7 0x67 0x03 0x8B     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_038B + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x035B [0xFF                    ] */ end
 
 .array ARRAY_035C
@@ -514,10 +514,10 @@ CHAN_0337:
     .byte SF2_INST_15
 
 .array ARRAY_0360
-    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
-    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
-    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G3
-    .byte ASEQ_OPC_LAYER_NOTEDV | PITCH_G2
+    .byte ASEQ_OP_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OP_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OP_LAYER_NOTEDV | PITCH_G3
+    .byte ASEQ_OP_LAYER_NOTEDV | PITCH_G2
 
 .array ARRAY_0364
     .byte 60, 115, 100, 100
@@ -1637,11 +1637,11 @@ CHAN_0DDF:
 /* 0x0DE6 [0xCB 0x0F 0x2D          ] */ ldseq       ARRAY_0F2D
 /* 0x0DE9 [0xCB 0x0E 0xED          ] */ ldseq       ARRAY_0EED
 /* 0x0DEC [0x74                    ] */ stio        IO_PORT_4
-/* 0x0DED [0xC7 0x67 0x0D 0xF5     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), CHAN_0DF4 + STSEQ_STSEQ_IMM
+/* 0x0DED [0xC7 0x67 0x0D 0xF5     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), CHAN_0DF4 + STSEQ_STSEQ_IMM
 /* 0x0DF1 [0xB8 0x02               ] */ rand        2
 /* 0x0DF3 [0x73                    ] */ stio        IO_PORT_3
 CHAN_0DF4:
-/* 0x0DF4 [0xC7 0x67 0x0E 0x3C     ] */ stseq       (ASEQ_OPC_LAYER_NOTEDV | PITCH_C4), LAYER_0E3C + STSEQ_NOTEDV_OPCODE_PITCH
+/* 0x0DF4 [0xC7 0x67 0x0E 0x3C     ] */ stseq       (ASEQ_OP_LAYER_NOTEDV | PITCH_C4), LAYER_0E3C + STSEQ_NOTEDV_OPCODE_PITCH
 /* 0x0DF8 [0xB8 0x1E               ] */ rand        30
 /* 0x0DFA [0xC7 0x31 0x0E 0x39     ] */ stseq       49, LAYER_0E38 + STSEQ_NOTEPAN
 /* 0x0DFE [0x76                    ] */ stio        IO_PORT_6

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -53,6 +53,19 @@
 #define ASEQ_H
 
 /**
+ *  MML Version
+ */
+
+#ifndef MML_VERSION
+    #error "MML version not defined, define MML_VERSION in the cpp invocation"
+#endif
+
+#define MML_VERSION_OOT  0
+#define MML_VERSION_MM   1
+
+
+
+/**
  *  IO Ports
  */
 
@@ -218,21 +231,190 @@
 #define FONTANY_INSTR_ASM_NOISE    136
 
 
-
-#ifdef _LANGUAGE_ASEQ
-
 /**
- *  MML Version
+ *  Command Opcode IDs
  */
 
-#ifndef MML_VERSION
-    #error "MML version not defined, define MML_VERSION in the cpp invocation"
+// control flow commands
+#define ASEQ_OPC_CONTROL_FLOW_FIRST 0xF2
+#define ASEQ_OPC_CTRLFLOW_RBLTZ     0xF2
+#define ASEQ_OPC_CTRLFLOW_RBEQZ     0xF3
+#define ASEQ_OPC_CTRLFLOW_RJUMP     0xF4
+#define ASEQ_OPC_CTRLFLOW_BGEZ      0xF5
+#define ASEQ_OPC_CTRLFLOW_BREAK     0xF6
+#define ASEQ_OPC_CTRLFLOW_LOOPEND   0xF7
+#define ASEQ_OPC_CTRLFLOW_LOOP      0xF8
+#define ASEQ_OPC_CTRLFLOW_BLTZ      0xF9
+#define ASEQ_OPC_CTRLFLOW_BEQZ      0xFA
+#define ASEQ_OPC_CTRLFLOW_JUMP      0xFB
+#define ASEQ_OPC_CTRLFLOW_CALL      0xFC
+#define ASEQ_OPC_CTRLFLOW_DELAY     0xFD
+#define ASEQ_OPC_CTRLFLOW_DELAY1    0xFE
+#define ASEQ_OPC_CTRLFLOW_END       0xFF
+
+// sequence commands
+#define ASEQ_OPC_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_SUBIO             0x50 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDRES             0x60 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_STIO              0x70 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDIO              0x80 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
+#define ASEQ_OPC_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_SEQUENCE_C2                0xC2
+#define ASEQ_OPC_SEQUENCE_C3                0xC3
+#endif
+#define ASEQ_OPC_SEQUENCE_RUNSEQ            0xC4
+#define ASEQ_OPC_SEQUENCE_SCRIPTCTR         0xC5
+#define ASEQ_OPC_SEQUENCE_STOP              0xC6
+#define ASEQ_OPC_SEQUENCE_STSEQ             0xC7
+#define ASEQ_OPC_SEQUENCE_SUB               0xC8
+#define ASEQ_OPC_SEQUENCE_AND               0xC9
+#define ASEQ_OPC_SEQUENCE_LDI               0xCC
+#define ASEQ_OPC_SEQUENCE_DYNCALL           0xCD
+#define ASEQ_OPC_SEQUENCE_RAND              0xCE
+#define ASEQ_OPC_SEQUENCE_NOTEALLOC         0xD0
+#define ASEQ_OPC_SEQUENCE_LDSHORTGATEARR    0xD1
+#define ASEQ_OPC_SEQUENCE_LDSHORTVELARR     0xD2
+#define ASEQ_OPC_SEQUENCE_MUTEBHV           0xD3
+#define ASEQ_OPC_SEQUENCE_MUTE              0xD4
+#define ASEQ_OPC_SEQUENCE_MUTESCALE         0xD5
+#define ASEQ_OPC_SEQUENCE_FREECHAN          0xD6
+#define ASEQ_OPC_SEQUENCE_INITCHAN          0xD7
+#define ASEQ_OPC_SEQUENCE_VOLSCALE          0xD9
+#define ASEQ_OPC_SEQUENCE_VOLMODE           0xDA
+#define ASEQ_OPC_SEQUENCE_VOL               0xDB
+#define ASEQ_OPC_SEQUENCE_TEMPOCHG          0xDC
+#define ASEQ_OPC_SEQUENCE_TEMPO             0xDD
+#define ASEQ_OPC_SEQUENCE_RTRANSPOSE        0xDE
+#define ASEQ_OPC_SEQUENCE_TRANSPOSE         0xDF
+#define ASEQ_OPC_SEQUENCE_EF                0xEF
+#define ASEQ_OPC_SEQUENCE_FREENOTELIST      0xF0
+#define ASEQ_OPC_SEQUENCE_ALLOCNOTELIST     0xF1
+
+// channel commands
+#define ASEQ_OPC_CHANNEL_CDELAY         0x00 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDCHAN         0x20 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_STCIO          0x30 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDCIO          0x40 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_LDIO           0x60 // low nibble used as argument
+#define ASEQ_OPC_CHANNEL_STIO           0x70 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
+#define ASEQ_OPC_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_CHANNEL_A0             0xA0
+#define ASEQ_OPC_CHANNEL_A1             0xA1
+#define ASEQ_OPC_CHANNEL_A2             0xA2
+#define ASEQ_OPC_CHANNEL_A3             0xA3
+#define ASEQ_OPC_CHANNEL_A4             0xA4
+#define ASEQ_OPC_CHANNEL_A5             0xA5
+#define ASEQ_OPC_CHANNEL_A6             0xA6
+#define ASEQ_OPC_CHANNEL_A7             0xA7
+#define ASEQ_OPC_CHANNEL_RANDPTR        0xA8
+#endif
+#define ASEQ_OPC_CHANNEL_LDFILTER       0xB0
+#define ASEQ_OPC_CHANNEL_FREEFILTER     0xB1
+#define ASEQ_OPC_CHANNEL_LDSEQTOPTR     0xB2
+#define ASEQ_OPC_CHANNEL_FILTER         0xB3
+#define ASEQ_OPC_CHANNEL_PTRTODYNTBL    0xB4
+#define ASEQ_OPC_CHANNEL_DYNTBLTOPTR    0xB5
+#define ASEQ_OPC_CHANNEL_DYNTBLV        0xB6
+#define ASEQ_OPC_CHANNEL_RANDTOPTR      0xB7
+#define ASEQ_OPC_CHANNEL_RAND           0xB8
+#define ASEQ_OPC_CHANNEL_RANDVEL        0xB9
+#define ASEQ_OPC_CHANNEL_RANDGATE       0xBA
+#define ASEQ_OPC_CHANNEL_COMBFILTER     0xBB
+#define ASEQ_OPC_CHANNEL_PTRADD         0xBC
+#if (MML_VERSION == MML_VERSION_OOT)
+#define ASEQ_OPC_CHANNEL_RANDPTR        0xBD
+#endif
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_CHANNEL_SAMPLESTART    0xBD
+#define ASEQ_OPC_CHANNEL_UNK_BE         0xBE
+#endif
+#define ASEQ_OPC_CHANNEL_INSTR          0xC1
+#define ASEQ_OPC_CHANNEL_DYNTBL         0xC2
+#define ASEQ_OPC_CHANNEL_SHORT          0xC3
+#define ASEQ_OPC_CHANNEL_NOSHORT        0xC4
+#define ASEQ_OPC_CHANNEL_DYNTBLLOOKUP   0xC5
+#define ASEQ_OPC_CHANNEL_FONT           0xC6
+#define ASEQ_OPC_CHANNEL_STSEQ          0xC7
+#define ASEQ_OPC_CHANNEL_SUB            0xC8
+#define ASEQ_OPC_CHANNEL_AND            0xC9
+#define ASEQ_OPC_CHANNEL_MUTEBHV        0xCA
+#define ASEQ_OPC_CHANNEL_LDSEQ          0xCB
+#define ASEQ_OPC_CHANNEL_LDI            0xCC
+#define ASEQ_OPC_CHANNEL_STOPCHAN       0xCD
+#define ASEQ_OPC_CHANNEL_LDPTR          0xCE
+#define ASEQ_OPC_CHANNEL_STPTRTOSEQ     0xCF
+#define ASEQ_OPC_CHANNEL_EFFECTS        0xD0
+#define ASEQ_OPC_CHANNEL_NOTEALLOC      0xD1
+#define ASEQ_OPC_CHANNEL_SUSTAIN        0xD2
+#define ASEQ_OPC_CHANNEL_BEND           0xD3
+#define ASEQ_OPC_CHANNEL_REVERB         0xD4
+#define ASEQ_OPC_CHANNEL_VIBFREQ        0xD7
+#define ASEQ_OPC_CHANNEL_VIBDEPTH       0xD8
+#define ASEQ_OPC_CHANNEL_RELEASERATE    0xD9
+#define ASEQ_OPC_CHANNEL_ENV            0xDA
+#define ASEQ_OPC_CHANNEL_TRANSPOSE      0xDB
+#define ASEQ_OPC_CHANNEL_PANWEIGHT      0xDC
+#define ASEQ_OPC_CHANNEL_PAN            0xDD
+#define ASEQ_OPC_CHANNEL_FREQSCALE      0xDE
+#define ASEQ_OPC_CHANNEL_VOL            0xDF
+#define ASEQ_OPC_CHANNEL_VOLEXP         0xE0
+#define ASEQ_OPC_CHANNEL_VIBFREQGRAD    0xE1
+#define ASEQ_OPC_CHANNEL_VIBDEPTHGRAD   0xE2
+#define ASEQ_OPC_CHANNEL_VIBDELAY       0xE3
+#define ASEQ_OPC_CHANNEL_DYNCALL        0xE4
+#define ASEQ_OPC_CHANNEL_REVERBIDX      0xE5
+#define ASEQ_OPC_CHANNEL_SAMPLEBOOK     0xE6
+#define ASEQ_OPC_CHANNEL_LDPARAMS       0xE7
+#define ASEQ_OPC_CHANNEL_PARAMS         0xE8
+#define ASEQ_OPC_CHANNEL_NOTEPRI        0xE9
+#define ASEQ_OPC_CHANNEL_STOP           0xEA
+#define ASEQ_OPC_CHANNEL_FONTINSTR      0xEB
+#define ASEQ_OPC_CHANNEL_VIBRESET       0xEC
+#define ASEQ_OPC_CHANNEL_GAIN           0xED
+#define ASEQ_OPC_CHANNEL_BENDFINE       0xEE
+#define ASEQ_OPC_CHANNEL_FREENOTELIST   0xF0
+#define ASEQ_OPC_CHANNEL_ALLOCNOTELIST  0xF1
+
+// layer commands
+#define ASEQ_OPC_LAYER_NOTEDVG      0x00
+#define ASEQ_OPC_LAYER_NOTEDV       0x40
+#define ASEQ_OPC_LAYER_NOTEVG       0x80
+#define ASEQ_OPC_LAYER_LDELAY       0xC0
+#define ASEQ_OPC_LAYER_SHORTVEL     0xC1
+#define ASEQ_OPC_LAYER_TRANSPOSE    0xC2
+#define ASEQ_OPC_LAYER_SHORTDELAY   0xC3
+#define ASEQ_OPC_LAYER_LEGATO       0xC4
+#define ASEQ_OPC_LAYER_NOLEGATO     0xC5
+#define ASEQ_OPC_LAYER_INSTR        0xC6
+#define ASEQ_OPC_LAYER_PORTAMENTO   0xC7
+#define ASEQ_OPC_LAYER_NOPORTAMENTO 0xC8
+#define ASEQ_OPC_LAYER_SHORTGATE    0xC9
+#define ASEQ_OPC_LAYER_NOTEPAN      0xCA
+#define ASEQ_OPC_LAYER_ENV          0xCB
+#define ASEQ_OPC_LAYER_NODRUMPAN    0xCC
+#define ASEQ_OPC_LAYER_STEREO       0xCD
+#define ASEQ_OPC_LAYER_BENDFINE     0xCE
+#define ASEQ_OPC_LAYER_RELEASERATE  0xCF
+#define ASEQ_OPC_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
+#define ASEQ_OPC_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
+#if (MML_VERSION == MML_VERSION_MM)
+#define ASEQ_OPC_LAYER_F0           0xF0
+#define ASEQ_OPC_LAYER_F1           0xF1
 #endif
 
-#define MML_VERSION_OOT  0
-#define MML_VERSION_MM   1
 
-
+#ifdef _LANGUAGE_ASEQ
 
 /**
  *  IDENT
@@ -389,7 +571,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, 0xB0,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_OPC_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -407,7 +589,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,0xCB,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_OPC_CHANNEL_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -417,14 +599,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,0xB3,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_OPC_CHANNEL_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,0xDA,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_OPC_CHANNEL_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -441,7 +623,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,0xCB,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_OPC_LAYER_ENV,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -733,7 +915,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, 0xFF,0xFF,0xFF,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,,,,,, 0, 0
 .endm
 
 /**
@@ -742,7 +924,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, 0xFE,0xFE,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_OPC_CTRLFLOW_DELAY1,ASEQ_OPC_CTRLFLOW_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -751,7 +933,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, 0xFD,0xFD,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_CTRLFLOW_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -762,7 +944,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, 0xFC,0xFC,0xFC,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -772,7 +954,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, 0xFB,0xFB,0xFB,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -782,7 +964,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, 0xFA,0xFA,0xFA,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -792,7 +974,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, 0xF9,0xF9,0xF9,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -806,7 +988,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, 0xF8,0xF8,0xF8,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -820,7 +1002,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, 0xF7,0xF7,0xF7,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -833,7 +1015,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, 0xF6,0xF6,0xF6,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -842,7 +1024,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, 0xF5,0xF5,0xF5,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -856,7 +1038,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, 0xF4,0xF4,0xF4,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -870,7 +1052,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, 0xF3,0xF3,0xF3,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -884,7 +1066,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, 0xF2,0xF2,0xF2,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -894,7 +1076,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, 0xF1,0xF1,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OPC_SEQUENCE_ALLOCNOTELIST,ASEQ_OPC_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -904,7 +1086,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, 0xF0,0xF0,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OPC_SEQUENCE_FREENOTELIST,ASEQ_OPC_CHANNEL_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -913,7 +1095,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, 0xEF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_OPC_SEQUENCE_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -924,7 +1106,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,0xEE,0xCE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_OPC_CHANNEL_BENDFINE,ASEQ_OPC_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -934,7 +1116,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,0xED,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_OPC_CHANNEL_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -944,7 +1126,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,0xEC,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_OPC_CHANNEL_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -953,7 +1135,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,0xEB,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_OPC_CHANNEL_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -966,7 +1148,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,0xE9,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_OPC_CHANNEL_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -977,7 +1159,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,0xE8,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_OPC_CHANNEL_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -995,7 +1177,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,0xE7,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_OPC_CHANNEL_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1005,7 +1187,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,0xE6,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_OPC_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1015,7 +1197,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,0xE5,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_OPC_CHANNEL_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1025,7 +1207,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,0xE3,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_OPC_CHANNEL_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1035,7 +1217,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,0xE2,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_OPC_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1047,7 +1229,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,0xE1,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_OPC_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1059,7 +1241,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,0xE0,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_OPC_CHANNEL_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1070,7 +1252,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, 0xDF,0xDB,0xC2,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OPC_SEQUENCE_TRANSPOSE,ASEQ_OPC_CHANNEL_TRANSPOSE,ASEQ_OPC_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1080,7 +1262,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, 0xDE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_OPC_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1090,7 +1272,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,0xDE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_OPC_CHANNEL_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1100,7 +1282,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, 0xDD,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_OPC_SEQUENCE_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1110,7 +1292,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, 0xDC,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_OPC_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1122,7 +1304,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,0xDD,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_OPC_CHANNEL_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1138,7 +1320,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,0xDC,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_OPC_CHANNEL_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1148,7 +1330,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, 0xDB,0xDF,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OPC_SEQUENCE_VOL,ASEQ_OPC_CHANNEL_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1158,7 +1340,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, 0xDA,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_OPC_SEQUENCE_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1169,7 +1351,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, 0xD9,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_OPC_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1179,7 +1361,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,0xD9,0xCF,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_OPC_CHANNEL_RELEASERATE,ASEQ_OPC_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1189,7 +1371,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,0xD8,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_OPC_CHANNEL_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1199,7 +1381,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,0xD7,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_OPC_CHANNEL_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1212,7 +1394,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, 0xD7,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_OPC_SEQUENCE_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1222,7 +1404,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, 0xD6,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_OPC_SEQUENCE_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1232,7 +1414,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, 0xD5,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_OPC_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1242,7 +1424,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, 0xD4,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_OPC_SEQUENCE_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1251,7 +1433,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,0xD4,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_OPC_CHANNEL_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1261,7 +1443,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, 0xD3,0xCA,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OPC_SEQUENCE_MUTEBHV,ASEQ_OPC_CHANNEL_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1271,7 +1453,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,0xD3,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_OPC_CHANNEL_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1281,7 +1463,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, 0xD2,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_OPC_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1291,7 +1473,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,0xD2,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_OPC_CHANNEL_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1301,7 +1483,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, 0xD1,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_OPC_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1311,7 +1493,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, 0xD0,0xD1,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OPC_SEQUENCE_NOTEALLOC,ASEQ_OPC_CHANNEL_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1328,7 +1510,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,0xD0,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_OPC_CHANNEL_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1338,7 +1520,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,0xCF,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_OPC_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1348,7 +1530,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,0xCE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1358,7 +1540,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,0xCE,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1368,7 +1550,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, 0xCE,0xB8,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OPC_SEQUENCE_RAND,ASEQ_OPC_CHANNEL_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1383,9 +1565,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,0xE4,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_OPC_CHANNEL_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, 0xCD,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_OPC_SEQUENCE_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1396,7 +1578,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, 0xCC,0xCC,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OPC_SEQUENCE_LDI,ASEQ_OPC_CHANNEL_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1406,7 +1588,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, 0xC9,0xC9,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OPC_SEQUENCE_AND,ASEQ_OPC_CHANNEL_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1416,7 +1598,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, 0xC8,0xC8,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OPC_SEQUENCE_SUB,ASEQ_OPC_CHANNEL_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1426,7 +1608,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, 0xC7,0xC7,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OPC_SEQUENCE_STSEQ,ASEQ_OPC_CHANNEL_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1437,7 +1619,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, 0xC6,0xEA,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OPC_SEQUENCE_STOP,ASEQ_OPC_CHANNEL_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1446,7 +1628,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,0xC6,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_OPC_CHANNEL_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1459,7 +1641,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, 0xC5,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_OPC_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1470,7 +1652,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,0xC5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_OPC_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1479,7 +1661,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, 0xC4,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_OPC_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1492,7 +1674,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, 0xC3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_OPC_SEQUENCE_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -1504,7 +1686,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,0xC4,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_OPC_CHANNEL_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1513,7 +1695,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,0xC3,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_OPC_CHANNEL_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1522,7 +1704,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,0xC2,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_OPC_CHANNEL_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1532,7 +1714,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,0xC1,0xC6,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_OPC_CHANNEL_INSTR,ASEQ_OPC_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1544,7 +1726,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_BE arg0
-        _wr_cmd_id  unk_BE, ,0xBE,,,,,,, 0, 0
+        _wr_cmd_id  unk_BE, ,ASEQ_OPC_CHANNEL_UNK_BE,,,,,,, 0, 0
         _wr_u8      \arg0
     .endm
 
@@ -1558,13 +1740,9 @@ $reladdr\@:
  *  If range is 0, it is treated as 65536.
  */
 .macro randptr range, offset
-    #if (MML_VERSION == MML_VERSION_OOT)
-        _wr_cmd_id  randptr, ,0xBD,,,,,,, 0, 0
-    #else
-        _wr_cmd_id  randptr, ,0xA8,,,,,,, 0, 0
-    #endif
-    _wr_u16         \range
-    _wr_u16         \offset
+    _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
+    _wr_u16     \range
+    _wr_u16     \offset
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -1575,7 +1753,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro samplestart arg
-        _wr_cmd_id  samplestart, ,0xBD,,,,,,, 0, 0
+        _wr_cmd_id  samplestart, ,ASEQ_OPC_CHANNEL_SAMPLESTART,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1585,7 +1763,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A7 arg
-        _wr_cmd_id  unk_A7, ,0xA7,,,,,,, 0, 0
+        _wr_cmd_id  unk_A7, ,ASEQ_OPC_CHANNEL_A7,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1595,7 +1773,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A6 arg0, arg1
-        _wr_cmd_id  unk_A6, ,0xA6,,,,,,, 0, 0
+        _wr_cmd_id  unk_A6, ,ASEQ_OPC_CHANNEL_A6,,,,,,, 0, 0
         _wr_u8      \arg0
         _wr_s16     \arg1
     .endm
@@ -1606,7 +1784,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A5
-        _wr_cmd_id  unk_A5, ,0xA5,,,,,,, 0, 0
+        _wr_cmd_id  unk_A5, ,ASEQ_OPC_CHANNEL_A5,,,,,,, 0, 0
     .endm
 
     /**
@@ -1615,7 +1793,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A4 arg
-        _wr_cmd_id  unk_A4, ,0xA4,,,,,,, 0, 0
+        _wr_cmd_id  unk_A4, ,ASEQ_OPC_CHANNEL_A4,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1625,7 +1803,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A3
-        _wr_cmd_id  unk_A3, ,0xA3,,,,,,, 0, 0
+        _wr_cmd_id  unk_A3, ,ASEQ_OPC_CHANNEL_A3,,,,,,, 0, 0
     .endm
 
     /**
@@ -1634,7 +1812,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A2 arg
-        _wr_cmd_id  unk_A2, ,0xA2,,,,,,, 0, 0
+        _wr_cmd_id  unk_A2, ,ASEQ_OPC_CHANNEL_A2,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1644,7 +1822,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A1
-        _wr_cmd_id  unk_A1, ,0xA1,,,,,,, 0, 0
+        _wr_cmd_id  unk_A1, ,ASEQ_OPC_CHANNEL_A1,,,,,,, 0, 0
     .endm
 
     /**
@@ -1653,7 +1831,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A0 arg
-        _wr_cmd_id  unk_A0, ,0xA0,,,,,,, 0, 0
+        _wr_cmd_id  unk_A0, ,ASEQ_OPC_CHANNEL_A0,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1665,7 +1843,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,0xBC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1677,7 +1855,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,0xBC,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1688,7 +1866,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,0xBB,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_OPC_CHANNEL_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1701,7 +1879,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,0xBA,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_OPC_CHANNEL_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1711,7 +1889,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,0xB9,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_OPC_CHANNEL_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1721,7 +1899,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,0xB7,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_OPC_CHANNEL_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1731,7 +1909,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,0xB6,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_OPC_CHANNEL_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1740,7 +1918,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,0xB5,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_OPC_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1749,7 +1927,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,0xB4,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OPC_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1760,7 +1938,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,0xB2,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_OPC_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1770,7 +1948,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,0xB1,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_OPC_CHANNEL_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1779,7 +1957,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,0xB0,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_OPC_CHANNEL_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1790,7 +1968,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,0x00,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_CDELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1804,9 +1982,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,0x10,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,0x18,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1820,7 +1998,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,0x30,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_OPC_CHANNEL_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1830,7 +2008,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,0x40,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_OPC_CHANNEL_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -1842,7 +2020,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,0x78,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_OPC_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -1856,7 +2034,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,0x80,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_OPC_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -1865,7 +2043,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,0x88,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_OPC_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -1875,7 +2053,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,0x90,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_OPC_CHANNEL_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -1884,7 +2062,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,0x98,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_OPC_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -1896,7 +2074,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, 0x00,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_OPC_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -1906,9 +2084,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, 0x40,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_OPC_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,0xCD,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_OPC_CHANNEL_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -1923,7 +2101,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, 0x50,0x50,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OPC_SEQUENCE_SUBIO,ASEQ_OPC_CHANNEL_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -1940,7 +2118,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, 0x60,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_OPC_SEQUENCE_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -1954,9 +2132,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,0x70,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_OPC_CHANNEL_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, 0x70,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_OPC_SEQUENCE_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -1967,7 +2145,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, 0x80,0x60,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OPC_SEQUENCE_LDIO,ASEQ_OPC_CHANNEL_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -1976,7 +2154,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, 0x90,0x20,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OPC_SEQUENCE_LDCHAN,ASEQ_OPC_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -1988,7 +2166,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, 0xA0,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_OPC_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -1998,7 +2176,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,0xC0,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2009,7 +2187,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,0xFD,0xC0,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2019,7 +2197,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,0xC1,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_OPC_LAYER_SHORTVEL,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2029,7 +2207,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,0xC3,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_OPC_LAYER_SHORTDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2039,7 +2217,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,0xC4,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_OPC_LAYER_LEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2048,7 +2226,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,0xC5,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_OPC_LAYER_NOLEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2057,7 +2235,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,0xC7,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_OPC_LAYER_PORTAMENTO,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2073,7 +2251,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,0xC8,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_OPC_LAYER_NOPORTAMENTO,,,,,, 0, 0
 .endm
 
 /**
@@ -2082,7 +2260,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,0xC9,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_OPC_LAYER_SHORTGATE,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2094,7 +2272,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,0xCA,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_OPC_LAYER_NOTEPAN,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2105,7 +2283,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,0xCC,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_OPC_LAYER_NODRUMPAN,,,,,, 0, 0
 .endm
 
 /**
@@ -2113,7 +2291,6 @@ $reladdr\@:
  *
  *  TODO DESCRIPTION
  */
-#define STEREO_OPCODE 0xCD
 .macro stereo type, strongR, strongL, strongRvrbR, strongRvrbL
     _check_arg_bitwidth_u \type, 2
     _check_arg_bitwidth_u \strongR, 1
@@ -2121,7 +2298,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  stereo, ,,STEREO_OPCODE,,,,,, 0, 0
+    _wr_cmd_id  stereo, ,,ASEQ_OPC_LAYER_STEREO,,,,,, 0, 0
     _wr_u8      (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -2131,7 +2308,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,0xD0,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_OPC_LAYER_LDSHORTVEL,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2140,7 +2317,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,0xE0,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_OPC_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2151,7 +2328,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_F0 arg
-        _wr_cmd_id  unk_F0, ,,0xF0,,,,,, 0, 0
+        _wr_cmd_id  unk_F0, ,,ASEQ_OPC_LAYER_F0,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -2160,9 +2337,8 @@ $reladdr\@:
      *
      *  TODO DESCRIPTION
      */
-    #define SURROUNDEFFECT_OPCODE 0xF1
     .macro surroundeffect arg
-        _wr_cmd_id  surroundeffect, ,,SURROUNDEFFECT_OPCODE,,,,,, 0, 0
+        _wr_cmd_id  surroundeffect, ,,ASEQ_OPC_LAYER_F1,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -2181,9 +2357,8 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDVG_OPCODE 0x00
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,0x00,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2196,16 +2371,15 @@ $reladdr\@:
  *
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
-#define NOTEDV_OPCODE 0x40
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,NOTEDV_OPCODE,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,0x40,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2218,7 +2392,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,0x80,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2232,7 +2406,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,0x00,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2245,7 +2419,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,0x40,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2257,7 +2431,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,0x80,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/include/audio/aseq.h
+++ b/include/audio/aseq.h
@@ -236,181 +236,181 @@
  */
 
 // control flow commands
-#define ASEQ_OPC_CONTROL_FLOW_FIRST 0xF2
-#define ASEQ_OPC_CTRLFLOW_RBLTZ     0xF2
-#define ASEQ_OPC_CTRLFLOW_RBEQZ     0xF3
-#define ASEQ_OPC_CTRLFLOW_RJUMP     0xF4
-#define ASEQ_OPC_CTRLFLOW_BGEZ      0xF5
-#define ASEQ_OPC_CTRLFLOW_BREAK     0xF6
-#define ASEQ_OPC_CTRLFLOW_LOOPEND   0xF7
-#define ASEQ_OPC_CTRLFLOW_LOOP      0xF8
-#define ASEQ_OPC_CTRLFLOW_BLTZ      0xF9
-#define ASEQ_OPC_CTRLFLOW_BEQZ      0xFA
-#define ASEQ_OPC_CTRLFLOW_JUMP      0xFB
-#define ASEQ_OPC_CTRLFLOW_CALL      0xFC
-#define ASEQ_OPC_CTRLFLOW_DELAY     0xFD
-#define ASEQ_OPC_CTRLFLOW_DELAY1    0xFE
-#define ASEQ_OPC_CTRLFLOW_END       0xFF
+#define ASEQ_OP_CONTROL_FLOW_FIRST 0xF2
+#define ASEQ_OP_RBLTZ   0xF2
+#define ASEQ_OP_RBEQZ   0xF3
+#define ASEQ_OP_RJUMP   0xF4
+#define ASEQ_OP_BGEZ    0xF5
+#define ASEQ_OP_BREAK   0xF6
+#define ASEQ_OP_LOOPEND 0xF7
+#define ASEQ_OP_LOOP    0xF8
+#define ASEQ_OP_BLTZ    0xF9
+#define ASEQ_OP_BEQZ    0xFA
+#define ASEQ_OP_JUMP    0xFB
+#define ASEQ_OP_CALL    0xFC
+#define ASEQ_OP_DELAY   0xFD
+#define ASEQ_OP_DELAY1  0xFE
+#define ASEQ_OP_END     0xFF
 
 // sequence commands
-#define ASEQ_OPC_SEQUENCE_TESTCHAN          0x00 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_STOPCHAN          0x40 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_SUBIO             0x50 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDRES             0x60 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_STIO              0x70 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDIO              0x80 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDCHAN            0x90 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_RLDCHAN           0xA0 // low nibble used as argument
-#define ASEQ_OPC_SEQUENCE_LDSEQ             0xB0 // low nibble used as argument
+#define ASEQ_OP_SEQ_TESTCHAN        0x00 // low nibble used as argument
+#define ASEQ_OP_SEQ_STOPCHAN        0x40 // low nibble used as argument
+#define ASEQ_OP_SEQ_SUBIO           0x50 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDRES           0x60 // low nibble used as argument
+#define ASEQ_OP_SEQ_STIO            0x70 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDIO            0x80 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDCHAN          0x90 // low nibble used as argument
+#define ASEQ_OP_SEQ_RLDCHAN         0xA0 // low nibble used as argument
+#define ASEQ_OP_SEQ_LDSEQ           0xB0 // low nibble used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_SEQUENCE_C2                0xC2
-#define ASEQ_OPC_SEQUENCE_C3                0xC3
+#define ASEQ_OP_SEQ_C2              0xC2
+#define ASEQ_OP_SEQ_C3              0xC3
 #endif
-#define ASEQ_OPC_SEQUENCE_RUNSEQ            0xC4
-#define ASEQ_OPC_SEQUENCE_SCRIPTCTR         0xC5
-#define ASEQ_OPC_SEQUENCE_STOP              0xC6
-#define ASEQ_OPC_SEQUENCE_STSEQ             0xC7
-#define ASEQ_OPC_SEQUENCE_SUB               0xC8
-#define ASEQ_OPC_SEQUENCE_AND               0xC9
-#define ASEQ_OPC_SEQUENCE_LDI               0xCC
-#define ASEQ_OPC_SEQUENCE_DYNCALL           0xCD
-#define ASEQ_OPC_SEQUENCE_RAND              0xCE
-#define ASEQ_OPC_SEQUENCE_NOTEALLOC         0xD0
-#define ASEQ_OPC_SEQUENCE_LDSHORTGATEARR    0xD1
-#define ASEQ_OPC_SEQUENCE_LDSHORTVELARR     0xD2
-#define ASEQ_OPC_SEQUENCE_MUTEBHV           0xD3
-#define ASEQ_OPC_SEQUENCE_MUTE              0xD4
-#define ASEQ_OPC_SEQUENCE_MUTESCALE         0xD5
-#define ASEQ_OPC_SEQUENCE_FREECHAN          0xD6
-#define ASEQ_OPC_SEQUENCE_INITCHAN          0xD7
-#define ASEQ_OPC_SEQUENCE_VOLSCALE          0xD9
-#define ASEQ_OPC_SEQUENCE_VOLMODE           0xDA
-#define ASEQ_OPC_SEQUENCE_VOL               0xDB
-#define ASEQ_OPC_SEQUENCE_TEMPOCHG          0xDC
-#define ASEQ_OPC_SEQUENCE_TEMPO             0xDD
-#define ASEQ_OPC_SEQUENCE_RTRANSPOSE        0xDE
-#define ASEQ_OPC_SEQUENCE_TRANSPOSE         0xDF
-#define ASEQ_OPC_SEQUENCE_EF                0xEF
-#define ASEQ_OPC_SEQUENCE_FREENOTELIST      0xF0
-#define ASEQ_OPC_SEQUENCE_ALLOCNOTELIST     0xF1
+#define ASEQ_OP_SEQ_RUNSEQ          0xC4
+#define ASEQ_OP_SEQ_SCRIPTCTR       0xC5
+#define ASEQ_OP_SEQ_STOP            0xC6
+#define ASEQ_OP_SEQ_STSEQ           0xC7
+#define ASEQ_OP_SEQ_SUB             0xC8
+#define ASEQ_OP_SEQ_AND             0xC9
+#define ASEQ_OP_SEQ_LDI             0xCC
+#define ASEQ_OP_SEQ_DYNCALL         0xCD
+#define ASEQ_OP_SEQ_RAND            0xCE
+#define ASEQ_OP_SEQ_NOTEALLOC       0xD0
+#define ASEQ_OP_SEQ_LDSHORTGATEARR  0xD1
+#define ASEQ_OP_SEQ_LDSHORTVELARR   0xD2
+#define ASEQ_OP_SEQ_MUTEBHV         0xD3
+#define ASEQ_OP_SEQ_MUTE            0xD4
+#define ASEQ_OP_SEQ_MUTESCALE       0xD5
+#define ASEQ_OP_SEQ_FREECHAN        0xD6
+#define ASEQ_OP_SEQ_INITCHAN        0xD7
+#define ASEQ_OP_SEQ_VOLSCALE        0xD9
+#define ASEQ_OP_SEQ_VOLMODE         0xDA
+#define ASEQ_OP_SEQ_VOL             0xDB
+#define ASEQ_OP_SEQ_TEMPOCHG        0xDC
+#define ASEQ_OP_SEQ_TEMPO           0xDD
+#define ASEQ_OP_SEQ_RTRANSPOSE      0xDE
+#define ASEQ_OP_SEQ_TRANSPOSE       0xDF
+#define ASEQ_OP_SEQ_EF              0xEF
+#define ASEQ_OP_SEQ_FREENOTELIST    0xF0
+#define ASEQ_OP_SEQ_ALLOCNOTELIST   0xF1
 
 // channel commands
-#define ASEQ_OPC_CHANNEL_CDELAY         0x00 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDSAMPLE       0x10 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDCHAN         0x20 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_STCIO          0x30 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDCIO          0x40 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_SUBIO          0x50 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_LDIO           0x60 // low nibble used as argument
-#define ASEQ_OPC_CHANNEL_STIO           0x70 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_RLDLAYER       0x78 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_TESTLAYER      0x80 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_LDLAYER        0x88 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_DELLAYER       0x90 // lower 3 bits used as argument
-#define ASEQ_OPC_CHANNEL_DYNLDLAYER     0x98 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_CDELAY         0x00 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDSAMPLE       0x10 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDCHAN         0x20 // low nibble used as argument
+#define ASEQ_OP_CHAN_STCIO          0x30 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDCIO          0x40 // low nibble used as argument
+#define ASEQ_OP_CHAN_SUBIO          0x50 // low nibble used as argument
+#define ASEQ_OP_CHAN_LDIO           0x60 // low nibble used as argument
+#define ASEQ_OP_CHAN_STIO           0x70 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_RLDLAYER       0x78 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_TESTLAYER      0x80 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_LDLAYER        0x88 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_DELLAYER       0x90 // lower 3 bits used as argument
+#define ASEQ_OP_CHAN_DYNLDLAYER     0x98 // lower 3 bits used as argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_CHANNEL_A0             0xA0
-#define ASEQ_OPC_CHANNEL_A1             0xA1
-#define ASEQ_OPC_CHANNEL_A2             0xA2
-#define ASEQ_OPC_CHANNEL_A3             0xA3
-#define ASEQ_OPC_CHANNEL_A4             0xA4
-#define ASEQ_OPC_CHANNEL_A5             0xA5
-#define ASEQ_OPC_CHANNEL_A6             0xA6
-#define ASEQ_OPC_CHANNEL_A7             0xA7
-#define ASEQ_OPC_CHANNEL_RANDPTR        0xA8
+#define ASEQ_OP_CHAN_A0             0xA0
+#define ASEQ_OP_CHAN_A1             0xA1
+#define ASEQ_OP_CHAN_A2             0xA2
+#define ASEQ_OP_CHAN_A3             0xA3
+#define ASEQ_OP_CHAN_A4             0xA4
+#define ASEQ_OP_CHAN_A5             0xA5
+#define ASEQ_OP_CHAN_A6             0xA6
+#define ASEQ_OP_CHAN_A7             0xA7
+#define ASEQ_OP_CHAN_RANDPTR        0xA8
 #endif
-#define ASEQ_OPC_CHANNEL_LDFILTER       0xB0
-#define ASEQ_OPC_CHANNEL_FREEFILTER     0xB1
-#define ASEQ_OPC_CHANNEL_LDSEQTOPTR     0xB2
-#define ASEQ_OPC_CHANNEL_FILTER         0xB3
-#define ASEQ_OPC_CHANNEL_PTRTODYNTBL    0xB4
-#define ASEQ_OPC_CHANNEL_DYNTBLTOPTR    0xB5
-#define ASEQ_OPC_CHANNEL_DYNTBLV        0xB6
-#define ASEQ_OPC_CHANNEL_RANDTOPTR      0xB7
-#define ASEQ_OPC_CHANNEL_RAND           0xB8
-#define ASEQ_OPC_CHANNEL_RANDVEL        0xB9
-#define ASEQ_OPC_CHANNEL_RANDGATE       0xBA
-#define ASEQ_OPC_CHANNEL_COMBFILTER     0xBB
-#define ASEQ_OPC_CHANNEL_PTRADD         0xBC
+#define ASEQ_OP_CHAN_LDFILTER       0xB0
+#define ASEQ_OP_CHAN_FREEFILTER     0xB1
+#define ASEQ_OP_CHAN_LDSEQTOPTR     0xB2
+#define ASEQ_OP_CHAN_FILTER         0xB3
+#define ASEQ_OP_CHAN_PTRTODYNTBL    0xB4
+#define ASEQ_OP_CHAN_DYNTBLTOPTR    0xB5
+#define ASEQ_OP_CHAN_DYNTBLV        0xB6
+#define ASEQ_OP_CHAN_RANDTOPTR      0xB7
+#define ASEQ_OP_CHAN_RAND           0xB8
+#define ASEQ_OP_CHAN_RANDVEL        0xB9
+#define ASEQ_OP_CHAN_RANDGATE       0xBA
+#define ASEQ_OP_CHAN_COMBFILTER     0xBB
+#define ASEQ_OP_CHAN_PTRADD         0xBC
 #if (MML_VERSION == MML_VERSION_OOT)
-#define ASEQ_OPC_CHANNEL_RANDPTR        0xBD
+#define ASEQ_OP_CHAN_RANDPTR        0xBD
 #endif
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_CHANNEL_SAMPLESTART    0xBD
-#define ASEQ_OPC_CHANNEL_UNK_BE         0xBE
+#define ASEQ_OP_CHAN_SAMPLESTART    0xBD
+#define ASEQ_OP_CHAN_UNK_BE         0xBE
 #endif
-#define ASEQ_OPC_CHANNEL_INSTR          0xC1
-#define ASEQ_OPC_CHANNEL_DYNTBL         0xC2
-#define ASEQ_OPC_CHANNEL_SHORT          0xC3
-#define ASEQ_OPC_CHANNEL_NOSHORT        0xC4
-#define ASEQ_OPC_CHANNEL_DYNTBLLOOKUP   0xC5
-#define ASEQ_OPC_CHANNEL_FONT           0xC6
-#define ASEQ_OPC_CHANNEL_STSEQ          0xC7
-#define ASEQ_OPC_CHANNEL_SUB            0xC8
-#define ASEQ_OPC_CHANNEL_AND            0xC9
-#define ASEQ_OPC_CHANNEL_MUTEBHV        0xCA
-#define ASEQ_OPC_CHANNEL_LDSEQ          0xCB
-#define ASEQ_OPC_CHANNEL_LDI            0xCC
-#define ASEQ_OPC_CHANNEL_STOPCHAN       0xCD
-#define ASEQ_OPC_CHANNEL_LDPTR          0xCE
-#define ASEQ_OPC_CHANNEL_STPTRTOSEQ     0xCF
-#define ASEQ_OPC_CHANNEL_EFFECTS        0xD0
-#define ASEQ_OPC_CHANNEL_NOTEALLOC      0xD1
-#define ASEQ_OPC_CHANNEL_SUSTAIN        0xD2
-#define ASEQ_OPC_CHANNEL_BEND           0xD3
-#define ASEQ_OPC_CHANNEL_REVERB         0xD4
-#define ASEQ_OPC_CHANNEL_VIBFREQ        0xD7
-#define ASEQ_OPC_CHANNEL_VIBDEPTH       0xD8
-#define ASEQ_OPC_CHANNEL_RELEASERATE    0xD9
-#define ASEQ_OPC_CHANNEL_ENV            0xDA
-#define ASEQ_OPC_CHANNEL_TRANSPOSE      0xDB
-#define ASEQ_OPC_CHANNEL_PANWEIGHT      0xDC
-#define ASEQ_OPC_CHANNEL_PAN            0xDD
-#define ASEQ_OPC_CHANNEL_FREQSCALE      0xDE
-#define ASEQ_OPC_CHANNEL_VOL            0xDF
-#define ASEQ_OPC_CHANNEL_VOLEXP         0xE0
-#define ASEQ_OPC_CHANNEL_VIBFREQGRAD    0xE1
-#define ASEQ_OPC_CHANNEL_VIBDEPTHGRAD   0xE2
-#define ASEQ_OPC_CHANNEL_VIBDELAY       0xE3
-#define ASEQ_OPC_CHANNEL_DYNCALL        0xE4
-#define ASEQ_OPC_CHANNEL_REVERBIDX      0xE5
-#define ASEQ_OPC_CHANNEL_SAMPLEBOOK     0xE6
-#define ASEQ_OPC_CHANNEL_LDPARAMS       0xE7
-#define ASEQ_OPC_CHANNEL_PARAMS         0xE8
-#define ASEQ_OPC_CHANNEL_NOTEPRI        0xE9
-#define ASEQ_OPC_CHANNEL_STOP           0xEA
-#define ASEQ_OPC_CHANNEL_FONTINSTR      0xEB
-#define ASEQ_OPC_CHANNEL_VIBRESET       0xEC
-#define ASEQ_OPC_CHANNEL_GAIN           0xED
-#define ASEQ_OPC_CHANNEL_BENDFINE       0xEE
-#define ASEQ_OPC_CHANNEL_FREENOTELIST   0xF0
-#define ASEQ_OPC_CHANNEL_ALLOCNOTELIST  0xF1
+#define ASEQ_OP_CHAN_INSTR          0xC1
+#define ASEQ_OP_CHAN_DYNTBL         0xC2
+#define ASEQ_OP_CHAN_SHORT          0xC3
+#define ASEQ_OP_CHAN_NOSHORT        0xC4
+#define ASEQ_OP_CHAN_DYNTBLLOOKUP   0xC5
+#define ASEQ_OP_CHAN_FONT           0xC6
+#define ASEQ_OP_CHAN_STSEQ          0xC7
+#define ASEQ_OP_CHAN_SUB            0xC8
+#define ASEQ_OP_CHAN_AND            0xC9
+#define ASEQ_OP_CHAN_MUTEBHV        0xCA
+#define ASEQ_OP_CHAN_LDSEQ          0xCB
+#define ASEQ_OP_CHAN_LDI            0xCC
+#define ASEQ_OP_CHAN_STOPCHAN       0xCD
+#define ASEQ_OP_CHAN_LDPTR          0xCE
+#define ASEQ_OP_CHAN_STPTRTOSEQ     0xCF
+#define ASEQ_OP_CHAN_EFFECTS        0xD0
+#define ASEQ_OP_CHAN_NOTEALLOC      0xD1
+#define ASEQ_OP_CHAN_SUSTAIN        0xD2
+#define ASEQ_OP_CHAN_BEND           0xD3
+#define ASEQ_OP_CHAN_REVERB         0xD4
+#define ASEQ_OP_CHAN_VIBFREQ        0xD7
+#define ASEQ_OP_CHAN_VIBDEPTH       0xD8
+#define ASEQ_OP_CHAN_RELEASERATE    0xD9
+#define ASEQ_OP_CHAN_ENV            0xDA
+#define ASEQ_OP_CHAN_TRANSPOSE      0xDB
+#define ASEQ_OP_CHAN_PANWEIGHT      0xDC
+#define ASEQ_OP_CHAN_PAN            0xDD
+#define ASEQ_OP_CHAN_FREQSCALE      0xDE
+#define ASEQ_OP_CHAN_VOL            0xDF
+#define ASEQ_OP_CHAN_VOLEXP         0xE0
+#define ASEQ_OP_CHAN_VIBFREQGRAD    0xE1
+#define ASEQ_OP_CHAN_VIBDEPTHGRAD   0xE2
+#define ASEQ_OP_CHAN_VIBDELAY       0xE3
+#define ASEQ_OP_CHAN_DYNCALL        0xE4
+#define ASEQ_OP_CHAN_REVERBIDX      0xE5
+#define ASEQ_OP_CHAN_SAMPLEBOOK     0xE6
+#define ASEQ_OP_CHAN_LDPARAMS       0xE7
+#define ASEQ_OP_CHAN_PARAMS         0xE8
+#define ASEQ_OP_CHAN_NOTEPRI        0xE9
+#define ASEQ_OP_CHAN_STOP           0xEA
+#define ASEQ_OP_CHAN_FONTINSTR      0xEB
+#define ASEQ_OP_CHAN_VIBRESET       0xEC
+#define ASEQ_OP_CHAN_GAIN           0xED
+#define ASEQ_OP_CHAN_BENDFINE       0xEE
+#define ASEQ_OP_CHAN_FREENOTELIST   0xF0
+#define ASEQ_OP_CHAN_ALLOCNOTELIST  0xF1
 
 // layer commands
-#define ASEQ_OPC_LAYER_NOTEDVG      0x00
-#define ASEQ_OPC_LAYER_NOTEDV       0x40
-#define ASEQ_OPC_LAYER_NOTEVG       0x80
-#define ASEQ_OPC_LAYER_LDELAY       0xC0
-#define ASEQ_OPC_LAYER_SHORTVEL     0xC1
-#define ASEQ_OPC_LAYER_TRANSPOSE    0xC2
-#define ASEQ_OPC_LAYER_SHORTDELAY   0xC3
-#define ASEQ_OPC_LAYER_LEGATO       0xC4
-#define ASEQ_OPC_LAYER_NOLEGATO     0xC5
-#define ASEQ_OPC_LAYER_INSTR        0xC6
-#define ASEQ_OPC_LAYER_PORTAMENTO   0xC7
-#define ASEQ_OPC_LAYER_NOPORTAMENTO 0xC8
-#define ASEQ_OPC_LAYER_SHORTGATE    0xC9
-#define ASEQ_OPC_LAYER_NOTEPAN      0xCA
-#define ASEQ_OPC_LAYER_ENV          0xCB
-#define ASEQ_OPC_LAYER_NODRUMPAN    0xCC
-#define ASEQ_OPC_LAYER_STEREO       0xCD
-#define ASEQ_OPC_LAYER_BENDFINE     0xCE
-#define ASEQ_OPC_LAYER_RELEASERATE  0xCF
-#define ASEQ_OPC_LAYER_LDSHORTVEL   0xD0 // low nibble used as an argument
-#define ASEQ_OPC_LAYER_LDSHORTGATE  0xE0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_NOTEDVG       0x00
+#define ASEQ_OP_LAYER_NOTEDV        0x40
+#define ASEQ_OP_LAYER_NOTEVG        0x80
+#define ASEQ_OP_LAYER_LDELAY        0xC0
+#define ASEQ_OP_LAYER_SHORTVEL      0xC1
+#define ASEQ_OP_LAYER_TRANSPOSE     0xC2
+#define ASEQ_OP_LAYER_SHORTDELAY    0xC3
+#define ASEQ_OP_LAYER_LEGATO        0xC4
+#define ASEQ_OP_LAYER_NOLEGATO      0xC5
+#define ASEQ_OP_LAYER_INSTR         0xC6
+#define ASEQ_OP_LAYER_PORTAMENTO    0xC7
+#define ASEQ_OP_LAYER_NOPORTAMENTO  0xC8
+#define ASEQ_OP_LAYER_SHORTGATE     0xC9
+#define ASEQ_OP_LAYER_NOTEPAN       0xCA
+#define ASEQ_OP_LAYER_ENV           0xCB
+#define ASEQ_OP_LAYER_NODRUMPAN     0xCC
+#define ASEQ_OP_LAYER_STEREO        0xCD
+#define ASEQ_OP_LAYER_BENDFINE      0xCE
+#define ASEQ_OP_LAYER_RELEASERATE   0xCF
+#define ASEQ_OP_LAYER_LDSHORTVEL    0xD0 // low nibble used as an argument
+#define ASEQ_OP_LAYER_LDSHORTGATE   0xE0 // low nibble used as an argument
 #if (MML_VERSION == MML_VERSION_MM)
-#define ASEQ_OPC_LAYER_F0           0xF0
-#define ASEQ_OPC_LAYER_F1           0xF1
+#define ASEQ_OP_LAYER_F0            0xF0
+#define ASEQ_OP_LAYER_F1            0xF1
 #endif
 
 
@@ -571,7 +571,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq ioPortNum, seqId, label
-        _wr_cmd_id  ldseq, ASEQ_OPC_SEQUENCE_LDSEQ,,,,,,,, \ioPortNum, 4
+        _wr_cmd_id  ldseq, ASEQ_OP_SEQ_LDSEQ,,,,,,,, \ioPortNum, 4
         _wr_u8      \seqId
         _wr_lbl     \label
     .endm
@@ -589,7 +589,7 @@ _RESET_SECTION
     /* `ldseq` changes structure based on current section. */
     .purgem ldseq
     .macro ldseq label
-        _wr_cmd_id  ldseq, ,ASEQ_OPC_CHANNEL_LDSEQ,,,,,,, 0, 0
+        _wr_cmd_id  ldseq, ,ASEQ_OP_CHAN_LDSEQ,,,,,,, 0, 0
         _wr_lbl     \label
     .endm
 
@@ -599,14 +599,14 @@ _RESET_SECTION
         _check_arg_bitwidth_u \lowpassCutoff, 4
         _check_arg_bitwidth_u \highpassCutoff, 4
 
-        _wr_cmd_id filter, ,ASEQ_OPC_CHANNEL_FILTER,,,,,,, 0, 0
+        _wr_cmd_id filter, ,ASEQ_OP_CHAN_FILTER,,,,,,, 0, 0
         _wr_u8 (\lowpassCutoff << 4) | (\highpassCutoff)
     .endm
 
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label
-        _wr_cmd_id env, ,ASEQ_OPC_CHANNEL_ENV,,,,,,, 0, 0
+        _wr_cmd_id env, ,ASEQ_OP_CHAN_ENV,,,,,,, 0, 0
         _wr_lbl \label
     .endm
 
@@ -623,7 +623,7 @@ _RESET_SECTION
     /* `env` changes structure based on current section. */
     .purgem env
     .macro env label, arg
-        _wr_cmd_id env, ,,ASEQ_OPC_LAYER_ENV,,,,,, 0, 0
+        _wr_cmd_id env, ,,ASEQ_OP_LAYER_ENV,,,,,, 0, 0
         _wr_lbl \label
         _wr_u8 \arg
     .endm
@@ -915,7 +915,7 @@ $reladdr\@:
  *  closed, so are its layers.
  */
 .macro end
-    _wr_cmd_id  end, ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,ASEQ_OPC_CTRLFLOW_END,,,,,, 0, 0
+    _wr_cmd_id  end, ASEQ_OP_END,ASEQ_OP_END,ASEQ_OP_END,,,,,, 0, 0
 .endm
 
 /**
@@ -924,7 +924,7 @@ $reladdr\@:
  *  Delays for one tick.
  */
 .macro delay1
-    _wr_cmd_id  delay1, ASEQ_OPC_CTRLFLOW_DELAY1,ASEQ_OPC_CTRLFLOW_DELAY1,,,,,,, 0, 0
+    _wr_cmd_id  delay1, ASEQ_OP_DELAY1,ASEQ_OP_DELAY1,,,,,,, 0, 0
 .endm
 
 /**
@@ -933,7 +933,7 @@ $reladdr\@:
  *  Delays for `delay` ticks.
  */
 .macro delay delay
-    _wr_cmd_id  delay, ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_CTRLFLOW_DELAY,,,,,,, 0, 0
+    _wr_cmd_id  delay, ASEQ_OP_DELAY,ASEQ_OP_DELAY,,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -944,7 +944,7 @@ $reladdr\@:
  *  subroutine encounters an `end` instruction.
  */
 .macro call label
-    _wr_cmd_id  call, ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,ASEQ_OPC_CTRLFLOW_CALL,,,,,, 0, 0
+    _wr_cmd_id  call, ASEQ_OP_CALL,ASEQ_OP_CALL,ASEQ_OP_CALL,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -954,7 +954,7 @@ $reladdr\@:
  *  Branches to `label` unconditionally.
  */
 .macro jump label
-    _wr_cmd_id  jump, ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,ASEQ_OPC_CTRLFLOW_JUMP,,,,,, 0, 0
+    _wr_cmd_id  jump, ASEQ_OP_JUMP,ASEQ_OP_JUMP,ASEQ_OP_JUMP,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -964,7 +964,7 @@ $reladdr\@:
  *  Branches to `label` if TR == 0.
  */
 .macro beqz label
-    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,ASEQ_OPC_CTRLFLOW_BEQZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_BEQZ,ASEQ_OP_BEQZ,ASEQ_OP_BEQZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -974,7 +974,7 @@ $reladdr\@:
  *  Branches to `label` if TR < 0.
  */
 .macro bltz label
-    _wr_cmd_id  beqz, ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,ASEQ_OPC_CTRLFLOW_BLTZ,,,,,, 0, 0
+    _wr_cmd_id  beqz, ASEQ_OP_BLTZ,ASEQ_OP_BLTZ,ASEQ_OP_BLTZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -988,7 +988,7 @@ $reladdr\@:
  *  becomes full.
  */
 .macro loop num
-    _wr_cmd_id  loop, ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,ASEQ_OPC_CTRLFLOW_LOOP,,,,,, 0, 0
+    _wr_cmd_id  loop, ASEQ_OP_LOOP,ASEQ_OP_LOOP,ASEQ_OP_LOOP,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1002,7 +1002,7 @@ $reladdr\@:
  *  stack is popped.
  */
 .macro loopend
-    _wr_cmd_id  loopend, ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,ASEQ_OPC_CTRLFLOW_LOOPEND,,,,,, 0, 0
+    _wr_cmd_id  loopend, ASEQ_OP_LOOPEND,ASEQ_OP_LOOPEND,ASEQ_OP_LOOPEND,,,,,, 0, 0
 .endm
 
 /**
@@ -1015,7 +1015,7 @@ $reladdr\@:
  *  the call stack would be popped twice.
  */
 .macro break
-    _wr_cmd_id  break, ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,ASEQ_OPC_CTRLFLOW_BREAK,,,,,, 0, 0
+    _wr_cmd_id  break, ASEQ_OP_BREAK,ASEQ_OP_BREAK,ASEQ_OP_BREAK,,,,,, 0, 0
 .endm
 
 /**
@@ -1024,7 +1024,7 @@ $reladdr\@:
  *  Branches to `label` if TR >= 0.
  */
 .macro bgez label
-    _wr_cmd_id  bgez, ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,ASEQ_OPC_CTRLFLOW_BGEZ,,,,,, 0, 0
+    _wr_cmd_id  bgez, ASEQ_OP_BGEZ,ASEQ_OP_BGEZ,ASEQ_OP_BGEZ,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1038,7 +1038,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rjump label
-    _wr_cmd_id  rjump, ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,ASEQ_OPC_CTRLFLOW_RJUMP,,,,,, 0, 0
+    _wr_cmd_id  rjump, ASEQ_OP_RJUMP,ASEQ_OP_RJUMP,ASEQ_OP_RJUMP,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1052,7 +1052,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbeqz label
-    _wr_cmd_id  rbeqz, ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,ASEQ_OPC_CTRLFLOW_RBEQZ,,,,,, 0, 0
+    _wr_cmd_id  rbeqz, ASEQ_OP_RBEQZ,ASEQ_OP_RBEQZ,ASEQ_OP_RBEQZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1066,7 +1066,7 @@ $reladdr\@:
  *  signed 8-bit (+/-128) range are reachable.
  */
 .macro rbltz label
-    _wr_cmd_id  rbltz, ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,ASEQ_OPC_CTRLFLOW_RBLTZ,,,,,, 0, 0
+    _wr_cmd_id  rbltz, ASEQ_OP_RBLTZ,ASEQ_OP_RBLTZ,ASEQ_OP_RBLTZ,,,,,, 0, 0
     _wr_8_rel   \label
 .endm
 
@@ -1076,7 +1076,7 @@ $reladdr\@:
  *  Clears the channel note pool and reallocates it with space for `num` notes.
  */
 .macro allocnotelist num
-    _wr_cmd_id  allocnotelist, ASEQ_OPC_SEQUENCE_ALLOCNOTELIST,ASEQ_OPC_CHANNEL_ALLOCNOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  allocnotelist, ASEQ_OP_SEQ_ALLOCNOTELIST,ASEQ_OP_CHAN_ALLOCNOTELIST,,,,,,, 0, 0
     _wr_u8      \num
 .endm
 
@@ -1086,7 +1086,7 @@ $reladdr\@:
  *  Clears the channel note pool.
  */
 .macro freenotelist
-    _wr_cmd_id  freenotelist, ASEQ_OPC_SEQUENCE_FREENOTELIST,ASEQ_OPC_CHANNEL_FREENOTELIST,,,,,,, 0, 0
+    _wr_cmd_id  freenotelist, ASEQ_OP_SEQ_FREENOTELIST,ASEQ_OP_CHAN_FREENOTELIST,,,,,,, 0, 0
 .endm
 
 /**
@@ -1095,7 +1095,7 @@ $reladdr\@:
  *  Has no function.
  */
 .macro unk_EF arg1, arg2
-    _wr_cmd_id  unk_EF, ASEQ_OPC_SEQUENCE_EF,,,,,,,, 0, 0
+    _wr_cmd_id  unk_EF, ASEQ_OP_SEQ_EF,,,,,,,, 0, 0
     _wr_s16     \arg1
     _w_u8       \arg2
 .endm
@@ -1106,7 +1106,7 @@ $reladdr\@:
  *  Fine-tunes the pitch bend amount for the channel or layer.
  */
 .macro bendfine amt
-    _wr_cmd_id  bendfine, ,ASEQ_OPC_CHANNEL_BENDFINE,ASEQ_OPC_LAYER_BENDFINE,,,,,, 0, 0
+    _wr_cmd_id  bendfine, ,ASEQ_OP_CHAN_BENDFINE,ASEQ_OP_LAYER_BENDFINE,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1116,7 +1116,7 @@ $reladdr\@:
  *  Sets the channel gain (multiplicative volume scale factor) to the provided qu4.4 fixed-point value.
  */
 .macro gain value
-    _wr_cmd_id  gain, ,ASEQ_OPC_CHANNEL_GAIN,,,,,,, 0, 0
+    _wr_cmd_id  gain, ,ASEQ_OP_CHAN_GAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1126,7 +1126,7 @@ $reladdr\@:
  *  Resets channel vibrato, filter, gain, sustain, etc. state.
  */
 .macro vibreset
-    _wr_cmd_id  vibreset, ,ASEQ_OPC_CHANNEL_VIBRESET,,,,,,, 0, 0
+    _wr_cmd_id  vibreset, ,ASEQ_OP_CHAN_VIBRESET,,,,,,, 0, 0
 .endm
 
 /**
@@ -1135,7 +1135,7 @@ $reladdr\@:
  *  Updates the soundfont and instrument for the channel simultaneously.
  */
 .macro fontinstr fontId, instId
-    _wr_cmd_id  fontinstr, ,ASEQ_OPC_CHANNEL_FONTINSTR,,,,,,, 0, 0
+    _wr_cmd_id  fontinstr, ,ASEQ_OP_CHAN_FONTINSTR,,,,,,, 0, 0
     _wr_u8      \fontId
     _wr_u8      \instId
 .endm
@@ -1148,7 +1148,7 @@ $reladdr\@:
 .macro notepri priority1, priority2
     _check_arg_bitwidth_u \priority1, 4
     _check_arg_bitwidth_u \priority2, 4
-    _wr_cmd_id  notepri, ,ASEQ_OPC_CHANNEL_NOTEPRI,,,,,,, 0, 0
+    _wr_cmd_id  notepri, ,ASEQ_OP_CHAN_NOTEPRI,,,,,,, 0, 0
     _wr_u8      (\priority1 << 4) | \priority2
 .endm
 
@@ -1159,7 +1159,7 @@ $reladdr\@:
  *  Sets various channel parameters.
  */
 .macro params muteBhv, noteAllocPolicy, channelPriority, transposition, pan, panWeight, reverb, reverbIndex
-    _wr_cmd_id  params, ,ASEQ_OPC_CHANNEL_PARAMS,,,,,,, 0, 0
+    _wr_cmd_id  params, ,ASEQ_OP_CHAN_PARAMS,,,,,,, 0, 0
     _wr_u8      \muteBhv
     _wr_u8      \noteAllocPolicy
     _wr_u8      \channelPriority
@@ -1177,7 +1177,7 @@ $reladdr\@:
  *  is ordered in the same way as the arguments in `params`.
  */
 .macro ldparams label
-    _wr_cmd_id  ldparams, ,ASEQ_OPC_CHANNEL_LDPARAMS,,,,,,, 0, 0
+    _wr_cmd_id  ldparams, ,ASEQ_OP_CHAN_LDPARAMS,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1187,7 +1187,7 @@ $reladdr\@:
  *  Sets the sample book mode.
  */
 .macro samplebook value
-    _wr_cmd_id  samplebook, ,ASEQ_OPC_CHANNEL_SAMPLEBOOK,,,,,,, 0, 0
+    _wr_cmd_id  samplebook, ,ASEQ_OP_CHAN_SAMPLEBOOK,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1197,7 +1197,7 @@ $reladdr\@:
  *  Sets the channel reverb.
  */
 .macro reverbidx arg
-    _wr_cmd_id  reverbidx, ,ASEQ_OPC_CHANNEL_REVERBIDX,,,,,,, 0, 0
+    _wr_cmd_id  reverbidx, ,ASEQ_OP_CHAN_REVERBIDX,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1207,7 +1207,7 @@ $reladdr\@:
  *  Sets the channel vibrato delay.
  */
 .macro vibdelay arg
-    _wr_cmd_id  vibdelay, ,ASEQ_OPC_CHANNEL_VIBDELAY,,,,,,, 0, 0
+    _wr_cmd_id  vibdelay, ,ASEQ_OP_CHAN_VIBDELAY,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1217,7 +1217,7 @@ $reladdr\@:
  *  Sets the vibrato extent.
  */
 .macro vibdepthgrad arg0, arg1, arg2
-    _wr_cmd_id  vibdepthgrad, ,ASEQ_OPC_CHANNEL_VIBDEPTHGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibdepthgrad, ,ASEQ_OP_CHAN_VIBDEPTHGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1229,7 +1229,7 @@ $reladdr\@:
  *  Sets the vibrato rate.
  */
 .macro vibfreqgrad arg0, arg1, arg2
-    _wr_cmd_id  vibfreqgrad, ,ASEQ_OPC_CHANNEL_VIBFREQGRAD,,,,,,, 0, 0
+    _wr_cmd_id  vibfreqgrad, ,ASEQ_OP_CHAN_VIBFREQGRAD,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u8      \arg1
     _wr_u8      \arg2
@@ -1241,7 +1241,7 @@ $reladdr\@:
  *  Changes the expression amount for the channel.
  */
 .macro volexp amt
-    _wr_cmd_id  volexp, ,ASEQ_OPC_CHANNEL_VOLEXP,,,,,,, 0, 0
+    _wr_cmd_id  volexp, ,ASEQ_OP_CHAN_VOLEXP,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1252,7 +1252,7 @@ $reladdr\@:
  *  provided number of semitones.
  */
 .macro transpose semitones
-    _wr_cmd_id  transpose, ASEQ_OPC_SEQUENCE_TRANSPOSE,ASEQ_OPC_CHANNEL_TRANSPOSE,ASEQ_OPC_LAYER_TRANSPOSE,,,,,, 0, 0
+    _wr_cmd_id  transpose, ASEQ_OP_SEQ_TRANSPOSE,ASEQ_OP_CHAN_TRANSPOSE,ASEQ_OP_LAYER_TRANSPOSE,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1262,7 +1262,7 @@ $reladdr\@:
  *  Adjusts the transposition amount. This is only available at the top sequence level.
  */
 .macro rtranspose semitones
-    _wr_cmd_id  rtranspose, ASEQ_OPC_SEQUENCE_RTRANSPOSE,,,,,,,, 0, 0
+    _wr_cmd_id  rtranspose, ASEQ_OP_SEQ_RTRANSPOSE,,,,,,,, 0, 0
     _wr_s8      \semitones
 .endm
 
@@ -1272,7 +1272,7 @@ $reladdr\@:
  *  Sets the freqScale for the current channel.
  */
 .macro freqscale arg
-    _wr_cmd_id  freqscale, ,ASEQ_OPC_CHANNEL_FREQSCALE,,,,,,, 0, 0
+    _wr_cmd_id  freqscale, ,ASEQ_OP_CHAN_FREQSCALE,,,,,,, 0, 0
     _wr_s16     \arg
 .endm
 
@@ -1282,7 +1282,7 @@ $reladdr\@:
  *  Changes the tempo of the sequence.
  */
 .macro tempo bpm
-    _wr_cmd_id  tempo, ASEQ_OPC_SEQUENCE_TEMPO,,,,,,,, 0, 0
+    _wr_cmd_id  tempo, ASEQ_OP_SEQ_TEMPO,,,,,,,, 0, 0
     _wr_u8      \bpm
 .endm
 
@@ -1292,7 +1292,7 @@ $reladdr\@:
  *  Sets the tempoChange for the sequence.
  */
 .macro tempochg arg
-    _wr_cmd_id  tempochg, ASEQ_OPC_SEQUENCE_TEMPOCHG,,,,,,,, 0, 0
+    _wr_cmd_id  tempochg, ASEQ_OP_SEQ_TEMPOCHG,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1304,7 +1304,7 @@ $reladdr\@:
 .macro pan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  pan, ,ASEQ_OPC_CHANNEL_PAN,,,,,,, 0, 0
+    _wr_cmd_id  pan, ,ASEQ_OP_CHAN_PAN,,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -1320,7 +1320,7 @@ $reladdr\@:
 .macro panweight weight
     /* weight can only take values in 0..127 */
     _check_arg_bitwidth_u \weight, 7
-    _wr_cmd_id  panweight, ,ASEQ_OPC_CHANNEL_PANWEIGHT,,,,,,, 0, 0
+    _wr_cmd_id  panweight, ,ASEQ_OP_CHAN_PANWEIGHT,,,,,,, 0, 0
     _wr_u8      \weight
 .endm
 
@@ -1330,7 +1330,7 @@ $reladdr\@:
  *  Sets the volume amount for this sequence or channel.
  */
 .macro vol amt
-    _wr_cmd_id  vol, ASEQ_OPC_SEQUENCE_VOL,ASEQ_OPC_CHANNEL_VOL,,,,,,, 0, 0
+    _wr_cmd_id  vol, ASEQ_OP_SEQ_VOL,ASEQ_OP_CHAN_VOL,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1340,7 +1340,7 @@ $reladdr\@:
  *  TODO DESCRIPTION
  */
 .macro volmode mode, fadeTimer
-    _wr_cmd_id  volmode, ASEQ_OPC_SEQUENCE_VOLMODE,,,,,,,, 0, 0
+    _wr_cmd_id  volmode, ASEQ_OP_SEQ_VOLMODE,,,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u16     \fadeTimer
 .endm
@@ -1351,7 +1351,7 @@ $reladdr\@:
  *  Sets the fadeVolumeScale for the sequence.
  */
 .macro volscale arg
-    _wr_cmd_id  volscale, ASEQ_OPC_SEQUENCE_VOLSCALE,,,,,,,, 0, 0
+    _wr_cmd_id  volscale, ASEQ_OP_SEQ_VOLSCALE,,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1361,7 +1361,7 @@ $reladdr\@:
  *  Sets the envelope release rate for this channel or layer.
  */
 .macro releaserate release
-    _wr_cmd_id  releaserate, ,ASEQ_OPC_CHANNEL_RELEASERATE,ASEQ_OPC_LAYER_RELEASERATE,,,,,, 0, 0
+    _wr_cmd_id  releaserate, ,ASEQ_OP_CHAN_RELEASERATE,ASEQ_OP_LAYER_RELEASERATE,,,,,, 0, 0
     _wr_u8      \release
 .endm
 
@@ -1371,7 +1371,7 @@ $reladdr\@:
  *  Sets the vibrato depth for the channel.
  */
 .macro vibdepth arg
-    _wr_cmd_id  vibdepth, ,ASEQ_OPC_CHANNEL_VIBDEPTH,,,,,,, 0, 0
+    _wr_cmd_id  vibdepth, ,ASEQ_OP_CHAN_VIBDEPTH,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1381,7 +1381,7 @@ $reladdr\@:
  *  Sets the vibrato rate for the channel.
  */
 .macro vibfreq arg
-    _wr_cmd_id  vibfreq, ,ASEQ_OPC_CHANNEL_VIBFREQ,,,,,,, 0, 0
+    _wr_cmd_id  vibfreq, ,ASEQ_OP_CHAN_VIBFREQ,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1394,7 +1394,7 @@ $reladdr\@:
  *       initchan 0b101 initializes channels 0 and 2.
  */
 .macro initchan bitmask
-    _wr_cmd_id  initchan, ASEQ_OPC_SEQUENCE_INITCHAN,,,,,,,, 0, 0
+    _wr_cmd_id  initchan, ASEQ_OP_SEQ_INITCHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1404,7 +1404,7 @@ $reladdr\@:
  *  Frees the channels marked in the provided bitmask.
  */
 .macro freechan bitmask
-    _wr_cmd_id  freechan, ASEQ_OPC_SEQUENCE_FREECHAN,,,,,,,, 0, 0
+    _wr_cmd_id  freechan, ASEQ_OP_SEQ_FREECHAN,,,,,,,, 0, 0
     _wr_u16     \bitmask
 .endm
 
@@ -1414,7 +1414,7 @@ $reladdr\@:
  *  Sets the muteVolumeScale for the sequence.
  */
 .macro mutescale arg
-    _wr_cmd_id  mutescale, ASEQ_OPC_SEQUENCE_MUTESCALE,,,,,,,, 0, 0
+    _wr_cmd_id  mutescale, ASEQ_OP_SEQ_MUTESCALE,,,,,,,, 0, 0
     _wr_s8      \arg
 .endm
 
@@ -1424,7 +1424,7 @@ $reladdr\@:
  *  Mutes the sequence player.
  */
 .macro mute
-    _wr_cmd_id  mute, ASEQ_OPC_SEQUENCE_MUTE,,,,,,,, 0, 0
+    _wr_cmd_id  mute, ASEQ_OP_SEQ_MUTE,,,,,,,, 0, 0
 .endm
 
 /**
@@ -1433,7 +1433,7 @@ $reladdr\@:
  *  Sets the reverb amount for this channel.
  */
 .macro reverb amt
-    _wr_cmd_id  reverb, ,ASEQ_OPC_CHANNEL_REVERB,,,,,,, 0, 0
+    _wr_cmd_id  reverb, ,ASEQ_OP_CHAN_REVERB,,,,,,, 0, 0
     _wr_u8      \amt
 .endm
 
@@ -1443,7 +1443,7 @@ $reladdr\@:
  *  Sets mute behavior for this sequence or channel.
  */
 .macro mutebhv flags
-    _wr_cmd_id  mutebhv, ASEQ_OPC_SEQUENCE_MUTEBHV,ASEQ_OPC_CHANNEL_MUTEBHV,,,,,,, 0, 0
+    _wr_cmd_id  mutebhv, ASEQ_OP_SEQ_MUTEBHV,ASEQ_OP_CHAN_MUTEBHV,,,,,,, 0, 0
     _wr_u8      \flags
 .endm
 
@@ -1453,7 +1453,7 @@ $reladdr\@:
  *  Sets the pitch bend amount for this channel.
  */
 .macro bend amt
-    _wr_cmd_id  bend, ,ASEQ_OPC_CHANNEL_BEND,,,,,,, 0, 0
+    _wr_cmd_id  bend, ,ASEQ_OP_CHAN_BEND,,,,,,, 0, 0
     _wr_s8      \amt
 .endm
 
@@ -1463,7 +1463,7 @@ $reladdr\@:
  *  Sets the location of SHORTVELTBL.
  */
 .macro ldshortvelarr label
-    _wr_cmd_id  ldshortvelarr, ASEQ_OPC_SEQUENCE_LDSHORTVELARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortvelarr, ASEQ_OP_SEQ_LDSHORTVELARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1473,7 +1473,7 @@ $reladdr\@:
  *  Sets the adsr sustain value for this channel.
  */
 .macro sustain value
-    _wr_cmd_id  sustain, ,ASEQ_OPC_CHANNEL_SUSTAIN,,,,,,, 0, 0
+    _wr_cmd_id  sustain, ,ASEQ_OP_CHAN_SUSTAIN,,,,,,, 0, 0
     _wr_u8      \value
 .endm
 
@@ -1483,7 +1483,7 @@ $reladdr\@:
  *  Sets the location of SHORTGATETBL.
  */
 .macro ldshortgatearr label
-    _wr_cmd_id  ldshortgatearr, ASEQ_OPC_SEQUENCE_LDSHORTGATEARR,,,,,,,, 0, 0
+    _wr_cmd_id  ldshortgatearr, ASEQ_OP_SEQ_LDSHORTGATEARR,,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1493,7 +1493,7 @@ $reladdr\@:
  *  Sets the noteAllocPolicy for either the sequence or the current channel.
  */
 .macro notealloc arg
-    _wr_cmd_id  notealloc, ASEQ_OPC_SEQUENCE_NOTEALLOC,ASEQ_OPC_CHANNEL_NOTEALLOC,,,,,,, 0, 0
+    _wr_cmd_id  notealloc, ASEQ_OP_SEQ_NOTEALLOC,ASEQ_OP_CHAN_NOTEALLOC,,,,,,, 0, 0
     _wr_u8      \arg
 .endm
 
@@ -1510,7 +1510,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  effects, ,ASEQ_OPC_CHANNEL_EFFECTS,,,,,,, 0, 0
+    _wr_cmd_id  effects, ,ASEQ_OP_CHAN_EFFECTS,,,,,,, 0, 0
     _wr_u8      (\headset << 7) | (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -1520,7 +1520,7 @@ $reladdr\@:
  *  Stores TP -> label
  */
 .macro stptrtoseq label
-    _wr_cmd_id  stptrtoseq, ,ASEQ_OPC_CHANNEL_STPTRTOSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stptrtoseq, ,ASEQ_OP_CHAN_STPTRTOSEQ,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1530,7 +1530,7 @@ $reladdr\@:
  *  Loads label -> TP
  */
 .macro ldptr label
-    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHAN_LDPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1540,7 +1540,7 @@ $reladdr\@:
  *  Loads imm -> TP
  */
 .macro ldptri imm
-    _wr_cmd_id  ldptr, ,ASEQ_OPC_CHANNEL_LDPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldptr, ,ASEQ_OP_CHAN_LDPTR,,,,,,, 0, 0
     _wr_u16     \imm
 .endm
 
@@ -1550,7 +1550,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TR. If max is 0 the range is [0, 255]
  */
 .macro rand max
-    _wr_cmd_id  rand, ASEQ_OPC_SEQUENCE_RAND,ASEQ_OPC_CHANNEL_RAND,,,,,,, 0, 0
+    _wr_cmd_id  rand, ASEQ_OP_SEQ_RAND,ASEQ_OP_CHAN_RAND,,,,,,, 0, 0
     _wr_u8      \max
 .endm
 
@@ -1565,9 +1565,9 @@ $reladdr\@:
  */
 .macro dyncall table=-1
     .if \table == -1
-        _wr_cmd_id  dyncall, ,ASEQ_OPC_CHANNEL_DYNCALL,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ,ASEQ_OP_CHAN_DYNCALL,,,,,,, 0, 0
     .else
-        _wr_cmd_id  dyncall, ASEQ_OPC_SEQUENCE_DYNCALL,,,,,,,, 0, 0
+        _wr_cmd_id  dyncall, ASEQ_OP_SEQ_DYNCALL,,,,,,,, 0, 0
         _wr_lbl     \table
     .endif
 .endm
@@ -1578,7 +1578,7 @@ $reladdr\@:
  *  Loads the immediate value `imm` into TR.
  */
 .macro ldi imm
-    _wr_cmd_id  ldi, ASEQ_OPC_SEQUENCE_LDI,ASEQ_OPC_CHANNEL_LDI,,,,,,, 0, 0
+    _wr_cmd_id  ldi, ASEQ_OP_SEQ_LDI,ASEQ_OP_CHAN_LDI,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1588,7 +1588,7 @@ $reladdr\@:
  *  Computes TR = TR & imm
  */
 .macro and imm
-    _wr_cmd_id  and, ASEQ_OPC_SEQUENCE_AND,ASEQ_OPC_CHANNEL_AND,,,,,,, 0, 0
+    _wr_cmd_id  and, ASEQ_OP_SEQ_AND,ASEQ_OP_CHAN_AND,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1598,7 +1598,7 @@ $reladdr\@:
  *  Computes TR = TR - imm
  */
 .macro sub imm
-    _wr_cmd_id  sub, ASEQ_OPC_SEQUENCE_SUB,ASEQ_OPC_CHANNEL_SUB,,,,,,, 0, 0
+    _wr_cmd_id  sub, ASEQ_OP_SEQ_SUB,ASEQ_OP_CHAN_SUB,,,,,,, 0, 0
     _wr_u8      \imm
 .endm
 
@@ -1608,7 +1608,7 @@ $reladdr\@:
  *  Stores the u8 value `TR + imm` to the location specified by `label`.
  */
 .macro stseq imm, label
-    _wr_cmd_id  stseq, ASEQ_OPC_SEQUENCE_STSEQ,ASEQ_OPC_CHANNEL_STSEQ,,,,,,, 0, 0
+    _wr_cmd_id  stseq, ASEQ_OP_SEQ_STSEQ,ASEQ_OP_CHAN_STSEQ,,,,,,, 0, 0
     _wr_u8      \imm
     _wr_lbl     \label
 .endm
@@ -1619,7 +1619,7 @@ $reladdr\@:
  *  Immediately stops the sequence or channel.
  */
 .macro stop
-    _wr_cmd_id  stop, ASEQ_OPC_SEQUENCE_STOP,ASEQ_OPC_CHANNEL_STOP,,,,,,, 0, 0
+    _wr_cmd_id  stop, ASEQ_OP_SEQ_STOP,ASEQ_OP_CHAN_STOP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1628,7 +1628,7 @@ $reladdr\@:
  *  Set the current soundfont for this channel to `fontId`.
  */
 .macro font fontId
-    _wr_cmd_id  font, ,ASEQ_OPC_CHANNEL_FONT,,,,,,, 0, 0
+    _wr_cmd_id  font, ,ASEQ_OP_CHAN_FONT,,,,,,, 0, 0
     _wr_u8      \fontId
 .endm
 
@@ -1641,7 +1641,7 @@ $reladdr\@:
  *  never used, so changing it with this instruction has no useful effects.
  */
 .macro scriptctr arg
-    _wr_cmd_id  scriptctr, ASEQ_OPC_SEQUENCE_SCRIPTCTR,,,,,,,, 0, 0
+    _wr_cmd_id  scriptctr, ASEQ_OP_SEQ_SCRIPTCTR,,,,,,,, 0, 0
     _wr_u16     \arg
 .endm
 
@@ -1652,7 +1652,7 @@ $reladdr\@:
  *  unless TR is -1, in which case nothing happens.
  */
 .macro dyntbllookup
-    _wr_cmd_id  dyntbllookup, ,ASEQ_OPC_CHANNEL_DYNTBLLOOKUP,,,,,,, 0, 0
+    _wr_cmd_id  dyntbllookup, ,ASEQ_OP_CHAN_DYNTBLLOOKUP,,,,,,, 0, 0
 .endm
 
 /**
@@ -1661,7 +1661,7 @@ $reladdr\@:
  *  Plays the sequence seqId on seqPlayer.
  */
 .macro runseq seqPlayer, seqId
-    _wr_cmd_id  runseq, ASEQ_OPC_SEQUENCE_RUNSEQ,,,,,,,, 0, 0
+    _wr_cmd_id  runseq, ASEQ_OP_SEQ_RUNSEQ,,,,,,,, 0, 0
     _wr_u8      \seqPlayer
     _wr_u8      \seqId
 .endm
@@ -1674,7 +1674,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro mutechan arg0
-        _wr_cmd_id  mutechan, ASEQ_OPC_SEQUENCE_C3,,,,,,,, 0, 0
+        _wr_cmd_id  mutechan, ASEQ_OP_SEQ_C3,,,,,,,, 0, 0
         _wr_s16     \arg0
     .endm
 
@@ -1686,7 +1686,7 @@ $reladdr\@:
  *  Disable short notes encoding.
  */
 .macro noshort
-    _wr_cmd_id  noshort, ,ASEQ_OPC_CHANNEL_NOSHORT,,,,,,, 0, 0
+    _wr_cmd_id  noshort, ,ASEQ_OP_CHAN_NOSHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1695,7 +1695,7 @@ $reladdr\@:
  *  Enable short notes encoding.
  */
 .macro short
-    _wr_cmd_id  short, ,ASEQ_OPC_CHANNEL_SHORT,,,,,,, 0, 0
+    _wr_cmd_id  short, ,ASEQ_OP_CHAN_SHORT,,,,,,, 0, 0
 .endm
 
 /**
@@ -1704,7 +1704,7 @@ $reladdr\@:
  *  Loads label -> DYNTBL
  */
 .macro dyntbl label
-    _wr_cmd_id  dyntbl, ,ASEQ_OPC_CHANNEL_DYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  dyntbl, ,ASEQ_OP_CHAN_DYNTBL,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1714,7 +1714,7 @@ $reladdr\@:
  *  Set instrument `instNum` from the current soundfont as the active instrument for this channel or layer.
  */
 .macro instr instNum
-    _wr_cmd_id  instr, ,ASEQ_OPC_CHANNEL_INSTR,ASEQ_OPC_LAYER_INSTR,,,,,, 0, 0
+    _wr_cmd_id  instr, ,ASEQ_OP_CHAN_INSTR,ASEQ_OP_LAYER_INSTR,,,,,, 0, 0
     _wr_u8      \instNum
 .endm
 
@@ -1726,7 +1726,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_BE arg0
-        _wr_cmd_id  unk_BE, ,ASEQ_OPC_CHANNEL_UNK_BE,,,,,,, 0, 0
+        _wr_cmd_id  unk_BE, ,ASEQ_OP_CHAN_UNK_BE,,,,,,, 0, 0
         _wr_u8      \arg0
     .endm
 
@@ -1740,7 +1740,7 @@ $reladdr\@:
  *  If range is 0, it is treated as 65536.
  */
 .macro randptr range, offset
-    _wr_cmd_id  randptr, ,ASEQ_OPC_CHANNEL_RANDPTR,,,,,,, 0, 0
+    _wr_cmd_id  randptr, ,ASEQ_OP_CHAN_RANDPTR,,,,,,, 0, 0
     _wr_u16     \range
     _wr_u16     \offset
 .endm
@@ -1753,7 +1753,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro samplestart arg
-        _wr_cmd_id  samplestart, ,ASEQ_OPC_CHANNEL_SAMPLESTART,,,,,,, 0, 0
+        _wr_cmd_id  samplestart, ,ASEQ_OP_CHAN_SAMPLESTART,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1763,7 +1763,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A7 arg
-        _wr_cmd_id  unk_A7, ,ASEQ_OPC_CHANNEL_A7,,,,,,, 0, 0
+        _wr_cmd_id  unk_A7, ,ASEQ_OP_CHAN_A7,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1773,7 +1773,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A6 arg0, arg1
-        _wr_cmd_id  unk_A6, ,ASEQ_OPC_CHANNEL_A6,,,,,,, 0, 0
+        _wr_cmd_id  unk_A6, ,ASEQ_OP_CHAN_A6,,,,,,, 0, 0
         _wr_u8      \arg0
         _wr_s16     \arg1
     .endm
@@ -1784,7 +1784,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A5
-        _wr_cmd_id  unk_A5, ,ASEQ_OPC_CHANNEL_A5,,,,,,, 0, 0
+        _wr_cmd_id  unk_A5, ,ASEQ_OP_CHAN_A5,,,,,,, 0, 0
     .endm
 
     /**
@@ -1793,7 +1793,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A4 arg
-        _wr_cmd_id  unk_A4, ,ASEQ_OPC_CHANNEL_A4,,,,,,, 0, 0
+        _wr_cmd_id  unk_A4, ,ASEQ_OP_CHAN_A4,,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -1803,7 +1803,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A3
-        _wr_cmd_id  unk_A3, ,ASEQ_OPC_CHANNEL_A3,,,,,,, 0, 0
+        _wr_cmd_id  unk_A3, ,ASEQ_OP_CHAN_A3,,,,,,, 0, 0
     .endm
 
     /**
@@ -1812,7 +1812,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A2 arg
-        _wr_cmd_id  unk_A2, ,ASEQ_OPC_CHANNEL_A2,,,,,,, 0, 0
+        _wr_cmd_id  unk_A2, ,ASEQ_OP_CHAN_A2,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1822,7 +1822,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A1
-        _wr_cmd_id  unk_A1, ,ASEQ_OPC_CHANNEL_A1,,,,,,, 0, 0
+        _wr_cmd_id  unk_A1, ,ASEQ_OP_CHAN_A1,,,,,,, 0, 0
     .endm
 
     /**
@@ -1831,7 +1831,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_A0 arg
-        _wr_cmd_id  unk_A0, ,ASEQ_OPC_CHANNEL_A0,,,,,,, 0, 0
+        _wr_cmd_id  unk_A0, ,ASEQ_OP_CHAN_A0,,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -1843,7 +1843,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptradd value
-    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHAN_PTRADD,,,,,,, 0, 0
     _wr_lbl     \value
 .endm
 
@@ -1855,7 +1855,7 @@ $reladdr\@:
  *  Computes TP += value
  */
 .macro ptraddi value
-    _wr_cmd_id  ptradd, ,ASEQ_OPC_CHANNEL_PTRADD,,,,,,, 0, 0
+    _wr_cmd_id  ptradd, ,ASEQ_OP_CHAN_PTRADD,,,,,,, 0, 0
     _wr_u16     \value
 .endm
 
@@ -1866,7 +1866,7 @@ $reladdr\@:
  *  TODO args? arg0=16,arg1=val<<8 maps well to midi chorus
  */
 .macro combfilter arg0, arg1
-    _wr_cmd_id  combfilter, ,ASEQ_OPC_CHANNEL_COMBFILTER,,,,,,, 0, 0
+    _wr_cmd_id  combfilter, ,ASEQ_OP_CHAN_COMBFILTER,,,,,,, 0, 0
     _wr_u8      \arg0
     _wr_u16     \arg1
 .endm
@@ -1879,7 +1879,7 @@ $reladdr\@:
  *  NOTE: This feature is bugged. If this is non-zero it will actually use the range set by randvel.
  */
 .macro randgate range
-    _wr_cmd_id  randgate, ,ASEQ_OPC_CHANNEL_RANDGATE,,,,,,, 0, 0
+    _wr_cmd_id  randgate, ,ASEQ_OP_CHAN_RANDGATE,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1889,7 +1889,7 @@ $reladdr\@:
  *  Sets the range for random note velocity fluctuations.
  */
 .macro randvel range
-    _wr_cmd_id  randvel, ,ASEQ_OPC_CHANNEL_RANDVEL,,,,,,, 0, 0
+    _wr_cmd_id  randvel, ,ASEQ_OP_CHAN_RANDVEL,,,,,,, 0, 0
     _wr_u8      \range
 .endm
 
@@ -1899,7 +1899,7 @@ $reladdr\@:
  *  Stores a random number in the range [0, max) into TP. If max is 0 the range is [0, 65535]
  */
 .macro randtoptr max
-    _wr_cmd_id  randtoptr, ,ASEQ_OPC_CHANNEL_RANDTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  randtoptr, ,ASEQ_OP_CHAN_RANDTOPTR,,,,,,, 0, 0
     _wr_u16     \max
 .endm
 
@@ -1909,7 +1909,7 @@ $reladdr\@:
  *  Loads DYNTBL8[TR] -> TR
  */
 .macro dyntblv
-    _wr_cmd_id  dyntblv, ,ASEQ_OPC_CHANNEL_DYNTBLV,,,,,,, 0, 0
+    _wr_cmd_id  dyntblv, ,ASEQ_OP_CHAN_DYNTBLV,,,,,,, 0, 0
 .endm
 
 /**
@@ -1918,7 +1918,7 @@ $reladdr\@:
  *  Loads DYNTBL16[TR] -> TP
  */
 .macro dyntbltoptr
-    _wr_cmd_id  dyntbltoptr, ,ASEQ_OPC_CHANNEL_DYNTBLTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  dyntbltoptr, ,ASEQ_OP_CHAN_DYNTBLTOPTR,,,,,,, 0, 0
 .endm
 
 /**
@@ -1927,7 +1927,7 @@ $reladdr\@:
  *  Transfers TP -> DYNTBL
  */
 .macro ptrtodyntbl
-    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OPC_CHANNEL_PTRTODYNTBL,,,,,,, 0, 0
+    _wr_cmd_id  ptrtodyntbl, ,ASEQ_OP_CHAN_PTRTODYNTBL,,,,,,, 0, 0
 .endm
 
 /**
@@ -1938,7 +1938,7 @@ $reladdr\@:
  *  Note that TR acts as an index into an array of u16 starting at label.
  */
 .macro ldseqtoptr label
-    _wr_cmd_id  ldseqtoptr, ,ASEQ_OPC_CHANNEL_LDSEQTOPTR,,,,,,, 0, 0
+    _wr_cmd_id  ldseqtoptr, ,ASEQ_OP_CHAN_LDSEQTOPTR,,,,,,, 0, 0
     _wr_lbl     \label
 .endm
 
@@ -1948,7 +1948,7 @@ $reladdr\@:
  *  Invalidates the current active filter buffer.
  */
 .macro freefilter
-    _wr_cmd_id  freefilter, ,ASEQ_OPC_CHANNEL_FREEFILTER,,,,,,, 0, 0
+    _wr_cmd_id  freefilter, ,ASEQ_OP_CHAN_FREEFILTER,,,,,,, 0, 0
 .endm
 
 /**
@@ -1957,7 +1957,7 @@ $reladdr\@:
  *  Sets the active filter buffer to the location specified by `filter`.
  */
 .macro ldfilter filter
-    _wr_cmd_id  ldfilter, ,ASEQ_OPC_CHANNEL_LDFILTER,,,,,,, 0, 0
+    _wr_cmd_id  ldfilter, ,ASEQ_OP_CHAN_LDFILTER,,,,,,, 0, 0
     _wr_lbl     \filter
 .endm
 
@@ -1968,7 +1968,7 @@ $reladdr\@:
  *  Delays by `delay` ticks.
  */
 .macro cdelay delay
-    _wr_cmd_id  cdelay, ,ASEQ_OPC_CHANNEL_CDELAY,,,,,,, \delay, 4
+    _wr_cmd_id  cdelay, ,ASEQ_OP_CHAN_CDELAY,,,,,,, \delay, 4
 .endm
 
 /**
@@ -1982,9 +1982,9 @@ $reladdr\@:
  */
 .macro ldsample type, portNum
     .if \type == LDSAMPLE_INST
-        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHAN_LDSAMPLE,,,,,,, \portNum, 3
     .elif \type == LDSAMPLE_SFX
-        _wr_cmd_id  ldsample, ,ASEQ_OPC_CHANNEL_LDSAMPLE | 8,,,,,,, \portNum, 3
+        _wr_cmd_id  ldsample, ,ASEQ_OP_CHAN_LDSAMPLE | 8,,,,,,, \portNum, 3
     .else
         .error "ldsample: invalid type"
     .endif
@@ -1998,7 +1998,7 @@ $reladdr\@:
  *  Stores the contents of TR into CIO[channelNum][portNum]
  */
 .macro stcio channelNum, portNum
-    _wr_cmd_id  stcio, ,ASEQ_OPC_CHANNEL_STCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  stcio, ,ASEQ_OP_CHAN_STCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2008,7 +2008,7 @@ $reladdr\@:
  *  Loads the contents of CIO[channelNum][portNum] into TR.
  */
 .macro ldcio channelNum, portNum
-    _wr_cmd_id  ldcio, ,ASEQ_OPC_CHANNEL_LDCIO,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldcio, ,ASEQ_OP_CHAN_LDCIO,,,,,,, \channelNum, 4
     _wr_u8      \portNum
 .endm
 
@@ -2020,7 +2020,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldlayer layerNum, label
-    _wr_cmd_id  rldlayer, ,ASEQ_OPC_CHANNEL_RLDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  rldlayer, ,ASEQ_OP_CHAN_RLDLAYER,,,,,,, \layerNum, 3
     _wr_16_rel  \label
 .endm
 
@@ -2034,7 +2034,7 @@ $reladdr\@:
  *   - -1 if layer does not exist.
  */
 .macro testlayer layerNum
-    _wr_cmd_id  testlayer, ,ASEQ_OPC_CHANNEL_TESTLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  testlayer, ,ASEQ_OP_CHAN_TESTLAYER,,,,,,, \layerNum, 3
 .endm
 
 /**
@@ -2043,7 +2043,7 @@ $reladdr\@:
  *  Opens the note layer at `label` for index `layerNum`.
  */
 .macro ldlayer layerNum, label
-    _wr_cmd_id  ldlayer, ,ASEQ_OPC_CHANNEL_LDLAYER,,,,,,, \layerNum, 3
+    _wr_cmd_id  ldlayer, ,ASEQ_OP_CHAN_LDLAYER,,,,,,, \layerNum, 3
     _wr_lbl     \label
 .endm
 
@@ -2053,7 +2053,7 @@ $reladdr\@:
  *  Deletes the layer specified by index `layerNum`.
  */
 .macro dellayer arg
-    _wr_cmd_id  dellayer, ,ASEQ_OPC_CHANNEL_DELLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dellayer, ,ASEQ_OP_CHAN_DELLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2062,7 +2062,7 @@ $reladdr\@:
  *  Allocates a new layer starting at the pointer read from DYNTBL16[TR]
  */
 .macro dynldlayer arg
-    _wr_cmd_id  dynldlayer, ,ASEQ_OPC_CHANNEL_DYNLDLAYER,,,,,,, \arg, 3
+    _wr_cmd_id  dynldlayer, ,ASEQ_OP_CHAN_DYNLDLAYER,,,,,,, \arg, 3
 .endm
 
 /**
@@ -2074,7 +2074,7 @@ $reladdr\@:
  *   - 1 if disabled
  */
 .macro testchan channelNum
-    _wr_cmd_id  testchan, ASEQ_OPC_SEQUENCE_TESTCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  testchan, ASEQ_OP_SEQ_TESTCHAN,,,,,,,, \channelNum, 4
 .endm
 
 /**
@@ -2084,9 +2084,9 @@ $reladdr\@:
  */
 .macro stopchan channelNum
     .if ASEQ_MODE == ASEQ_MODE_SEQUENCE
-        _wr_cmd_id  stopchan, ASEQ_OPC_SEQUENCE_STOPCHAN,,,,,,,, \channelNum, 4
+        _wr_cmd_id  stopchan, ASEQ_OP_SEQ_STOPCHAN,,,,,,,, \channelNum, 4
     .else
-        _wr_cmd_id  stopchan, ,ASEQ_OPC_CHANNEL_STOPCHAN,,,,,,, 0, 0
+        _wr_cmd_id  stopchan, ,ASEQ_OP_CHAN_STOPCHAN,,,,,,, 0, 0
         _wr_u8      \channelNum
     .endif
 .endm
@@ -2101,7 +2101,7 @@ $reladdr\@:
  *      Computes TR = TR - CIO[CUR_CHANNEL][portNum]
  */
 .macro subio portNum
-    _wr_cmd_id  subio, ASEQ_OPC_SEQUENCE_SUBIO,ASEQ_OPC_CHANNEL_SUBIO,,,,,,, \portNum, 4
+    _wr_cmd_id  subio, ASEQ_OP_SEQ_SUBIO,ASEQ_OP_CHAN_SUBIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2118,7 +2118,7 @@ $reladdr\@:
  *  Load status is made available in SIO[portNum].
  */
 .macro ldres portNum, resType, resId
-    _wr_cmd_id  ldres, ASEQ_OPC_SEQUENCE_LDRES,,,,,,,, \portNum, 4
+    _wr_cmd_id  ldres, ASEQ_OP_SEQ_LDRES,,,,,,,, \portNum, 4
     _wr_u8      \resType
     _wr_u8      \resId
 .endm
@@ -2132,9 +2132,9 @@ $reladdr\@:
  */
 .macro stio portNum
     .if ASEQ_MODE == ASEQ_MODE_CHANNEL
-        _wr_cmd_id  stio, ,ASEQ_OPC_CHANNEL_STIO,,,,,,, \portNum, 3
+        _wr_cmd_id  stio, ,ASEQ_OP_CHAN_STIO,,,,,,, \portNum, 3
     .else
-        _wr_cmd_id  stio, ASEQ_OPC_SEQUENCE_STIO,,,,,,,, \portNum, 4
+        _wr_cmd_id  stio, ASEQ_OP_SEQ_STIO,,,,,,,, \portNum, 4
     .endif
 .endm
 
@@ -2145,7 +2145,7 @@ $reladdr\@:
  *  depending on current section.
  */
 .macro ldio portNum
-    _wr_cmd_id  ldio, ASEQ_OPC_SEQUENCE_LDIO,ASEQ_OPC_CHANNEL_LDIO,,,,,,, \portNum, 4
+    _wr_cmd_id  ldio, ASEQ_OP_SEQ_LDIO,ASEQ_OP_CHAN_LDIO,,,,,,, \portNum, 4
 .endm
 
 /**
@@ -2154,7 +2154,7 @@ $reladdr\@:
  *  Opens the sequence channel for index `channelNum` with data beginning at `label`.
  */
 .macro ldchan channelNum, label
-    _wr_cmd_id  ldchan, ASEQ_OPC_SEQUENCE_LDCHAN,ASEQ_OPC_CHANNEL_LDCHAN,,,,,,, \channelNum, 4
+    _wr_cmd_id  ldchan, ASEQ_OP_SEQ_LDCHAN,ASEQ_OP_CHAN_LDCHAN,,,,,,, \channelNum, 4
     _wr_lbl     \label
 .endm
 
@@ -2166,7 +2166,7 @@ $reladdr\@:
  *  for use in position-independent code.
  */
 .macro rldchan channelNum, label
-    _wr_cmd_id  rldchan, ASEQ_OPC_SEQUENCE_RLDCHAN,,,,,,,, \channelNum, 4
+    _wr_cmd_id  rldchan, ASEQ_OP_SEQ_RLDCHAN,,,,,,,, \channelNum, 4
     _wr_16_rel  \label
 .endm
 
@@ -2176,7 +2176,7 @@ $reladdr\@:
  *  Delay for `delay` ticks.
  */
 .macro ldelay delay
-    _wr_cmd_id  ldelay, ,,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  ldelay, ,,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2187,7 +2187,7 @@ $reladdr\@:
  * Should never be used when not required for matching purposes.
  */
 .macro lldelay delay
-    _wr_cmd_id  lldelay, ,ASEQ_OPC_CTRLFLOW_DELAY,ASEQ_OPC_LAYER_LDELAY,,,,,, 0, 0
+    _wr_cmd_id  lldelay, ,ASEQ_OP_DELAY,ASEQ_OP_LAYER_LDELAY,,,,,, 0, 0
     _var_long   \delay
 .endm
 
@@ -2197,7 +2197,7 @@ $reladdr\@:
  * Set velocity used by short notes.
  */
 .macro shortvel velocity
-    _wr_cmd_id  shortvel, ,,ASEQ_OPC_LAYER_SHORTVEL,,,,,, 0, 0
+    _wr_cmd_id  shortvel, ,,ASEQ_OP_LAYER_SHORTVEL,,,,,, 0, 0
     _wr_u8      \velocity
 .endm
 
@@ -2207,7 +2207,7 @@ $reladdr\@:
  * Set delay used by short notes.
  */
 .macro shortdelay delay
-    _wr_cmd_id  shortdelay, ,,ASEQ_OPC_LAYER_SHORTDELAY,,,,,, 0, 0
+    _wr_cmd_id  shortdelay, ,,ASEQ_OP_LAYER_SHORTDELAY,,,,,, 0, 0
     _var        \delay
 .endm
 
@@ -2217,7 +2217,7 @@ $reladdr\@:
  *  Enables legato on the current layer.
  */
 .macro legato
-    _wr_cmd_id  legato, ,,ASEQ_OPC_LAYER_LEGATO,,,,,, 0, 0
+    _wr_cmd_id  legato, ,,ASEQ_OP_LAYER_LEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2226,7 +2226,7 @@ $reladdr\@:
  *  Disables legato on the current layer.
  */
 .macro nolegato
-    _wr_cmd_id  nolegato, ,,ASEQ_OPC_LAYER_NOLEGATO,,,,,, 0, 0
+    _wr_cmd_id  nolegato, ,,ASEQ_OP_LAYER_NOLEGATO,,,,,, 0, 0
 .endm
 
 /**
@@ -2235,7 +2235,7 @@ $reladdr\@:
  *  The time argument is either a var or a u8 depending on mode
  */
 .macro portamento mode, target, time
-    _wr_cmd_id  portamento, ,,ASEQ_OPC_LAYER_PORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  portamento, ,,ASEQ_OP_LAYER_PORTAMENTO,,,,,, 0, 0
     _wr_u8      \mode
     _wr_u8      \target
     .if (\mode & 0x80) != 0
@@ -2251,7 +2251,7 @@ $reladdr\@:
  *  Disables portamento on the current layer.
  */
 .macro noportamento
-    _wr_cmd_id  noportamento, ,,ASEQ_OPC_LAYER_NOPORTAMENTO,,,,,, 0, 0
+    _wr_cmd_id  noportamento, ,,ASEQ_OP_LAYER_NOPORTAMENTO,,,,,, 0, 0
 .endm
 
 /**
@@ -2260,7 +2260,7 @@ $reladdr\@:
  *  Sets gate time for short notes.
  */
 .macro shortgate gateTime
-    _wr_cmd_id  shortgate, ,,ASEQ_OPC_LAYER_SHORTGATE,,,,,, 0, 0
+    _wr_cmd_id  shortgate, ,,ASEQ_OP_LAYER_SHORTGATE,,,,,, 0, 0
     _wr_u8      \gateTime
 .endm
 
@@ -2272,7 +2272,7 @@ $reladdr\@:
 .macro notepan pan
     /* pan can only take values in 0..127 */
     _check_arg_bitwidth_u \pan, 7
-    _wr_cmd_id  notepan, ,,ASEQ_OPC_LAYER_NOTEPAN,,,,,, 0, 0
+    _wr_cmd_id  notepan, ,,ASEQ_OP_LAYER_NOTEPAN,,,,,, 0, 0
     _wr_u8      \pan
 .endm
 
@@ -2283,7 +2283,7 @@ $reladdr\@:
  *  use pan set in the layer.
  */
 .macro nodrumpan
-    _wr_cmd_id  nodrumpan, ,,ASEQ_OPC_LAYER_NODRUMPAN,,,,,, 0, 0
+    _wr_cmd_id  nodrumpan, ,,ASEQ_OP_LAYER_NODRUMPAN,,,,,, 0, 0
 .endm
 
 /**
@@ -2298,7 +2298,7 @@ $reladdr\@:
     _check_arg_bitwidth_u \strongRvrbR, 1
     _check_arg_bitwidth_u \strongRvrbL, 1
 
-    _wr_cmd_id  stereo, ,,ASEQ_OPC_LAYER_STEREO,,,,,, 0, 0
+    _wr_cmd_id  stereo, ,,ASEQ_OP_LAYER_STEREO,,,,,, 0, 0
     _wr_u8      (\type << 4) | (\strongR << 3) | (\strongL << 2) | (\strongRvrbR << 1) | (\strongRvrbL << 0)
 .endm
 
@@ -2308,7 +2308,7 @@ $reladdr\@:
  *  Sets the velocity used in short notes by reading from SHORTVELTBL[velocity]
  */
 .macro ldshortvel velocity
-    _wr_cmd_id  ldshortvel, ,,ASEQ_OPC_LAYER_LDSHORTVEL,,,,,, \velocity, 4
+    _wr_cmd_id  ldshortvel, ,,ASEQ_OP_LAYER_LDSHORTVEL,,,,,, \velocity, 4
 .endm
 
 /**
@@ -2317,7 +2317,7 @@ $reladdr\@:
  *  Sets the gate time used in short notes by reading from SHORTGATETBL[gateTime]
  */
 .macro ldshortgate gateTime
-    _wr_cmd_id  ldshortgate, ,,ASEQ_OPC_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
+    _wr_cmd_id  ldshortgate, ,,ASEQ_OP_LAYER_LDSHORTGATE,,,,,, \gateTime, 4
 .endm
 
 #if (MML_VERSION == MML_VERSION_MM)
@@ -2328,7 +2328,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro unk_F0 arg
-        _wr_cmd_id  unk_F0, ,,ASEQ_OPC_LAYER_F0,,,,,, 0, 0
+        _wr_cmd_id  unk_F0, ,,ASEQ_OP_LAYER_F0,,,,,, 0, 0
         _wr_s16     \arg
     .endm
 
@@ -2338,7 +2338,7 @@ $reladdr\@:
      *  TODO DESCRIPTION
      */
     .macro surroundeffect arg
-        _wr_cmd_id  surroundeffect, ,,ASEQ_OPC_LAYER_F1,,,,,, 0, 0
+        _wr_cmd_id  surroundeffect, ,,ASEQ_OP_LAYER_F1,,,,,, 0, 0
         _wr_u8      \arg
     .endm
 
@@ -2358,7 +2358,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedvg pitch, delay, velocity, gateTime
-    _wr_cmd_id  notedvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  notedvg, ,,ASEQ_OP_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
     _wr_u8      \gateTime
@@ -2372,14 +2372,14 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notedv pitch, delay, velocity
-    _wr_cmd_id  notedv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  notedv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
     _var        \delay
     _wr_u8      \velocity
 .endm
 
 /* Workaround for bugs in vanilla sequences, force long encoding for delay. This should not typically be used. */
 .macro noteldv pitch, delay, velocity
-    _wr_cmd_id  noteldv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  noteldv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
     _var_long   \delay
     _wr_u8      \velocity
 .endm
@@ -2392,7 +2392,7 @@ $reladdr\@:
  *  This instruction must only be used when long notes are enabled with the noshort instruction.
  */
 .macro notevg pitch, velocity, gateTime
-    _wr_cmd_id  notevg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  notevg, ,,ASEQ_OP_LAYER_NOTEVG,,,,,, \pitch, 6
     _wr_u8      \velocity
     _wr_u8      \gateTime
 .endm
@@ -2406,7 +2406,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdvg pitch, delay
-    _wr_cmd_id  shortdvg, ,,ASEQ_OPC_LAYER_NOTEDVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortdvg, ,,ASEQ_OP_LAYER_NOTEDVG,,,,,, \pitch, 6
     _var        \delay
 .endm
 
@@ -2419,7 +2419,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortdv pitch
-    _wr_cmd_id  shortdv, ,,ASEQ_OPC_LAYER_NOTEDV,,,,,, \pitch, 6
+    _wr_cmd_id  shortdv, ,,ASEQ_OP_LAYER_NOTEDV,,,,,, \pitch, 6
 .endm
 
 /**
@@ -2431,7 +2431,7 @@ $reladdr\@:
  *  This instruction must only be used when short notes are enabled with the short instruction.
  */
 .macro shortvg pitch
-    _wr_cmd_id  shortvg, ,,ASEQ_OPC_LAYER_NOTEVG,,,,,, \pitch, 6
+    _wr_cmd_id  shortvg, ,,ASEQ_OP_LAYER_NOTEVG,,,,,, \pitch, 6
 .endm
 
 /**

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -671,7 +671,7 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
 
         switch (cmd) {
             case ASEQ_OPC_LAYER_SHORTVEL: // layer: set short note velocity
-            case ASEQ_OPC_LAYER_NOTEPAN: // layer: set pan
+            case ASEQ_OPC_LAYER_NOTEPAN:  // layer: set pan
                 cmdArg8 = *(state->pc++);
                 if (cmd == ASEQ_OPC_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
@@ -690,7 +690,7 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case ASEQ_OPC_LAYER_LEGATO: // layer: continuous notes on
+            case ASEQ_OPC_LAYER_LEGATO:   // layer: continuous notes on
             case ASEQ_OPC_LAYER_NOLEGATO: // layer: continuous notes off
                 if (cmd == ASEQ_OPC_LAYER_LEGATO) {
                     layer->continuousNotes = true;
@@ -2015,7 +2015,7 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         break;
 
                     case ASEQ_OPC_SEQUENCE_LDSHORTGATEARR: // seqPlayer: set short note gatetime table
-                    case ASEQ_OPC_SEQUENCE_LDSHORTVELARR: // seqPlayer: set short note velocity table
+                    case ASEQ_OPC_SEQUENCE_LDSHORTVELARR:  // seqPlayer: set short note velocity table
                         temp = AudioScript_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
                         if (cmd == ASEQ_OPC_SEQUENCE_LDSHORTVELARR) {

--- a/src/audio/lib/seqplayer.c
+++ b/src/audio/lib/seqplayer.c
@@ -14,6 +14,8 @@
  *     Otherwise, each set of instructions has its own command interpreter
  */
 #include "global.h"
+#define MML_VERSION MML_VERSION_MM
+#include "audio/aseq.h"
 #include "audio/seqplayer.h"
 #include "attributes.h"
 
@@ -139,21 +141,21 @@ u8 sSeqInstructionArgsTable[] = {
     CMD_ARGS_2(s16, u8),    // 0xEF ()
     CMD_ARGS_0(),           // 0xF0 (channel: unreserve notes)
     CMD_ARGS_1(u8),         // 0xF1 (channel: reserve notes)
-    // Control flow instructions (>= 0xF2) can only have 0 or 1 args
-    CMD_ARGS_1(u8),  // 0xF2 (branch relative if less than zero)
-    CMD_ARGS_1(u8),  // 0xF3 (branch relative if equal to zero)
-    CMD_ARGS_1(u8),  // 0xF4 (jump relative)
-    CMD_ARGS_1(s16), // 0xF5 (branch if greater than or equal to zero)
-    CMD_ARGS_0(),    // 0xF6 (break)
-    CMD_ARGS_0(),    // 0xF7 (loop end)
-    CMD_ARGS_1(u8),  // 0xF8 (loop)
-    CMD_ARGS_1(s16), // 0xF9 (branch if less than zero)
-    CMD_ARGS_1(s16), // 0xFA (branch if equal to zero)
-    CMD_ARGS_1(s16), // 0xFB (jump)
-    CMD_ARGS_1(s16), // 0xFC (call and jump to a function)
-    CMD_ARGS_0(),    // 0xFD (delay n frames)
-    CMD_ARGS_0(),    // 0xFE (delay 1 frame)
-    CMD_ARGS_0(),    // 0xFF (end script)
+    // Control flow instructions (>= ASEQ_OPC_CONTROL_FLOW_FIRST) can only have 0 or 1 args
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBLTZ (branch relative if less than zero)
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RBEQZ (branch relative if equal to zero)
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_RJUMP (jump relative)
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BGEZ (branch if greater than or equal to zero)
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_BREAK (break)
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_LOOPEND (loop end)
+    CMD_ARGS_1(u8),  // ASEQ_OPC_CTRLFLOW_LOOP (loop)
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BLTZ (branch if less than zero)
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_BEQZ (branch if equal to zero)
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_JUMP (jump)
+    CMD_ARGS_1(s16), // ASEQ_OPC_CTRLFLOW_CALL (call and jump to a function)
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY (delay n frames)
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_DELAY1 (delay 1 frame)
+    CMD_ARGS_0(),    // ASEQ_OPC_CTRLFLOW_END (end script)
 };
 
 /**
@@ -188,30 +190,30 @@ s32 AudioScript_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptStat
     u32 depth;
 
     switch (cmd) {
-        case 0xFF: // end script
+        case ASEQ_OPC_CTRLFLOW_END: // end script
             if (state->depth == 0) {
                 return PROCESS_SCRIPT_END;
             }
             state->pc = state->stack[--state->depth];
             break;
 
-        case 0xFD: // delay n frames
+        case ASEQ_OPC_CTRLFLOW_DELAY: // delay n frames
             return AudioScript_ScriptReadCompressedU16(state);
 
-        case 0xFE: // delay 1 frame
+        case ASEQ_OPC_CTRLFLOW_DELAY1: // delay 1 frame
             return 1;
 
-        case 0xFC: // call and jump to a function
+        case ASEQ_OPC_CTRLFLOW_CALL: // call and jump to a function
             state->stack[depth = state->depth++] = state->pc;
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case 0xF8: // loop
+        case ASEQ_OPC_CTRLFLOW_LOOP: // loop
             state->remLoopIters[depth = state->depth] = cmdArg;
             state->stack[state->depth++] = state->pc;
             break;
 
-        case 0xF7: // loop end
+        case ASEQ_OPC_CTRLFLOW_LOOPEND: // loop end
             state->remLoopIters[state->depth - 1]--;
             if (state->remLoopIters[state->depth - 1] != 0) {
                 state->pc = state->stack[state->depth - 1];
@@ -220,33 +222,33 @@ s32 AudioScript_HandleScriptFlowControl(SequencePlayer* seqPlayer, SeqScriptStat
             }
             break;
 
-        case 0xF6: // break
+        case ASEQ_OPC_CTRLFLOW_BREAK: // break
             state->depth--;
             break;
 
-        case 0xF5: // branch if greater than or equal to zero
-        case 0xF9: // branch if less than zero
-        case 0xFA: // branch if equal to zero
-        case 0xFB: // jump
-            if ((cmd == 0xFA) && (state->value != 0)) {
+        case ASEQ_OPC_CTRLFLOW_BGEZ: // branch if greater than or equal to zero
+        case ASEQ_OPC_CTRLFLOW_BLTZ: // branch if less than zero
+        case ASEQ_OPC_CTRLFLOW_BEQZ: // branch if equal to zero
+        case ASEQ_OPC_CTRLFLOW_JUMP: // jump
+            if ((cmd == ASEQ_OPC_CTRLFLOW_BEQZ) && (state->value != 0)) {
                 break;
             }
-            if ((cmd == 0xF9) && (state->value >= 0)) {
+            if ((cmd == ASEQ_OPC_CTRLFLOW_BLTZ) && (state->value >= 0)) {
                 break;
             }
-            if ((cmd == 0xF5) && (state->value < 0)) {
+            if ((cmd == ASEQ_OPC_CTRLFLOW_BGEZ) && (state->value < 0)) {
                 break;
             }
             state->pc = seqPlayer->seqData + (u16)cmdArg;
             break;
 
-        case 0xF2: // branch relative if less than zero
-        case 0xF3: // branch relative if equal to zero
-        case 0xF4: // jump relative
-            if ((cmd == 0xF3) && (state->value != 0)) {
+        case ASEQ_OPC_CTRLFLOW_RBLTZ: // branch relative if less than zero
+        case ASEQ_OPC_CTRLFLOW_RBEQZ: // branch relative if equal to zero
+        case ASEQ_OPC_CTRLFLOW_RJUMP: // jump relative
+            if ((cmd == ASEQ_OPC_CTRLFLOW_RBEQZ) && (state->value != 0)) {
                 break;
             }
-            if ((cmd == 0xF2) && (state->value >= 0)) {
+            if ((cmd == ASEQ_OPC_CTRLFLOW_RBLTZ) && (state->value >= 0)) {
                 break;
             }
             state->pc += (s8)(cmdArg & 0xFF);
@@ -657,7 +659,7 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         // Control Flow Commands
-        if (cmd >= 0xF2) {
+        if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
             cmdArg16 = AudioScript_GetScriptControlFlowArgument(state, cmd);
 
             if (AudioScript_HandleScriptFlowControl(seqPlayer, state, cmd, cmdArg16) == 0) {
@@ -668,29 +670,29 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
         }
 
         switch (cmd) {
-            case 0xC1: // layer: set short note velocity
-            case 0xCA: // layer: set pan
+            case ASEQ_OPC_LAYER_SHORTVEL: // layer: set short note velocity
+            case ASEQ_OPC_LAYER_NOTEPAN: // layer: set pan
                 cmdArg8 = *(state->pc++);
-                if (cmd == 0xC1) {
+                if (cmd == ASEQ_OPC_LAYER_SHORTVEL) {
                     layer->velocitySquare = SQ(cmdArg8) / SQ(127.0f);
                 } else {
                     layer->pan = cmdArg8;
                 }
                 break;
 
-            case 0xC9: // layer: set short note gatetime
-            case 0xC2: // layer: set transposition in semitones
+            case ASEQ_OPC_LAYER_SHORTGATE: // layer: set short note gatetime
+            case ASEQ_OPC_LAYER_TRANSPOSE: // layer: set transposition in semitones
                 cmdArg8 = *(state->pc++);
-                if (cmd == 0xC9) {
+                if (cmd == ASEQ_OPC_LAYER_SHORTGATE) {
                     layer->gateTime = cmdArg8;
                 } else {
                     layer->transposition = cmdArg8;
                 }
                 break;
 
-            case 0xC4: // layer: continuous notes on
-            case 0xC5: // layer: continuous notes off
-                if (cmd == 0xC4) {
+            case ASEQ_OPC_LAYER_LEGATO: // layer: continuous notes on
+            case ASEQ_OPC_LAYER_NOLEGATO: // layer: continuous notes off
+                if (cmd == ASEQ_OPC_LAYER_LEGATO) {
                     layer->continuousNotes = true;
                 } else {
                     layer->continuousNotes = false;
@@ -699,12 +701,12 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 AudioPlayback_SeqLayerNoteDecay(layer);
                 break;
 
-            case 0xC3: // layer: set short note default delay
+            case ASEQ_OPC_LAYER_SHORTDELAY: // layer: set short note default delay
                 cmdArg16 = AudioScript_ScriptReadCompressedU16(state);
                 layer->shortNoteDefaultDelay = cmdArg16;
                 break;
 
-            case 0xC6: // layer: set instrument
+            case ASEQ_OPC_LAYER_INSTR: // layer: set instrument
                 cmd = AudioScript_ScriptReadU8(state);
                 if (cmd >= 0x7E) {
                     if (cmd == 0x7E) {
@@ -731,7 +733,7 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 }
                 break;
 
-            case 0xC7: // layer: enable portamento
+            case ASEQ_OPC_LAYER_PORTAMENTO: // layer: enable portamento
                 layer->portamento.mode = AudioScript_ScriptReadU8(state);
 
                 cmd = AudioScript_ScriptReadU8(state);
@@ -755,48 +757,48 @@ s32 AudioScript_SeqLayerProcessScriptStep2(SequenceLayer* layer) {
                 layer->portamentoTime = cmdArg16;
                 break;
 
-            case 0xC8: // layer: disable portamento
+            case ASEQ_OPC_LAYER_NOPORTAMENTO: // layer: disable portamento
                 layer->portamento.mode = PORTAMENTO_MODE_OFF;
                 break;
 
-            case 0xCB: // layer: set envelope and decay index
+            case ASEQ_OPC_LAYER_ENV: // layer: set envelope and decay index
                 cmdArg16 = AudioScript_ScriptReadS16(state);
                 layer->adsr.envelope = (EnvelopePoint*)(seqPlayer->seqData + cmdArg16);
                 FALLTHROUGH;
-            case 0xCF: // layer: set decay index
+            case ASEQ_OPC_LAYER_RELEASERATE: // layer: set decay index
                 layer->adsr.decayIndex = AudioScript_ScriptReadU8(state);
                 break;
 
-            case 0xCC: // layer: ignore drum pan
+            case ASEQ_OPC_LAYER_NODRUMPAN: // layer: ignore drum pan
                 layer->ignoreDrumPan = true;
                 break;
 
-            case 0xCD: // layer: stereo effects
+            case ASEQ_OPC_LAYER_STEREO: // layer: stereo effects
                 layer->stereoData.asByte = AudioScript_ScriptReadU8(state);
                 break;
 
-            case 0xCE: // layer: bend pitch
+            case ASEQ_OPC_LAYER_BENDFINE: // layer: bend pitch
                 cmdArg8 = AudioScript_ScriptReadU8(state);
                 layer->bend = gBendPitchTwoSemitonesFrequencies[(u8)(cmdArg8 + 0x80)];
                 break;
 
-            case 0xF0: // layer:
+            case ASEQ_OPC_LAYER_F0: // layer:
                 cmdArg16 = AudioScript_ScriptReadS16(state);
                 layer->unk_0A.asByte &= (cmdArg16 ^ 0xFFFF);
                 break;
 
-            case 0xF1: // layer:
+            case ASEQ_OPC_LAYER_F1: // layer:
                 layer->surroundEffectIndex = AudioScript_ScriptReadU8(state);
                 break;
 
             default:
                 switch (cmd & 0xF0) {
-                    case 0xD0: // layer: set short note velocity from table
+                    case ASEQ_OPC_LAYER_LDSHORTVEL: // layer: set short note velocity from table
                         velocity = seqPlayer->shortNoteVelocityTable[cmd & 0xF];
                         layer->velocitySquare = SQ(velocity) / SQ(127.0f);
                         break;
 
-                    case 0xE0: // layer: set short note gatetime from table
+                    case ASEQ_OPC_LAYER_LDSHORTGATE: // layer: set short note gatetime from table
                         layer->gateTime = seqPlayer->shortNoteGateTimeTable[cmd & 0xF];
                         break;
                 }
@@ -1025,7 +1027,7 @@ s32 AudioScript_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
     s32 intDelta;
     f32 floatDelta;
 
-    if (cmd == 0xC0) { // layer: delay
+    if (cmd == ASEQ_OPC_LAYER_LDELAY) { // layer: delay
         layer->delay = AudioScript_ScriptReadCompressedU16(state);
         layer->muted = true;
         layer->bit1 = false;
@@ -1036,21 +1038,21 @@ s32 AudioScript_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
 
     if (channel->largeNotes == true) {
         switch (cmd & 0xC0) {
-            case 0x00: // layer: large note 0
+            case ASEQ_OPC_LAYER_NOTEDVG: // layer: large note 0
                 delay = AudioScript_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
                 layer->lastDelay = delay;
                 break;
 
-            case 0x40: // layer: large note 1
+            case ASEQ_OPC_LAYER_NOTEDV: // layer: large note 1
                 delay = AudioScript_ScriptReadCompressedU16(state);
                 velocity = *(state->pc++);
                 layer->gateTime = 0;
                 layer->lastDelay = delay;
                 break;
 
-            case 0x80: // layer: large note 2
+            case ASEQ_OPC_LAYER_NOTEVG: // layer: large note 2
                 delay = layer->lastDelay;
                 velocity = *(state->pc++);
                 layer->gateTime = *(state->pc++);
@@ -1064,16 +1066,16 @@ s32 AudioScript_SeqLayerProcessScriptStep3(SequenceLayer* layer, s32 cmd) {
         cmd -= (cmd & 0xC0);
     } else {
         switch (cmd & 0xC0) {
-            case 0x00: // layer: small note 0
+            case ASEQ_OPC_LAYER_NOTEDVG: // layer: small note 0
                 delay = AudioScript_ScriptReadCompressedU16(state);
                 layer->lastDelay = delay;
                 break;
 
-            case 0x40: // layer: small note 1
+            case ASEQ_OPC_LAYER_NOTEDV: // layer: small note 1
                 delay = layer->shortNoteDefaultDelay;
                 break;
 
-            case 0x80: // layer: small note 2
+            case ASEQ_OPC_LAYER_NOTEVG: // layer: small note 2
                 delay = layer->lastDelay;
                 break;
         }
@@ -1242,7 +1244,7 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             // Control Flow Commands
-            if (cmd >= 0xF2) {
+            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
                 delay = AudioScript_HandleScriptFlowControl(seqPlayer, scriptState, cmd, cmdArgs[0]);
 
                 if (delay != 0) {
@@ -1257,26 +1259,26 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
             }
 
             switch (cmd) {
-                case 0xEA: // channel: stop script
+                case ASEQ_OPC_CHANNEL_STOP: // channel: stop script
                     channel->stopScript = true;
                     goto exit_loop;
 
-                case 0xF1: // channel: reserve notes
+                case ASEQ_OPC_CHANNEL_ALLOCNOTELIST: // channel: reserve notes
                     AudioList_ClearNotePool(&channel->notePool);
                     cmd = (u8)cmdArgs[0];
                     AudioList_FillNotePool(&channel->notePool, cmd);
                     break;
 
-                case 0xF0: // channel: unreserve notes
+                case ASEQ_OPC_CHANNEL_FREENOTELIST: // channel: unreserve notes
                     AudioList_ClearNotePool(&channel->notePool);
                     break;
 
-                case 0xC2: // channel: set dyntable
+                case ASEQ_OPC_CHANNEL_DYNTBL: // channel: set dyntable
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->dynTable = (void*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case 0xC5: // channel: dyn set dyntable
+                case ASEQ_OPC_CHANNEL_DYNTBLLOOKUP: // channel: dyn set dyntable
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (u16)((data[0] << 8) + data[1]);
@@ -1284,7 +1286,7 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xEB: // channel: set soundFont and instrument
+                case ASEQ_OPC_CHANNEL_FONTINSTR: // channel: set soundFont and instrument
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1299,93 +1301,93 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
 
                     cmdArgs[0] = cmdArgs[1];
                     FALLTHROUGH;
-                case 0xC1: // channel: set instrument
+                case ASEQ_OPC_CHANNEL_INSTR: // channel: set instrument
                     cmd = (u8)cmdArgs[0];
                     AudioScript_SetInstrument(channel, cmd);
                     break;
 
-                case 0xC3: // channel: large notes off
+                case ASEQ_OPC_CHANNEL_SHORT: // channel: large notes off
                     channel->largeNotes = false;
                     break;
 
-                case 0xC4: // channel: large notes on
+                case ASEQ_OPC_CHANNEL_NOSHORT: // channel: large notes on
                     channel->largeNotes = true;
                     break;
 
-                case 0xDF: // channel: set volume
+                case ASEQ_OPC_CHANNEL_VOL: // channel: set volume
                     cmd = (u8)cmdArgs[0];
                     AudioScript_SequenceChannelSetVolume(channel, cmd);
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xE0: // channel: set volume scale
+                case ASEQ_OPC_CHANNEL_VOLEXP: // channel: set volume scale
                     cmd = (u8)cmdArgs[0];
                     channel->volumeScale = (f32)(s32)cmd / 128.0f;
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xDE: // channel: set freqscale
+                case ASEQ_OPC_CHANNEL_FREQSCALE: // channel: set freqscale
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->freqScale = (f32)(s32)cmdArgU16 / 0x8000;
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xD3: // channel: large bend pitch
+                case ASEQ_OPC_CHANNEL_BEND: // channel: large bend pitch
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchOneOctaveFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xEE: // channel: small bend pitch
+                case ASEQ_OPC_CHANNEL_BENDFINE: // channel: small bend pitch
                     cmd = (u8)cmdArgs[0];
                     cmd += 0x80;
                     channel->freqScale = gBendPitchTwoSemitonesFrequencies[cmd];
                     channel->changes.s.freqScale = true;
                     break;
 
-                case 0xDD: // channel: set pan
+                case ASEQ_OPC_CHANNEL_PAN: // channel: set pan
                     cmd = (u8)cmdArgs[0];
                     channel->newPan = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xDC: // channel: set pan mix
+                case ASEQ_OPC_CHANNEL_PANWEIGHT: // channel: set pan mix
                     cmd = (u8)cmdArgs[0];
                     channel->panChannelWeight = cmd;
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xDB: // channel: transpose
+                case ASEQ_OPC_CHANNEL_TRANSPOSE: // channel: transpose
                     cmdArgS8 = (s8)cmdArgs[0];
                     channel->transposition = cmdArgS8;
                     break;
 
-                case 0xDA: // channel: set envelope
+                case ASEQ_OPC_CHANNEL_ENV: // channel: set envelope
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->adsr.envelope = (EnvelopePoint*)&seqPlayer->seqData[cmdArgU16];
                     break;
 
-                case 0xD9: // channel: set decay index
+                case ASEQ_OPC_CHANNEL_RELEASERATE: // channel: set decay index
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.decayIndex = cmd;
                     break;
 
-                case 0xD8: // channel: set vibrato depth
+                case ASEQ_OPC_CHANNEL_VIBDEPTH: // channel: set vibrato depth
                     cmd = (u8)cmdArgs[0];
                     channel->vibrato.vibratoDepthTarget = cmd * 8;
                     channel->vibrato.vibratoDepthStart = 0;
                     channel->vibrato.vibratoDepthChangeDelay = 0;
                     break;
 
-                case 0xD7: // channel: set vibrato rate
+                case ASEQ_OPC_CHANNEL_VIBFREQ: // channel: set vibrato rate
                     cmd = (u8)cmdArgs[0];
                     channel->vibrato.vibratoRateChangeDelay = 0;
                     channel->vibrato.vibratoRateTarget = cmd * 32;
                     channel->vibrato.vibratoRateStart = cmd * 32;
                     break;
 
-                case 0xE2: // channel: set vibrato depth linear
+                case ASEQ_OPC_CHANNEL_VIBDEPTHGRAD: // channel: set vibrato depth linear
                     cmd = (u8)cmdArgs[0];
                     channel->vibrato.vibratoDepthStart = cmd * 8;
                     cmd = (u8)cmdArgs[1];
@@ -1394,7 +1396,7 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibrato.vibratoDepthChangeDelay = cmd * 16;
                     break;
 
-                case 0xE1: // channel: set vibratorate linear
+                case ASEQ_OPC_CHANNEL_VIBFREQGRAD: // channel: set vibratorate linear
                     cmd = (u8)cmdArgs[0];
                     channel->vibrato.vibratoRateStart = cmd * 32;
                     cmd = (u8)cmdArgs[1];
@@ -1403,17 +1405,17 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->vibrato.vibratoRateChangeDelay = cmd * 16;
                     break;
 
-                case 0xE3: // channel: set vibrato delay
+                case ASEQ_OPC_CHANNEL_VIBDELAY: // channel: set vibrato delay
                     cmd = (u8)cmdArgs[0];
                     channel->vibrato.vibratoDelay = cmd * 16;
                     break;
 
-                case 0xD4: // channel: set reverb volume
+                case ASEQ_OPC_CHANNEL_REVERB: // channel: set reverb volume
                     cmd = (u8)cmdArgs[0];
                     channel->targetReverbVol = cmd;
                     break;
 
-                case 0xC6: // channel: set soundFont
+                case ASEQ_OPC_CHANNEL_FONT: // channel: set soundFont
                     cmd = (u8)cmdArgs[0];
 
                     if (seqPlayer->defaultFont != 0xFF) {
@@ -1427,56 +1429,56 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xC7: // channel: write into sequence script
+                case ASEQ_OPC_CHANNEL_STSEQ: // channel: write into sequence script
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case 0xC8: // channel: subtract -> set value
-                case 0xCC: // channel: set value
-                case 0xC9: // channel: `bit and` -> set value
+                case ASEQ_OPC_CHANNEL_SUB: // channel: subtract -> set value
+                case ASEQ_OPC_CHANNEL_LDI: // channel: set value
+                case ASEQ_OPC_CHANNEL_AND: // channel: `bit and` -> set value
                     cmdArgS8 = (s8)cmdArgs[0];
 
-                    if (cmd == 0xC8) {
+                    if (cmd == ASEQ_OPC_CHANNEL_SUB) {
                         scriptState->value -= cmdArgS8;
-                    } else if (cmd == 0xCC) {
+                    } else if (cmd == ASEQ_OPC_CHANNEL_LDI) {
                         scriptState->value = cmdArgS8;
                     } else {
                         scriptState->value &= cmdArgS8;
                     }
                     break;
 
-                case 0xCD: // channel: disable channel
+                case ASEQ_OPC_CHANNEL_STOPCHAN: // channel: disable channel
                     cmd = (u8)cmdArgs[0];
                     AudioScript_SequenceChannelDisable(seqPlayer->channels[cmd]);
                     break;
 
-                case 0xCA: // channel: set mute behavior
+                case ASEQ_OPC_CHANNEL_MUTEBHV: // channel: set mute behavior
                     cmd = (u8)cmdArgs[0];
                     channel->muteFlags = cmd;
                     channel->changes.s.volume = true;
                     break;
 
-                case 0xCB: // channel: read sequence -> set value
+                case ASEQ_OPC_CHANNEL_LDSEQ: // channel: read sequence -> set value
                     cmdArgU16 = (u16)cmdArgs[0];
                     scriptState->value = *(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value));
                     break;
 
-                case 0xCE: // channel:
+                case ASEQ_OPC_CHANNEL_LDPTR: // channel:
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = cmdArgU16;
                     break;
 
-                case 0xCF: // channel: write large into sequence script
+                case ASEQ_OPC_CHANNEL_STPTRTOSEQ: // channel: write large into sequence script
                     cmdArgU16 = (u16)cmdArgs[0];
                     seqData = &seqPlayer->seqData[cmdArgU16];
                     seqData[0] = (channel->unk_22 >> 8) & 0xFF;
                     seqData[1] = channel->unk_22 & 0xFF;
                     break;
 
-                case 0xD0: // channel: stereo headset effects
+                case ASEQ_OPC_CHANNEL_EFFECTS: // channel: stereo headset effects
                     cmd = (u8)cmdArgs[0];
                     if (cmd & 0x80) {
                         channel->stereoHeadsetEffects = true;
@@ -1486,22 +1488,22 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->stereoData.asByte = cmd & 0x7F;
                     break;
 
-                case 0xD1: // channel: set note allocation policy
+                case ASEQ_OPC_CHANNEL_NOTEALLOC: // channel: set note allocation policy
                     cmd = (u8)cmdArgs[0];
                     channel->noteAllocPolicy = cmd;
                     break;
 
-                case 0xD2: // channel: set sustain
+                case ASEQ_OPC_CHANNEL_SUSTAIN: // channel: set sustain
                     cmd = (u8)cmdArgs[0];
                     channel->adsr.sustain = cmd;
                     break;
 
-                case 0xE5: // channel: set reverb index
+                case ASEQ_OPC_CHANNEL_REVERBIDX: // channel: set reverb index
                     cmd = (u8)cmdArgs[0];
                     channel->reverbIndex = cmd;
                     break;
 
-                case 0xE4: // channel: dyncall
+                case ASEQ_OPC_CHANNEL_DYNCALL: // channel: dyncall
                     if (scriptState->value != -1) {
                         data = (*channel->dynTable)[scriptState->value];
                         depth = scriptState->depth;
@@ -1513,12 +1515,12 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xE6: // channel: set book offset
+                case ASEQ_OPC_CHANNEL_SAMPLEBOOK: // channel: set book offset
                     cmd = (u8)cmdArgs[0];
                     channel->bookOffset = cmd;
                     break;
 
-                case 0xE7: // channel:
+                case ASEQ_OPC_CHANNEL_LDPARAMS: // channel:
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = &seqPlayer->seqData[cmdArgU16];
                     channel->muteFlags = *data++;
@@ -1533,7 +1535,7 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xE8: // channel:
+                case ASEQ_OPC_CHANNEL_PARAMS: // channel:
                     channel->muteFlags = cmdArgs[0];
                     channel->noteAllocPolicy = cmdArgs[1];
                     cmd = (u8)cmdArgs[2];
@@ -1547,7 +1549,7 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->changes.s.pan = true;
                     break;
 
-                case 0xEC: // channel: reset vibrato
+                case ASEQ_OPC_CHANNEL_VIBRESET: // channel: reset vibrato
                     channel->vibrato.vibratoDepthTarget = 0;
                     channel->vibrato.vibratoDepthStart = 0;
                     channel->vibrato.vibratoDepthChangeDelay = 0;
@@ -1567,26 +1569,26 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->freqScale = 1.0f;
                     break;
 
-                case 0xE9: // channel: set note priority
+                case ASEQ_OPC_CHANNEL_NOTEPRI: // channel: set note priority
                     AudioScript_SetChannelPriorities(channel, (u8)cmdArgs[0]);
                     break;
 
-                case 0xED: // channel: set hilo gain
+                case ASEQ_OPC_CHANNEL_GAIN: // channel: set hilo gain
                     cmd = (u8)cmdArgs[0];
                     channel->gain = cmd;
                     break;
 
-                case 0xB0: // channel: set filter
+                case ASEQ_OPC_CHANNEL_LDFILTER: // channel: set filter
                     cmdArgU16 = (u16)cmdArgs[0];
                     data = seqPlayer->seqData + cmdArgU16;
                     channel->filter = (s16*)data;
                     break;
 
-                case 0xB1: // channel: clear filter
+                case ASEQ_OPC_CHANNEL_FREEFILTER: // channel: clear filter
                     channel->filter = NULL;
                     break;
 
-                case 0xB3: // channel: load filter
+                case ASEQ_OPC_CHANNEL_FILTER: // channel: load filter
                     cmd = cmdArgs[0];
 
                     if (channel->filter != NULL) {
@@ -1596,34 +1598,34 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xB2: // channel: dynread sequence large
+                case ASEQ_OPC_CHANNEL_LDSEQTOPTR: // channel: dynread sequence large
                     cmdArgU16 = (u16)cmdArgs[0];
                     channel->unk_22 = *(u16*)(seqPlayer->seqData + (u32)(cmdArgU16 + scriptState->value * 2));
                     break;
 
-                case 0xB4: // channel: set dyntable large
+                case ASEQ_OPC_CHANNEL_PTRTODYNTBL: // channel: set dyntable large
                     channel->dynTable = (void*)&seqPlayer->seqData[channel->unk_22];
                     break;
 
-                case 0xB5: // channel: read dyntable large
+                case ASEQ_OPC_CHANNEL_DYNTBLTOPTR: // channel: read dyntable large
                     channel->unk_22 = ((u16*)(channel->dynTable))[scriptState->value];
                     break;
 
-                case 0xB6: // channel: read dyntable
+                case ASEQ_OPC_CHANNEL_DYNTBLV: // channel: read dyntable
                     scriptState->value = (*channel->dynTable)[0][scriptState->value];
                     break;
 
-                case 0xB7: // channel: random large
+                case ASEQ_OPC_CHANNEL_RANDTOPTR: // channel: random large
                     channel->unk_22 =
                         (cmdArgs[0] == 0) ? (gAudioCtx.audioRandom & 0xFFFF) : (gAudioCtx.audioRandom % cmdArgs[0]);
                     break;
 
-                case 0xB8: // channel: random value
+                case ASEQ_OPC_CHANNEL_RAND: // channel: random value
                     scriptState->value =
                         (cmdArgs[0] == 0) ? (gAudioCtx.audioRandom & 0xFFFF) : (gAudioCtx.audioRandom % cmdArgs[0]);
                     break;
 
-                case 0xA8: // channel: random range large (only cmd that differs from OoT)
+                case ASEQ_OPC_CHANNEL_RANDPTR: // channel: random range large (only cmd that differs from OoT)
                     rand = AudioThread_NextRandom();
                     channel->unk_22 = (cmdArgs[0] == 0) ? (rand & 0xFFFF) : (rand % cmdArgs[0]);
                     channel->unk_22 += cmdArgs[1];
@@ -1632,28 +1634,28 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     channel->unk_22 = (temp2 << 8) | param;
                     break;
 
-                case 0xB9: // channel: set velocity random variance
+                case ASEQ_OPC_CHANNEL_RANDVEL: // channel: set velocity random variance
                     channel->velocityRandomVariance = cmdArgs[0];
                     break;
 
-                case 0xBA: // channel: set gatetime random variance
+                case ASEQ_OPC_CHANNEL_RANDGATE: // channel: set gatetime random variance
                     channel->gateTimeRandomVariance = cmdArgs[0];
                     break;
 
-                case 0xBB: // channel:
+                case ASEQ_OPC_CHANNEL_COMBFILTER: // channel:
                     channel->combFilterSize = cmdArgs[0];
                     channel->combFilterGain = cmdArgs[1];
                     break;
 
-                case 0xBC: // channel: add large
+                case ASEQ_OPC_CHANNEL_PTRADD: // channel: add large
                     channel->unk_22 += cmdArgs[0];
                     break;
 
-                case 0xBD: // channel:
+                case ASEQ_OPC_CHANNEL_SAMPLESTART: // channel:
                     channel->startSamplePos = cmdArgs[0];
                     break;
 
-                case 0xBE: // channel:
+                case ASEQ_OPC_CHANNEL_UNK_BE: // channel:
                     if (cmdArgs[0] < 5) {
                         if (1) {}
                         if (gAudioCtx.customSeqFunctions[cmdArgs[0]] != NULL) {
@@ -1663,18 +1665,18 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xA0: // channel: read from SfxChannelState using arg
-                case 0xA1: // channel: read from SfxChannelState using unk_22
-                case 0xA2: // channel: write to SfxChannelState using arg
-                case 0xA3: // channel: write to SfxChannelState using unk_22
-                    if ((cmd == 0xA0) || (cmd == 0xA2)) {
+                case ASEQ_OPC_CHANNEL_A0: // channel: read from SfxChannelState using arg
+                case ASEQ_OPC_CHANNEL_A1: // channel: read from SfxChannelState using unk_22
+                case ASEQ_OPC_CHANNEL_A2: // channel: write to SfxChannelState using arg
+                case ASEQ_OPC_CHANNEL_A3: // channel: write to SfxChannelState using unk_22
+                    if ((cmd == ASEQ_OPC_CHANNEL_A0) || (cmd == ASEQ_OPC_CHANNEL_A2)) {
                         cmdArgU16 = (u16)cmdArgs[0];
                     } else {
                         cmdArgU16 = channel->unk_22;
                     }
 
                     if (channel->sfxState != NULL) {
-                        if ((cmd == 0xA0) || (cmd == 0xA1)) {
+                        if ((cmd == ASEQ_OPC_CHANNEL_A0) || (cmd == ASEQ_OPC_CHANNEL_A1)) {
                             scriptState->value = channel->sfxState[cmdArgU16];
                         } else {
                             channel->sfxState[cmdArgU16] = scriptState->value;
@@ -1682,22 +1684,22 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0xA4: // channel:
+                case ASEQ_OPC_CHANNEL_A4: // channel:
                     channel->surroundEffectIndex = cmdArgs[0];
                     break;
 
-                case 0xA5: // channel:
+                case ASEQ_OPC_CHANNEL_A5: // channel:
                     scriptState->value += channel->channelIndex;
                     break;
 
-                case 0xA6: // channel:
+                case ASEQ_OPC_CHANNEL_A6: // channel:
                     cmd = (u8)cmdArgs[0];
                     cmdArgU16 = (u16)cmdArgs[1];
                     seqData = seqPlayer->seqData + (u32)(cmdArgU16 + channel->channelIndex);
                     seqData[0] = (u8)scriptState->value + cmd;
                     break;
 
-                case 0xA7: // channel:
+                case ASEQ_OPC_CHANNEL_A7: // channel:
                     new_var2 = (cmdArgs[0] & 0x80);
                     new_var = (scriptState->value & 0x80);
 
@@ -1722,12 +1724,12 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
         if (cmd >= 0x70) {
             lowBits = cmd & 0x7;
 
-            if (((cmd & 0xF8) != 0x70) && (lowBits >= 4)) {
+            if (((cmd & 0xF8) != ASEQ_OPC_CHANNEL_STIO) && (lowBits >= 4)) {
                 lowBits = 0;
             }
 
             switch (cmd & 0xF8) {
-                case 0x80: // channel: test layer is finished
+                case ASEQ_OPC_CHANNEL_TESTLAYER: // channel: test layer is finished
                     if (channel->layers[lowBits] != NULL) {
                         scriptState->value = channel->layers[lowBits]->finished;
                     } else {
@@ -1735,18 +1737,18 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0x88: // channel: set layer
+                case ASEQ_OPC_CHANNEL_LDLAYER: // channel: set layer
                     cmdArgU16 = AudioScript_ScriptReadS16(scriptState);
                     if (!AudioScript_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &seqPlayer->seqData[cmdArgU16];
                     }
                     break;
 
-                case 0x90: // channel: free layer
+                case ASEQ_OPC_CHANNEL_DELLAYER: // channel: free layer
                     AudioScript_SeqLayerFree(channel, lowBits);
                     break;
 
-                case 0x98: // channel: dynset layer
+                case ASEQ_OPC_CHANNEL_DYNLDLAYER: // channel: dynset layer
                     if ((scriptState->value != -1) && (AudioScript_SeqChannelSetLayer(channel, lowBits) != -1)) {
                         data = (*channel->dynTable)[scriptState->value];
                         cmdArgU16 = (data[0] << 8) + data[1];
@@ -1754,11 +1756,11 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                     }
                     break;
 
-                case 0x70: // channel: io write value
+                case ASEQ_OPC_CHANNEL_STIO: // channel: io write value
                     channel->seqScriptIO[lowBits] = scriptState->value;
                     break;
 
-                case 0x78: // channel: set layer relative
+                case ASEQ_OPC_CHANNEL_RLDLAYER: // channel: set layer relative
                     temp1 = AudioScript_ScriptReadS16(scriptState);
                     if (!AudioScript_SeqChannelSetLayer(channel, lowBits)) {
                         channel->layers[lowBits]->scriptState.pc = &scriptState->pc[temp1];
@@ -1772,14 +1774,14 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
         lowBits = cmd & 0xF;
 
         switch (cmd & 0xF0) {
-            case 0x00: // channel: delay short
+            case ASEQ_OPC_CHANNEL_CDELAY: // channel: delay short
                 channel->delay = lowBits;
                 if (lowBits == 0) {
                     break;
                 }
                 goto exit_loop;
 
-            case 0x10: // channel: load sample
+            case ASEQ_OPC_CHANNEL_LDSAMPLE: // channel: load sample
                 if (lowBits < 8) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                     if (AudioLoad_SlowLoadSample(channel->fontId, scriptState->value, &channel->seqScriptIO[lowBits]) ==
@@ -1792,28 +1794,28 @@ void AudioScript_SequenceChannelProcessScript(SequenceChannel* channel) {
                 }
                 break;
 
-            case 0x60: // channel: io read value
+            case ASEQ_OPC_CHANNEL_LDIO: // channel: io read value
                 scriptState->value = channel->seqScriptIO[lowBits];
                 if (lowBits < 2) {
                     channel->seqScriptIO[lowBits] = SEQ_IO_VAL_NONE;
                 }
                 break;
 
-            case 0x50: // channel: io read value subtract
+            case ASEQ_OPC_CHANNEL_SUBIO: // channel: io read value subtract
                 scriptState->value -= channel->seqScriptIO[lowBits];
                 break;
 
-            case 0x20: // channel: start channel
+            case ASEQ_OPC_CHANNEL_LDCHAN: // channel: start channel
                 cmdArgU16 = AudioScript_ScriptReadS16(scriptState);
                 AudioScript_SequenceChannelEnable(seqPlayer, lowBits, &seqPlayer->seqData[cmdArgU16]);
                 break;
 
-            case 0x30: // channel: io write value 2
+            case ASEQ_OPC_CHANNEL_STCIO: // channel: io write value 2
                 cmd = AudioScript_ScriptReadU8(scriptState);
                 seqPlayer->channels[lowBits]->seqScriptIO[cmd] = scriptState->value;
                 break;
 
-            case 0x40: // channel: io read value 2
+            case ASEQ_OPC_CHANNEL_LDCIO: // channel: io read value 2
                 cmd = AudioScript_ScriptReadU8(scriptState);
                 scriptState->value = seqPlayer->channels[lowBits]->seqScriptIO[cmd];
                 break;
@@ -1895,7 +1897,7 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmd = AudioScript_ScriptReadU8(seqScript);
 
             // 0xF2 and above are "flow control" commands, including termination.
-            if (cmd >= 0xF2) {
+            if (cmd >= ASEQ_OPC_CONTROL_FLOW_FIRST) {
                 delay = AudioScript_HandleScriptFlowControl(
                     seqPlayer, seqScript, cmd, AudioScript_GetScriptControlFlowArgument(&seqPlayer->scriptState, cmd));
 
@@ -1913,24 +1915,24 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             // Commands 0xC0 - 0xF1
             if (cmd >= 0xC0) {
                 switch (cmd) {
-                    case 0xF1: // seqPlayer: reserve notes
+                    case ASEQ_OPC_SEQUENCE_ALLOCNOTELIST: // seqPlayer: reserve notes
                         AudioList_ClearNotePool(&seqPlayer->notePool);
                         cmd = AudioScript_ScriptReadU8(seqScript);
                         AudioList_FillNotePool(&seqPlayer->notePool, cmd);
                         break;
 
-                    case 0xF0: // seqPlayer: unreserve notes
+                    case ASEQ_OPC_SEQUENCE_FREENOTELIST: // seqPlayer: unreserve notes
                         AudioList_ClearNotePool(&seqPlayer->notePool);
                         break;
 
-                    case 0xDF: // seqPlayer: transpose
+                    case ASEQ_OPC_SEQUENCE_TRANSPOSE: // seqPlayer: transpose
                         seqPlayer->transposition = 0;
                         FALLTHROUGH;
-                    case 0xDE: // seqPlayer: transpose relative
+                    case ASEQ_OPC_SEQUENCE_RTRANSPOSE: // seqPlayer: transpose relative
                         seqPlayer->transposition += (s8)AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xDD: // seqPlayer: set tempo
+                    case ASEQ_OPC_SEQUENCE_TEMPO: // seqPlayer: set tempo
                         seqPlayer->tempo = AudioScript_ScriptReadU8(seqScript) * TATUMS_PER_BEAT;
                         if (seqPlayer->tempo > gAudioCtx.maxTempo) {
                             seqPlayer->tempo = gAudioCtx.maxTempo;
@@ -1941,11 +1943,11 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xDC: // seqPlayer: add tempo
+                    case ASEQ_OPC_SEQUENCE_TEMPOCHG: // seqPlayer: add tempo
                         seqPlayer->tempoChange = (s8)AudioScript_ScriptReadU8(seqScript) * TATUMS_PER_BEAT;
                         break;
 
-                    case 0xDA: // seqPlayer: change volume
+                    case ASEQ_OPC_SEQUENCE_VOLMODE: // seqPlayer: change volume
                         cmd = AudioScript_ScriptReadU8(seqScript);
                         temp = AudioScript_ScriptReadS16(seqScript);
                         switch (cmd) {
@@ -1965,7 +1967,7 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xDB: // seqPlayer: set volume
+                    case ASEQ_OPC_SEQUENCE_VOL: // seqPlayer: set volume
                         value = AudioScript_ScriptReadU8(seqScript);
                         switch (seqPlayer->state) {
                             case SEQPLAYER_STATE_FADE_IN:
@@ -1987,47 +1989,47 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xD9: // seqPlayer: set volume scale
+                    case ASEQ_OPC_SEQUENCE_VOLSCALE: // seqPlayer: set volume scale
                         seqPlayer->fadeVolumeScale = (s8)AudioScript_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case 0xD7: // seqPlayer: initialize channels
+                    case ASEQ_OPC_SEQUENCE_INITCHAN: // seqPlayer: initialize channels
                         temp = AudioScript_ScriptReadS16(seqScript);
                         AudioScript_SequencePlayerSetupChannels(seqPlayer, temp);
                         break;
 
-                    case 0xD6: // seqPlayer: disable channels
+                    case ASEQ_OPC_SEQUENCE_FREECHAN: // seqPlayer: disable channels
                         AudioScript_ScriptReadS16(seqScript);
                         break;
 
-                    case 0xD5: // seqPlayer: set mute scale
+                    case ASEQ_OPC_SEQUENCE_MUTESCALE: // seqPlayer: set mute scale
                         seqPlayer->muteVolumeScale = (s8)AudioScript_ScriptReadU8(seqScript) / 127.0f;
                         break;
 
-                    case 0xD4: // seqPlayer: mute
+                    case ASEQ_OPC_SEQUENCE_MUTE: // seqPlayer: mute
                         seqPlayer->muted = true;
                         break;
 
-                    case 0xD3: // seqPlayer: set mute behavior
+                    case ASEQ_OPC_SEQUENCE_MUTEBHV: // seqPlayer: set mute behavior
                         seqPlayer->muteFlags = AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xD1: // seqPlayer: set short note gatetime table
-                    case 0xD2: // seqPlayer: set short note velocity table
+                    case ASEQ_OPC_SEQUENCE_LDSHORTGATEARR: // seqPlayer: set short note gatetime table
+                    case ASEQ_OPC_SEQUENCE_LDSHORTVELARR: // seqPlayer: set short note velocity table
                         temp = AudioScript_ScriptReadS16(seqScript);
                         data3 = &seqPlayer->seqData[temp];
-                        if (cmd == 0xD2) {
+                        if (cmd == ASEQ_OPC_SEQUENCE_LDSHORTVELARR) {
                             seqPlayer->shortNoteVelocityTable = data3;
                         } else {
                             seqPlayer->shortNoteGateTimeTable = data3;
                         }
                         break;
 
-                    case 0xD0: // seqPlayer: set note allocation policy
+                    case ASEQ_OPC_SEQUENCE_NOTEALLOC: // seqPlayer: set note allocation policy
                         seqPlayer->noteAllocPolicy = AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xCE: // seqPlayer: random value
+                    case ASEQ_OPC_SEQUENCE_RAND: // seqPlayer: random value
                         cmd = AudioScript_ScriptReadU8(seqScript);
                         if (cmd == 0) {
                             seqScript->value = (gAudioCtx.audioRandom >> 2) & 0xFF;
@@ -2036,7 +2038,7 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xCD: // seqPlayer: dyncall
+                    case ASEQ_OPC_SEQUENCE_DYNCALL: // seqPlayer: dyncall
                         temp = AudioScript_ScriptReadS16(seqScript);
                         if ((seqScript->value != -1) && (seqScript->depth != 3)) {
                             data1 = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -2047,26 +2049,26 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xCC: // seqPlayer: set value
+                    case ASEQ_OPC_SEQUENCE_LDI: // seqPlayer: set value
                         seqScript->value = AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC9: // seqPlayer: `bit and` -> set value
+                    case ASEQ_OPC_SEQUENCE_AND: // seqPlayer: `bit and` -> set value
                         seqScript->value &= AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC8: // seqPlayer: subtract -> set value
+                    case ASEQ_OPC_SEQUENCE_SUB: // seqPlayer: subtract -> set value
                         seqScript->value -= AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC7: // seqPlayer: write into sequence script
+                    case ASEQ_OPC_SEQUENCE_STSEQ: // seqPlayer: write into sequence script
                         cmd = AudioScript_ScriptReadU8(seqScript);
                         temp = AudioScript_ScriptReadS16(seqScript);
                         data2 = &seqPlayer->seqData[temp];
                         *data2 = (u8)seqScript->value + cmd;
                         break;
 
-                    case 0xC2: // seqPlayer:
+                    case ASEQ_OPC_SEQUENCE_C2: // seqPlayer:
                         temp = AudioScript_ScriptReadS16(seqScript);
                         if (seqScript->value != -1) {
                             data4 = seqPlayer->seqData + (u32)(temp + (seqScript->value << 1));
@@ -2076,20 +2078,20 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xC6: // seqPlayer: stop script
+                    case ASEQ_OPC_SEQUENCE_STOP: // seqPlayer: stop script
                         seqPlayer->stopScript = true;
                         return;
 
-                    case 0xC5: // seqPlayer:
+                    case ASEQ_OPC_SEQUENCE_SCRIPTCTR: // seqPlayer:
                         seqPlayer->unk_16 = AudioScript_ScriptReadS16(seqScript);
                         break;
 
-                    case 0xEF: // seqPlayer:
+                    case ASEQ_OPC_SEQUENCE_EF: // seqPlayer:
                         AudioScript_ScriptReadS16(seqScript);
                         AudioScript_ScriptReadU8(seqScript);
                         break;
 
-                    case 0xC4: // seqPlayer: start sequence
+                    case ASEQ_OPC_SEQUENCE_RUNSEQ: // seqPlayer: start sequence
                         cmd = AudioScript_ScriptReadU8(seqScript);
                         if (cmd == 0xFF) {
                             cmd = seqPlayer->playerIndex;
@@ -2105,7 +2107,7 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
                         }
                         break;
 
-                    case 0xC3: // seqPlayer:
+                    case ASEQ_OPC_SEQUENCE_C3: // seqPlayer:
                         temp = AudioScript_ScriptReadS16(seqScript);
                         if (seqScript->value != -1) {
                             new_var = (u16*)(seqPlayer->seqData + (u32)(temp + seqScript->value * 2));
@@ -2125,47 +2127,47 @@ void AudioScript_SequencePlayerProcessSequence(SequencePlayer* seqPlayer) {
             cmdLowBits = cmd & 0x0F;
 
             switch (cmd & 0xF0) {
-                case 0x00: // seqPlayer: test channel disabled
+                case ASEQ_OPC_SEQUENCE_TESTCHAN: // seqPlayer: test channel disabled
                     seqScript->value = seqPlayer->channels[cmdLowBits]->enabled ^ 1;
                     break;
 
-                case 0x50: // seqPlayer: io read value subtract
+                case ASEQ_OPC_SEQUENCE_SUBIO: // seqPlayer: io read value subtract
                     seqScript->value -= seqPlayer->seqScriptIO[cmdLowBits];
                     break;
 
-                case 0x70: // seqPlayer: io write value
+                case ASEQ_OPC_SEQUENCE_STIO: // seqPlayer: io write value
                     seqPlayer->seqScriptIO[cmdLowBits] = seqScript->value;
                     break;
 
-                case 0x80: // seqPlayer: io read value
+                case ASEQ_OPC_SEQUENCE_LDIO: // seqPlayer: io read value
                     seqScript->value = seqPlayer->seqScriptIO[cmdLowBits];
                     if (cmdLowBits < 2) {
                         seqPlayer->seqScriptIO[cmdLowBits] = SEQ_IO_VAL_NONE;
                     }
                     break;
 
-                case 0x40: // seqPlayer: disable channel
+                case ASEQ_OPC_SEQUENCE_STOPCHAN: // seqPlayer: disable channel
                     AudioScript_SequenceChannelDisable(seqPlayer->channels[cmdLowBits]);
                     break;
 
-                case 0x90: // seqPlayer: start channel
+                case ASEQ_OPC_SEQUENCE_LDCHAN: // seqPlayer: start channel
                     temp = AudioScript_ScriptReadS16(seqScript);
                     AudioScript_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqPlayer->seqData[temp]);
                     break;
 
-                case 0xA0: // seqPlayer: start channel relative
+                case ASEQ_OPC_SEQUENCE_RLDCHAN: // seqPlayer: start channel relative
                     tempS = AudioScript_ScriptReadS16(seqScript);
                     AudioScript_SequenceChannelEnable(seqPlayer, cmdLowBits, (void*)&seqScript->pc[tempS]);
                     break;
 
-                case 0xB0: // seqPlayer: load sequence
+                case ASEQ_OPC_SEQUENCE_LDSEQ: // seqPlayer: load sequence
                     cmd = AudioScript_ScriptReadU8(seqScript);
                     temp = AudioScript_ScriptReadS16(seqScript);
                     data2 = &seqPlayer->seqData[temp];
                     AudioLoad_SlowLoadSeq(cmd, data2, &seqPlayer->seqScriptIO[cmdLowBits]);
                     break;
 
-                case 0x60: // seqPlayer: async load
+                case ASEQ_OPC_SEQUENCE_LDRES: // seqPlayer: async load
                     cmd = AudioScript_ScriptReadU8(seqScript);
                     value = cmd;
                     temp = AudioScript_ScriptReadU8(seqScript);


### PR DESCRIPTION
Macroify the Music Macro Language (MML) opcodes, and use them in the sequence player interpreter.

Companion PR to https://github.com/zeldaret/oot/pull/2485