### PR TITLE
Replace erroneous CsCmdStartSeq with CsCmdStopSeq

### DIFF
--- a/src/code/z_demo.c
+++ b/src/code/z_demo.c
@@ -1252,7 +1252,7 @@ void Cutscene_ProcessScript(PlayState* play, CutsceneContext* csCtx, u8* script)
 
                 for (j = 0; j < cmdEntries; j++) {
                     CutsceneCmd_StopSequence(play, csCtx, (CsCmdStopSeq*)script);
-                    script += sizeof(CsCmdStartSeq);
+                    script += sizeof(CsCmdStopSeq);
                 }
                 break;
 


### PR DESCRIPTION
The cutscene command for stopping a sequence advances the script by `sizeof(CsCmdStartSeq)` instead of `sizeof(CsCmdStopSeq)`. The values are the same.