### PR TITLE
Overwrite PRINTF instead of whole new macros

### DIFF
--- a/src/boot/libu64/debug.c
+++ b/src/boot/libu64/debug.c
@@ -1,12 +1,9 @@
 #include "global.h"
 #include "fault.h"
 
-#if MM_VERSION < N64_US || DEBUG_FEATURES
-#define DEBUG_PRINTF osSyncPrintf
-#elif IDO_PRINTF_WORKAROUND
-#define DEBUG_PRINTF(args) (void)0
-#else
-#define DEBUG_PRINTF(format, ...) (void)0
+#if MM_VERSION < N64_US
+#undef PRINTF
+#define PRINTF osSyncPrintf
 #endif
 
 #if MM_VERSION < N64_US
@@ -23,11 +20,11 @@ f32 LogUtils_CheckFloatRange(const char* exp, int line, const char* valueName, f
 NORETURN void _dbg_hungup(const char* file, int lineNum) {
     OSId threadId = osGetThreadId(NULL);
 
-    DEBUG_PRINTF("*** HungUp in thread %d, [%s:%d] ***\n", threadId, file, lineNum);
+    PRINTF("*** HungUp in thread %d, [%s:%d] ***\n", threadId, file, lineNum);
     Fault_AddHungupAndCrash(file, lineNum);
 }
 
 NORETURN void Reset(void) {
-    DEBUG_PRINTF("*** Reset ***\n");
+    PRINTF("*** Reset ***\n");
     Fault_AddHungupAndCrash("Reset", 0);
 }

--- a/src/boot/libu64/gfxprint.c
+++ b/src/boot/libu64/gfxprint.c
@@ -9,12 +9,9 @@
 #define GFXP_FLAG_ENLARGE (1 << 6)
 #define GFXP_FLAG_OPEN (1 << 7)
 
-#if MM_VERSION < N64_US || DEBUG_FEATURES
-#define GFXPRINT_PRINTF osSyncPrintf
-#elif IDO_PRINTF_WORKAROUND
-#define GFXPRINT_PRINTF(args) (void)0
-#else
-#define GFXPRINT_PRINTF(format, ...) (void)0
+#if MM_VERSION < N64_US
+#undef PRINTF
+#define PRINTF osSyncPrintf
 #endif
 
 u64 sGfxPrintFontTLUT[] = {
@@ -235,7 +232,7 @@ void GfxPrint_Open(GfxPrint* this, Gfx* dList) {
         this->dList = dList;
         GfxPrint_Setup(this);
     } else {
-        GFXPRINT_PRINTF(T("gfxprint_open:２重オープンです\n", "gfxprint_open: Double open\n"));
+        PRINTF(T("gfxprint_open:２重オープンです\n", "gfxprint_open: Double open\n"));
     }
 }
 

--- a/src/boot/libu64/rcp_utils.c
+++ b/src/boot/libu64/rcp_utils.c
@@ -1,27 +1,24 @@
 #include "ultra64.h"
 #include "macros.h"
 
-#if MM_VERSION < N64_US || DEBUG_FEATURES
-#define RCP_UTILS_PRINTF osSyncPrintf
-#elif IDO_PRINTF_WORKAROUND
-#define RCP_UTILS_PRINTF(args) (void)0
-#else
-#define RCP_UTILS_PRINTF(format, ...) (void)0
+#if MM_VERSION < N64_US
+#undef PRINTF
+#define PRINTF osSyncPrintf
 #endif
 
 #define printSpStatus(x, name) \
     if (x & SP_STATUS_##name)  \
-    RCP_UTILS_PRINTF(#name " ")
+    PRINTF(#name " ")
 
 #define printDpStatus(x, name) \
     if (x & DPC_STATUS_##name) \
-    RCP_UTILS_PRINTF(#name " ")
+    PRINTF(#name " ")
 
 void RcpUtils_PrintRegisterStatus(void) {
     u32 spStatus = __osSpGetStatus();
     u32 dpStatus = osDpGetStatus();
 
-    RCP_UTILS_PRINTF("osSpGetStatus=%08x: ", spStatus);
+    PRINTF("osSpGetStatus=%08x: ", spStatus);
     printSpStatus(spStatus, HALT);
     printSpStatus(spStatus, BROKE);
     printSpStatus(spStatus, DMA_BUSY);
@@ -37,9 +34,9 @@ void RcpUtils_PrintRegisterStatus(void) {
     printSpStatus(spStatus, SIG5);
     printSpStatus(spStatus, SIG6);
     printSpStatus(spStatus, SIG7);
-    RCP_UTILS_PRINTF("\n");
+    PRINTF("\n");
 
-    RCP_UTILS_PRINTF("osDpGetStatus=%08x:", dpStatus);
+    PRINTF("osDpGetStatus=%08x:", dpStatus);
     printDpStatus(dpStatus, XBUS_DMEM_DMA);
     printDpStatus(dpStatus, FREEZE);
     printDpStatus(dpStatus, FLUSH);
@@ -51,7 +48,7 @@ void RcpUtils_PrintRegisterStatus(void) {
     printDpStatus(dpStatus, DMA_BUSY);
     printDpStatus(dpStatus, END_VALID);
     printDpStatus(dpStatus, START_VALID);
-    RCP_UTILS_PRINTF("\n");
+    PRINTF("\n");
 }
 
 void RcpUtils_Reset(void) {

--- a/src/boot/libu64/stackcheck.c
+++ b/src/boot/libu64/stackcheck.c
@@ -6,12 +6,9 @@
 
 #include "versions.h"
 
-#if MM_VERSION < N64_US || DEBUG_FEATURES
-#define STACKCHECK_PRINTF osSyncPrintf
-#elif IDO_PRINTF_WORKAROUND
-#define STACKCHECK_PRINTF(args) (void)0
-#else
-#define STACKCHECK_PRINTF(format, ...) (void)0
+#if MM_VERSION < N64_US
+#undef PRINTF
+#define PRINTF osSyncPrintf
 #endif
 
 StackEntry* sStackInfoListStart = NULL;
@@ -32,7 +29,7 @@ void StackCheck_Init(StackEntry* entry, void* stackBottom, void* stackTop, u32 i
 
         for (iter = sStackInfoListStart; iter != NULL; iter = iter->next) {
             if (iter == entry) {
-                STACKCHECK_PRINTF(
+                PRINTF(
                     T("stackcheck_init: %08x は既にリスト中にある\n", "stackcheck_init: %08x is already in the list\n"),
                     entry);
                 return;
@@ -83,8 +80,8 @@ void StackCheck_Cleanup(StackEntry* entry) {
     }
 
     if (inconsistency) {
-        STACKCHECK_PRINTF(
-            T("stackcheck_cleanup: %08x リスト不整合です\n", "stackcheck_cleanup: %08x list inconsistency\n"), entry);
+        PRINTF(T("stackcheck_cleanup: %08x リスト不整合です\n", "stackcheck_cleanup: %08x list inconsistency\n"),
+               entry);
     }
 }
 
@@ -111,8 +108,8 @@ StackStatus StackCheck_GetState(StackEntry* entry) {
         status = STACK_STATUS_OK;
     }
 
-    STACKCHECK_PRINTF("head=%08x tail=%08x last=%08x used=%08x free=%08x [%s]\n", entry->head, entry->tail, last, used,
-                      free, (entry->name != NULL) ? entry->name : "(null)");
+    PRINTF("head=%08x tail=%08x last=%08x used=%08x free=%08x [%s]\n", entry->head, entry->tail, last, used, free,
+           (entry->name != NULL) ? entry->name : "(null)");
 
 #if MM_VERSION >= N64_US
     (void)"(null)";


### PR DESCRIPTION
Instead of having multiple seperate PRINTF macros for the files that leave osSyncPrintf behind, I thought of an idea where where just overwrite the PRINTF macro.