### PR TITLE
Fix docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,15 @@ FROM ubuntu:24.04 AS build
 ENV TZ=UTC
 ENV LANG=C.UTF-8
 
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Add source for practicerom-dev install
+RUN apt-get update && apt-get install -y curl && \
+    curl -o /etc/apt/trusted.gpg.d/practicerom.gpg https://practicerom.com/public/packages/practicerom.gpg && \
+    echo 'deb [arch=amd64] http://practicerom.com/public/packages/debian unstable main' > /etc/apt/sources.list.d/practicerom.list
+
 # Install Required Dependencies
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
-    apt-get update && apt-get install -y \
-    curl \
+RUN apt-get update && apt-get install -y \
     build-essential \
     binutils-mips-linux-gnu \
     pkg-config \
@@ -20,12 +25,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &
     vim \
     clang-tidy-14 \
     clang-format-14 \
-    libpng-dev && \
-    # Add source for practicerom-dev install
-    curl https://practicerom.com/public/packages/debian/pgp.pub | apt-key add - && \ 
-    echo deb http://practicerom.com/public/packages/debian staging main >/etc/apt/sources.list.d/practicerom.list && \
-    apt-get update && \
-    apt-get install -y \
+    libpng-dev \
     practicerom-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Preparation is covered in [Building Docker](docs/BUILDING_DOCKER.md).
 
 The build process has the following package requirements:
 
-* make
 * git
 * build-essential
 * binutils-mips-linux-gnu
@@ -77,7 +76,7 @@ Under Debian / Ubuntu (which we recommend using), you can install them with the 
 
 ```bash
 sudo apt update
-sudo apt install make git build-essential binutils-mips-linux-gnu curl python3 python3-pip python3-venv libpng-dev libxml2-dev
+sudo apt install git build-essential binutils-mips-linux-gnu curl python3 python3-pip python3-venv libpng-dev libxml2-dev
 ```
 
 #### 2. Clone the repository
@@ -102,11 +101,13 @@ Rename the file to `baserom.z64`, `baserom.n64` or `baserom.v64`, depending on t
 
 #### 4. Make and Build the ROM
 
-To start the extraction/build process, run the following command:
+For a first time build, run the following command, where `N` is the number of cores your processor has (see the note at the bottom for more information):
 
 ```bash
-make init
+make init -j N
 ```
+
+After the very first build you'll want to run `make -j N` instead, since you likely won't need all the setup the `init` command provides.
 
 The extraction/build process:
 1. Prepares build environment:

--- a/docs/BUILDING_DOCKER.md
+++ b/docs/BUILDING_DOCKER.md
@@ -6,7 +6,7 @@ You will need [Docker](https://docs.docker.com/get-docker/) Follow the instructi
 
 ## 1. Clone the Repository
 
-You will need to prepare a local version of the project with a copied base ROM (see steps [2](../README.md#2-clone-the-repository) and [4](../README.md#4-prepare-a-base-rom) of the Linux instructions).
+You will need to prepare a local version of the project with a copied base ROM (see steps [2. Clone the repository](../README.md#2-clone-the-repository) and [3. Prepare a base ROM](../README.md#3-prepare-a-base-rom) of the Linux instructions).
 
 ## 2. Create the Docker image
 
@@ -38,10 +38,4 @@ docker run -it --rm --mount type=bind,source="$(pwd)",destination=/mm mm "/usr/b
 
 ## 4. Setup and Build the ROM
 
-Once inside the container, you will need to set the repository as a trusted repository with the following command:
-
-```bash
-git config --global --add safe.directory /mm
-```
-
-After that continue with step [5. Make and Build the ROM](../README.md#5-make-and-build-the-rom) of the Linux instructions to setup and build the ROM, or run any other command you need.
+After that continue with step [4. Make and Build the ROM](../README.md#4-make-and-build-the-rom) of the Linux instructions to setup and build the ROM, or run any other command you need.


### PR DESCRIPTION
I got curious about PR #1813, because it claimed Docker builds to be broken, but the PR did not provide any reason why Docker doesn't work, so I tried it out.

The issue was caused by not being able to setup the practicerom stuff while creating the Docker image.
- The gpg key was moved on the host, so the old link leads to a 404 error.
- The old contents of the `practicerom.list` apt list are no longer valid either.
  - This actually causes issues when trying to `apt update` on a machine that still uses the old `practicerom.list`. I had to `sudo rm /etc/apt/sources.list.d/practicerom.list` on my main pc to get rid of the errors.

The changes to the practicerom repository seems to have happened 2 days ago by judging by [this commit on glankk's repo](https://github.com/glankk/n64/commit/e7bec93b0b11b37a63abcf5ac28728f2fcd4045b#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)

I changed the `Dockerfile` to use the updated instructions instead.

I also updated some updated references on the markdown files.

Besides this, I could use updated Docker image to build MM without any other problem.