### PR TITLE
Document inconsistent empty C-button disabling bug

### DIFF
--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -2044,9 +2044,10 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
         if (GET_PLAYER_FORM == player->transformation) {
             for (i = EQUIP_SLOT_C_LEFT; i <= EQUIP_SLOT_C_RIGHT; i++) {
                 // Individual C button
-                //! @bug When C-buttons are empty, their item code is 255. However, gPlayerFormItemRestrictions's second dimension has
-                //! only been allocated 114 elements. This leads to inconsistent behaviour when checking the status of empty
-                //! C-buttons - for most forms, the C-buttons are enabled when empty, however for Deku Link only, empty C-buttons are disabled.
+                //! @bug When C-buttons are empty, their item code is 255. However, gPlayerFormItemRestrictions's second
+                //! dimension has only been allocated 114 elements. This leads to inconsistent behaviour when checking
+                //! the status of empty C-buttons - for most forms, the C-buttons are enabled when empty, however for
+                //! Deku Link only, empty C-buttons are disabled.
                 if (!gPlayerFormItemRestrictions[GET_PLAYER_FORM][GET_CUR_FORM_BTN_ITEM(i)]) {
                     // Item not usable in current playerForm
                     if (gSaveContext.buttonStatus[i] != BTN_DISABLED) {

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -2044,6 +2044,9 @@ void Interface_UpdateButtonsPart2(PlayState* play) {
         if (GET_PLAYER_FORM == player->transformation) {
             for (i = EQUIP_SLOT_C_LEFT; i <= EQUIP_SLOT_C_RIGHT; i++) {
                 // Individual C button
+                //! @bug When C-buttons are empty, their item code is 255. However, gPlayerFormItemRestrictions's second dimension has
+                //! only been allocated 114 elements. This leads to inconsistent behaviour when checking the status of empty
+                //! C-buttons - for most forms, the C-buttons are enabled when empty, however for Deku Link only, empty C-buttons are disabled.
                 if (!gPlayerFormItemRestrictions[GET_PLAYER_FORM][GET_CUR_FORM_BTN_ITEM(i)]) {
                     // Item not usable in current playerForm
                     if (gSaveContext.buttonStatus[i] != BTN_DISABLED) {


### PR DESCRIPTION
In Interface_UpdateButtonsPart2, there is a bug causing empty C-buttons to be disabled inconsistently (for most forms, they are enabled, but when Deku Link, they are disabled): [Example](https://tcrf.net/The_Legend_of_Zelda:_Majora%27s_Mask/Program_Revision_Differences#C-Buttons)

This is because the function checks the 255th index of the second dimension of gPlayerFormItemRestrictions - a dimension which has only been allocated 114 elements. This leads to inconsistent behaviour.